### PR TITLE
fix: v0.10.5 — PoW units (bits not bytes) and per-request urlconf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,60 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.5] - 2026-05-23
+
+### Fixed
+
+- **Proof-of-work difficulty counted in bytes instead of bits** (lockout
+  regression). `verify_challenge_solution` and the JS solver both required
+  `difficulty` leading zero **bytes** in the SHA-256 digest, while the
+  README and inline comments documented the field as leading zero **bits**.
+  At the default of 4, average work was `256^4 ≈ 4.3 billion` hashes —
+  unsolvable in a browser. Combined with `ICV_WAF_CHALLENGE_ESCALATION_THRESHOLD=10`,
+  legitimate users challenged by the WAF were auto-blocked within seconds.
+
+  **Fix**: server verifier and JS solver now count leading zero **bits**,
+  matching the documented semantics. Difficulty selection is now
+  device-aware: desktop UAs get `ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP`
+  (default 22, ~1–2s on a laptop), mobile UAs get `..._MOBILE` (default 18,
+  ~1–3s on a budget phone). The legacy `ICV_WAF_CHALLENGE_DIFFICULTY`
+  remains as a single-value fallback (default 20). The token's stored
+  difficulty drives the solver, so it never drifts from the verifier.
+
+- **Per-request urlconf routing broke challenge redirects**
+  (django-hosts and similar). The middleware called
+  `reverse("icv_waf:challenge")` with no `urlconf` argument and cached the
+  result on the middleware instance. With per-request urlconf routing the
+  first host to trigger a challenge froze its resolved path for every
+  subsequent request on every host, until the process restarted.
+
+  **Fix**: the resolved paths are no longer cached — `_get_challenge_paths`
+  consults the active urlconf on every call. Two new settings,
+  `ICV_WAF_CHALLENGE_URL` and `ICV_WAF_VERIFY_URL`, let operators bypass
+  `reverse()` entirely with literal paths when the icv_waf URLs are not
+  mounted on every host.
+
+### Added
+
+- **Device-aware challenge difficulty**: `ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP`
+  and `ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE` (set either to `None` to fall
+  back to the single-value setting).
+- **Challenge URL overrides**: `ICV_WAF_CHALLENGE_URL` /
+  `ICV_WAF_VERIFY_URL` for projects with per-request urlconf routing.
+- **Challenge UI progress bar + ETA**, so slow devices see legible progress
+  rather than a stalled spinner.
+- **Django system check** (`icv_waf.E002` / `W001` / `W002` / `E001` /
+  `icv_waf.checks.check_challenge_difficulty`) that refuses to start with a
+  PoW difficulty that would lock users out, and warns on values that are
+  too high for low-end phones or too low to deter bots.
+
+### Changed
+
+- **Default difficulty raised** from `4` to `20` bits. With the previous
+  byte-counting bug fixed, 4 bits ≈ 16 hashes — effectively no PoW. The
+  new default targets ~1–2s of work, visible as a "verifying" signal
+  without being painful.
+
 ## [0.10.4] - 2026-05-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -142,7 +142,11 @@ All settings are namespaced under `ICV_WAF_*` and have sensible defaults.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `ICV_WAF_CHALLENGE_DIFFICULTY` | `4` | Proof-of-work leading zero bits |
+| `ICV_WAF_CHALLENGE_DIFFICULTY` | `20` | Fallback proof-of-work leading zero **bits** when the desktop/mobile overrides are not set. Average work is `2 ** bits` SHA-256 hashes |
+| `ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP` | `22` | PoW difficulty (bits) for non-mobile User-Agents. ~4M hashes, ~1–2s on a laptop |
+| `ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE` | `18` | PoW difficulty (bits) for mobile User-Agents. ~260k hashes, ~1–3s on a budget phone |
+| `ICV_WAF_CHALLENGE_URL` | `""` | Optional literal path to the challenge view. Set this in projects using per-request urlconf routing (django-hosts and similar) where `reverse("icv_waf:challenge")` cannot resolve. Empty = use `reverse()` |
+| `ICV_WAF_VERIFY_URL` | `""` | Optional literal path to the verify view. Empty = use `reverse()` |
 | `ICV_WAF_CHALLENGE_COOKIE_TTL` | `86400` | Seconds a solved-challenge cookie remains valid |
 | `ICV_WAF_CHALLENGE_NO_REFERER` | `False` | Challenge requests that have no `Referer` header |
 | `ICV_WAF_NO_REFERER_EXEMPT_PATHS` | `["/", "/search/", "/robots.txt", "/sitemap.xml", "/favicon.ico"]` | Paths exempt from the no-referer challenge (only evaluated when `ICV_WAF_CHALLENGE_NO_REFERER` is `True`) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "0.10.4"
+version = "0.10.5"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/icv_waf/apps.py
+++ b/src/icv_waf/apps.py
@@ -9,4 +9,4 @@ class IcvWafConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self) -> None:
-        from . import handlers  # noqa: F401 — connect signal handlers
+        from . import checks, handlers  # noqa: F401 — register handlers & system checks

--- a/src/icv_waf/checks.py
+++ b/src/icv_waf/checks.py
@@ -1,0 +1,75 @@
+"""Django system checks for icv-waf configuration.
+
+These checks catch settings combinations that would lock legitimate users
+out of the site (the v0.10.4 regression motivating their introduction:
+``ICV_WAF_CHALLENGE_DIFFICULTY`` was implemented in bytes while documented
+in bits, so the default of 4 became unsolvable).
+
+Difficulty here is counted in **leading zero bits** of the SHA-256 digest.
+Expected attempts is ``2 ** difficulty``. Thresholds:
+
+* ``> 28`` (~268M hashes, > 60s on most laptops) — Error.
+* ``> 24`` (~16M hashes, ~5–20s on phones) — Warning.
+* ``< 8``  (256 hashes, no real bot deterrence) — Warning.
+"""
+
+from __future__ import annotations
+
+from django.core.checks import Error, Warning, register
+
+
+@register()
+def check_challenge_difficulty(app_configs, **kwargs):
+    from icv_waf import conf
+
+    messages = []
+    # (name, value, allow_none) — desktop/mobile may be None to fall through
+    # to the single-value ICV_WAF_CHALLENGE_DIFFICULTY.
+    fields = (
+        ("ICV_WAF_CHALLENGE_DIFFICULTY", conf.ICV_WAF_CHALLENGE_DIFFICULTY, False),
+        ("ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", conf.ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP, True),
+        ("ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", conf.ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE, True),
+    )
+
+    for name, value, allow_none in fields:
+        if value is None and allow_none:
+            continue
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            messages.append(
+                Error(
+                    f"{name} must be a non-negative integer (got {value!r}).",
+                    hint="Difficulty is the number of leading zero bits required in the SHA-256(token+nonce) digest.",
+                    id="icv_waf.E001",
+                )
+            )
+            continue
+        if value > 28:
+            messages.append(
+                Error(
+                    f"{name}={value} is effectively unsolvable in a browser "
+                    f"(~{2**value:,} hashes on average). Legitimate users will "
+                    "fail the challenge and be auto-blocked.",
+                    hint="Set to 22 for desktops, 18 for mobile, or lower.",
+                    id="icv_waf.E002",
+                )
+            )
+        elif value > 24:
+            messages.append(
+                Warning(
+                    f"{name}={value} (~{2**value:,} hashes) may exceed 10s on "
+                    "low-end phones, causing visible delay or timeouts.",
+                    hint="22 (desktop) / 18 (mobile) are the recommended defaults.",
+                    id="icv_waf.W001",
+                )
+            )
+        elif 0 < value < 8:
+            messages.append(
+                Warning(
+                    f"{name}={value} (~{2**value} hashes) offers little bot "
+                    "deterrence — the PoW is effectively instant.",
+                    hint="Raise to 18+ for meaningful proof-of-work cost.",
+                    id="icv_waf.W002",
+                )
+            )
+
+    return messages

--- a/src/icv_waf/conf.py
+++ b/src/icv_waf/conf.py
@@ -11,8 +11,28 @@ from django.conf import settings
 # Enable or disable the WAF middleware entirely.
 ICV_WAF_ENABLED: bool = getattr(settings, "ICV_WAF_ENABLED", True)
 
-# Proof-of-work challenge difficulty (leading zero bits required).
-ICV_WAF_CHALLENGE_DIFFICULTY: int = getattr(settings, "ICV_WAF_CHALLENGE_DIFFICULTY", 4)
+# Proof-of-work challenge difficulty — number of leading zero **bits** the
+# SHA-256(token + nonce) digest must contain. Average solve cost is
+# ``2 ** difficulty`` hashes. Acts as the single-value fallback when the
+# desktop/mobile overrides below are unset.
+ICV_WAF_CHALLENGE_DIFFICULTY: int = getattr(settings, "ICV_WAF_CHALLENGE_DIFFICULTY", 20)
+
+# Desktop-class clients (default 22 bits ≈ 4M hashes, ~1–2s on a laptop).
+# Slightly stronger than mobile because desktops have more CPU headroom.
+# Set to ``None`` to fall back to ``ICV_WAF_CHALLENGE_DIFFICULTY``.
+ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP: int | None = getattr(settings, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22)
+
+# Mobile-class clients (default 18 bits ≈ 260k hashes, ~1–3s on a phone).
+# Set lower than desktop so budget devices don't time out.
+# Set to ``None`` to fall back to ``ICV_WAF_CHALLENGE_DIFFICULTY``.
+ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE: int | None = getattr(settings, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18)
+
+# Optional literal-path overrides for the WAF's own challenge/verify URLs.
+# When set, the middleware uses these strings directly instead of calling
+# ``reverse()``. Recommended for projects using per-request urlconf routing
+# (django-hosts and similar) that don't mount icv_waf URLs on every host.
+ICV_WAF_CHALLENGE_URL: str = getattr(settings, "ICV_WAF_CHALLENGE_URL", "")
+ICV_WAF_VERIFY_URL: str = getattr(settings, "ICV_WAF_VERIFY_URL", "")
 
 # TTL in seconds for a solved-challenge cookie.
 ICV_WAF_CHALLENGE_COOKIE_TTL: int = getattr(settings, "ICV_WAF_CHALLENGE_COOKIE_TTL", 86400)

--- a/src/icv_waf/middleware.py
+++ b/src/icv_waf/middleware.py
@@ -32,15 +32,26 @@ class WafMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
-        self._challenge_path: str | None = None
-        self._verify_path: str | None = None
 
     def _get_challenge_paths(self) -> tuple[str, str]:
-        """Return (challenge_path, verify_path), resolved once and cached."""
-        if self._challenge_path is None:
-            self._challenge_path = reverse("icv_waf:challenge")
-            self._verify_path = reverse("icv_waf:verify")
-        return self._challenge_path, self._verify_path
+        """Return (challenge_path, verify_path) for the current request.
+
+        Resolved fresh on every call rather than cached on the middleware
+        instance, because projects using per-request urlconf routing (e.g.
+        django-hosts) need ``reverse()`` to consult the active thread-local
+        urlconf each time. Caching would freeze whichever host first hit a
+        challenge into the resolved path for the lifetime of the process.
+
+        Operators can short-circuit ``reverse()`` entirely by setting
+        ``ICV_WAF_CHALLENGE_URL`` / ``ICV_WAF_VERIFY_URL`` to literal paths,
+        which is the recommended approach for multi-urlconf projects that
+        don't mount the icv_waf URLs on every host.
+        """
+        from icv_waf import conf
+
+        challenge = conf.ICV_WAF_CHALLENGE_URL or reverse("icv_waf:challenge")
+        verify = conf.ICV_WAF_VERIFY_URL or reverse("icv_waf:verify")
+        return challenge, verify
 
     def __call__(self, request):
         from icv_waf import conf

--- a/src/icv_waf/services/challenge_service.py
+++ b/src/icv_waf/services/challenge_service.py
@@ -48,7 +48,60 @@ _CHALLENGE_KEY = "waf:challenge:{token}"
 # ---------------------------------------------------------------------------
 
 
-def issue_challenge(ip_address: str, redis_client) -> object:
+def _is_mobile_user_agent(user_agent: str) -> bool:
+    """Cheap UA-string heuristic for mobile-class devices.
+
+    Honest about its limits: UA strings lie, "tablet" sits in the middle,
+    and a high-end phone can outpace a low-end laptop. Used only to pick a
+    PoW difficulty band — wrong guesses cost a 1–3s solve discrepancy, not
+    a lockout. Refer to ``ICV_WAF_CHALLENGE_DIFFICULTY_*`` to tune.
+    """
+    if not user_agent:
+        return False
+    ua = user_agent.lower()
+    # "Mobi" covers Firefox Mobile + Chrome Mobile per their official UAs;
+    # "Android" without "Mobi" is a tablet, which we treat as desktop-class.
+    return "mobi" in ua or "iphone" in ua or "ipod" in ua
+
+
+def _pick_difficulty(user_agent: str) -> int:
+    """Return the configured PoW difficulty for a request's device class.
+
+    Resolves in this order:
+      1. The device-class setting (mobile vs desktop) if it is set (non-None).
+      2. The single-value fallback ``ICV_WAF_CHALLENGE_DIFFICULTY``.
+
+    Lets operators either use the device-aware split (default) or pin a
+    single value by setting the desktop/mobile keys to ``None``.
+    """
+    from icv_waf import conf
+
+    if _is_mobile_user_agent(user_agent):
+        value = conf.ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE
+    else:
+        value = conf.ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP
+    if value is None:
+        value = conf.ICV_WAF_CHALLENGE_DIFFICULTY
+    return value
+
+
+def _digest_has_leading_zero_bits(digest: bytes, bits: int) -> bool:
+    """Return True iff ``digest`` starts with at least ``bits`` zero bits."""
+    if bits <= 0:
+        return True
+    full_bytes, remainder = divmod(bits, 8)
+    if len(digest) < full_bytes + (1 if remainder else 0):
+        return False
+    if any(b != 0 for b in digest[:full_bytes]):
+        return False
+    if remainder == 0:
+        return True
+    # Top `remainder` bits of the next byte must be zero.
+    mask = 0xFF << (8 - remainder) & 0xFF
+    return (digest[full_bytes] & mask) == 0
+
+
+def issue_challenge(ip_address: str, redis_client, *, user_agent: str = "") -> object:
     """Create a new challenge token for the given IP address.
 
     Stores the token in both the DB and Redis. Emits challenge_issued signal.
@@ -56,6 +109,8 @@ def issue_challenge(ip_address: str, redis_client) -> object:
     Args:
         ip_address: Client IP address that will be challenged.
         redis_client: Configured Redis client instance.
+        user_agent: Optional User-Agent string; selects mobile vs desktop
+            difficulty. Falls back to the desktop value when empty or unset.
 
     Returns:
         ChallengeToken model instance.
@@ -64,7 +119,7 @@ def issue_challenge(ip_address: str, redis_client) -> object:
     from icv_waf.models import ChallengeToken
 
     token = secrets.token_hex(64)
-    difficulty = conf.ICV_WAF_CHALLENGE_DIFFICULTY
+    difficulty = _pick_difficulty(user_agent)
     ttl = conf.ICV_WAF_CHALLENGE_COOKIE_TTL
     expires_at = timezone.now() + timezone.timedelta(seconds=ttl)
 
@@ -110,7 +165,7 @@ def verify_challenge_solution(
     Lookup order: Redis first, fallback to DB.
 
     Per BR-CHAL-002, verifies SHA-256(token + nonce) has `difficulty` leading
-    zero bytes. Per BR-CHAL-003, verification is always server-side.
+    zero **bits**. Per BR-CHAL-003, verification is always server-side.
 
     Args:
         token: The challenge token string.
@@ -170,8 +225,7 @@ def verify_challenge_solution(
 
     # --- Proof-of-work verification (BR-CHAL-002, BR-CHAL-003) ---
     digest = hashlib.sha256(f"{token}{nonce}".encode()).digest()
-    leading_zero_bytes = difficulty
-    if any(b != 0 for b in digest[:leading_zero_bytes]):
+    if not _digest_has_leading_zero_bits(digest, difficulty):
         # Solution incorrect
         db_token_obj.status = ChallengeStatus.FAILED
         db_token_obj.save(update_fields=["status"])

--- a/src/icv_waf/templates/icv_waf/challenge.html
+++ b/src/icv_waf/templates/icv_waf/challenge.html
@@ -76,6 +76,29 @@
             font-weight: 600;
         }
 
+        .progress {
+            width: 100%;
+            height: 6px;
+            background: #e5e7eb;
+            border-radius: 3px;
+            overflow: hidden;
+            margin: 0.75rem 0 0.25rem;
+        }
+
+        .progress-bar {
+            height: 100%;
+            width: 0;
+            background: #374151;
+            transition: width 0.2s linear;
+        }
+
+        #eta {
+            font-size: 0.75rem;
+            color: #9ca3af;
+            min-height: 1rem;
+            margin: 0;
+        }
+
         #error {
             display: none;
             color: #b91c1c;
@@ -110,6 +133,8 @@
 
         <div class="spinner" id="spinner" role="status" aria-label="Working…"></div>
         <p id="status" aria-live="polite">Working&hellip;</p>
+        <div class="progress" aria-hidden="true"><div class="progress-bar" id="progress-bar"></div></div>
+        <p id="eta" aria-live="polite"></p>
         <div id="error" role="alert"></div>
 
         <p class="privacy-note">
@@ -130,6 +155,14 @@
         var statusEl = document.getElementById("status");
         var spinnerEl = document.getElementById("spinner");
         var errorEl = document.getElementById("error");
+        var progressBarEl = document.getElementById("progress-bar");
+        var etaEl = document.getElementById("eta");
+
+        // Expected attempts to solve: 2^difficulty on average. Used to drive
+        // the progress bar (linear in attempts/expected) and the ETA, which
+        // recomputes from observed hash rate every UI tick.
+        var expectedAttempts = Math.pow(2, difficulty);
+        var startTime = 0;
 
         // --- SHA-256 via Web Crypto API ---
         function sha256(message) {
@@ -139,11 +172,17 @@
             });
         }
 
-        function hasLeadingZeroBytes(hash, count) {
-            for (var i = 0; i < count; i++) {
+        // Return true iff the digest starts with `bits` zero bits.
+        // Mirrors _digest_has_leading_zero_bits() in the Python verifier.
+        function hasLeadingZeroBits(hash, bits) {
+            var fullBytes = bits >>> 3;
+            var remainder = bits & 7;
+            for (var i = 0; i < fullBytes; i++) {
                 if (hash[i] !== 0) return false;
             }
-            return true;
+            if (remainder === 0) return true;
+            var mask = (0xFF << (8 - remainder)) & 0xFF;
+            return (hash[fullBytes] & mask) === 0;
         }
 
         function showError(message) {
@@ -152,25 +191,50 @@
             errorEl.style.display = "block";
         }
 
+        function formatEta(seconds) {
+            if (!isFinite(seconds) || seconds < 0) return "";
+            if (seconds < 1) return "less than a second";
+            if (seconds < 60) return Math.round(seconds) + "s remaining";
+            var mins = Math.ceil(seconds / 60);
+            return "~" + mins + " min remaining";
+        }
+
+        function updateProgress() {
+            var ratio = Math.min(nonce / expectedAttempts, 0.99);
+            progressBarEl.style.width = (ratio * 100).toFixed(1) + "%";
+
+            var elapsed = (performance.now() - startTime) / 1000;
+            if (elapsed > 0.25 && nonce > 0) {
+                var rate = nonce / elapsed; // hashes per second
+                var remainingAttempts = Math.max(expectedAttempts - nonce, 0);
+                etaEl.textContent = formatEta(remainingAttempts / rate);
+            }
+        }
+
         // Yield to the browser event loop to keep the UI responsive.
         function yieldToUI() {
             return new Promise(function (resolve) { setTimeout(resolve, 0); });
         }
 
         async function solve() {
+            startTime = performance.now();
             while (true) {
                 var hash = await sha256(token + nonce.toString());
-                if (hasLeadingZeroBytes(hash, difficulty)) {
+                if (hasLeadingZeroBits(hash, difficulty)) {
                     statusEl.textContent = "Verified!";
                     statusEl.className = "success";
+                    progressBarEl.style.width = "100%";
+                    etaEl.textContent = "";
                     spinnerEl.style.display = "none";
                     await submit(nonce.toString());
                     return;
                 }
                 nonce++;
-                // Yield every 10 000 iterations to keep UI responsive.
-                if (nonce % 10000 === 0) {
+                // Yield every 2 000 iterations to keep UI responsive and
+                // give the progress bar a chance to repaint.
+                if (nonce % 2000 === 0) {
                     statusEl.textContent = "Working\u2026 (" + nonce.toLocaleString() + " attempts)";
+                    updateProgress();
                     await yieldToUI();
                 }
             }
@@ -209,6 +273,8 @@
                 // Retry with the fresh token.
                 token = data.new_token;
                 nonce = 0;
+                progressBarEl.style.width = "0";
+                etaEl.textContent = "";
                 errorEl.style.display = "none";
                 spinnerEl.style.display = "block";
                 statusEl.textContent = "Retrying\u2026";

--- a/src/icv_waf/views.py
+++ b/src/icv_waf/views.py
@@ -114,19 +114,21 @@ class ChallengeView(TemplateView):
     template_name = "icv_waf/challenge.html"
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
-        from icv_waf import conf
         from icv_waf.services.challenge_service import issue_challenge
 
         ip = _get_ip(request)
         next_url = _validate_next_url(request, request.GET.get("next"))
         redis_client = _get_redis_client()
+        user_agent = request.META.get("HTTP_USER_AGENT", "")
 
-        challenge_token = issue_challenge(ip, redis_client)
+        challenge_token = issue_challenge(ip, redis_client, user_agent=user_agent)
 
         response = self.render_to_response(
             {
                 "token": challenge_token.token,
-                "difficulty": conf.ICV_WAF_CHALLENGE_DIFFICULTY,
+                # Use the token's stored difficulty so the solver always
+                # matches the verifier, even if conf changes mid-flight.
+                "difficulty": challenge_token.difficulty,
                 "next_url": next_url,
                 "post_url": request.build_absolute_uri(reverse("icv_waf:verify")),
             }
@@ -187,7 +189,8 @@ class VerifyView(View):
         except (ChallengeExpiredError, ChallengeMismatchError, ChallengeInvalidError) as exc:
             reason = str(exc)
             try:
-                new_token = issue_challenge(ip, redis_client)
+                user_agent = request.META.get("HTTP_USER_AGENT", "")
+                new_token = issue_challenge(ip, redis_client, user_agent=user_agent)
                 return JsonResponse({"error": reason, "new_token": new_token.token}, status=400)
             except Exception:
                 logger.exception("icv-waf: failed to issue replacement challenge token")

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,89 @@
+"""Tests for the icv_waf Django system checks.
+
+These exist because v0.10.4 shipped with a units mismatch
+(``ICV_WAF_CHALLENGE_DIFFICULTY`` was counted in bytes while documented in
+bits) that made the default unsolvable in a browser and locked legitimate
+users out. The check refuses settings that would reproduce that lockout.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+
+def _run_checks():
+    from icv_waf.checks import check_challenge_difficulty
+
+    return check_challenge_difficulty(app_configs=None)
+
+
+class TestChallengeDifficultyCheck:
+    def test_recommended_defaults_produce_no_messages(self):
+        import icv_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 20),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18),
+        ):
+            assert _run_checks() == []
+
+    def test_difficulty_over_28_errors(self):
+        """The v0.10.4 lockout class — refuse to start with this config."""
+        import icv_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 32),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18),
+        ):
+            messages = _run_checks()
+
+        assert any(m.id == "icv_waf.E002" for m in messages)
+
+    def test_difficulty_over_24_warns(self):
+        import icv_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 20),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 26),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18),
+        ):
+            messages = _run_checks()
+
+        assert any(m.id == "icv_waf.W001" for m in messages)
+
+    def test_difficulty_under_8_warns(self):
+        import icv_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 20),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 4),
+        ):
+            messages = _run_checks()
+
+        assert any(m.id == "icv_waf.W002" for m in messages)
+
+    def test_none_allowed_for_device_keys(self):
+        """Desktop/mobile = None means 'use the fallback' and must not warn."""
+        import icv_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 20),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", None),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", None),
+        ):
+            assert _run_checks() == []
+
+    def test_negative_is_error(self):
+        import icv_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", -1),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18),
+        ):
+            messages = _run_checks()
+
+        assert any(m.id == "icv_waf.E001" for m in messages)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -916,3 +916,79 @@ class TestMiddlewareHelpers:
             side_effect=RuntimeError("listener crashed"),
         ):
             _emit_request_throttled(MagicMock(), "1.2.3.4")
+
+
+# ---------------------------------------------------------------------------
+# _get_challenge_paths — urlconf handling (regression: v0.10.4 cached the
+# resolved path on the middleware instance, breaking per-request urlconf
+# routing such as django-hosts).
+# ---------------------------------------------------------------------------
+
+
+class TestGetChallengePaths:
+    def test_setting_overrides_reverse(self):
+        """ICV_WAF_CHALLENGE_URL / _VERIFY_URL short-circuit reverse()."""
+        import icv_waf.conf as conf_mod
+
+        middleware = _make_middleware()
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_URL", "/custom/challenge/"),
+            patch.object(conf_mod, "ICV_WAF_VERIFY_URL", "/custom/verify/"),
+            patch("icv_waf.middleware.reverse") as mock_reverse,
+        ):
+            challenge, verify = middleware._get_challenge_paths()
+
+        assert challenge == "/custom/challenge/"
+        assert verify == "/custom/verify/"
+        # reverse() must not be called when overrides are set — that's the
+        # whole point for projects with per-request urlconf routing.
+        mock_reverse.assert_not_called()
+
+    def test_falls_back_to_reverse_when_unset(self):
+        """With overrides empty, reverse() is called fresh each request."""
+        import icv_waf.conf as conf_mod
+
+        middleware = _make_middleware()
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_URL", ""),
+            patch.object(conf_mod, "ICV_WAF_VERIFY_URL", ""),
+            patch(
+                "icv_waf.middleware.reverse",
+                side_effect=["/waf/challenge/", "/waf/verify/"],
+            ) as mock_reverse,
+        ):
+            challenge, verify = middleware._get_challenge_paths()
+
+        assert challenge == "/waf/challenge/"
+        assert verify == "/waf/verify/"
+        assert mock_reverse.call_count == 2
+
+    def test_paths_not_cached_between_calls(self):
+        """Each call resolves fresh — required for per-request urlconf routing.
+
+        Regression: v0.10.4 memoised the result on the middleware instance,
+        so the first host to trigger a challenge under django-hosts froze its
+        path for every subsequent request on every host.
+        """
+        import icv_waf.conf as conf_mod
+
+        middleware = _make_middleware()
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_URL", ""),
+            patch.object(conf_mod, "ICV_WAF_VERIFY_URL", ""),
+            patch(
+                "icv_waf.middleware.reverse",
+                side_effect=[
+                    "/host-a/challenge/",
+                    "/host-a/verify/",
+                    "/host-b/challenge/",
+                    "/host-b/verify/",
+                ],
+            ) as mock_reverse,
+        ):
+            first = middleware._get_challenge_paths()
+            second = middleware._get_challenge_paths()
+
+        assert first == ("/host-a/challenge/", "/host-a/verify/")
+        assert second == ("/host-b/challenge/", "/host-b/verify/")
+        assert mock_reverse.call_count == 4

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -762,6 +762,111 @@ class TestEvaluateRequest:
 
 
 # ---------------------------------------------------------------------------
+# Device-aware difficulty selection (v0.10.5)
+# ---------------------------------------------------------------------------
+
+
+class TestPickDifficulty:
+    def test_mobile_ua_selects_mobile_difficulty(self):
+        import icv_waf.conf as conf_mod
+        from icv_waf.services.challenge_service import _pick_difficulty
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 20),
+        ):
+            iphone = "Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605"
+            android_phone = "Mozilla/5.0 (Linux; Android 13; Pixel 7) AppleWebKit/537.36 Mobile"
+            assert _pick_difficulty(iphone) == 18
+            assert _pick_difficulty(android_phone) == 18
+
+    def test_desktop_ua_selects_desktop_difficulty(self):
+        import icv_waf.conf as conf_mod
+        from icv_waf.services.challenge_service import _pick_difficulty
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 20),
+        ):
+            mac = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/605 Version/16 Safari"
+            windows = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Gecko/20100101 Firefox/120.0"
+            android_tablet = "Mozilla/5.0 (Linux; Android 13; SM-T970) AppleWebKit/537.36 Safari"
+            assert _pick_difficulty(mac) == 22
+            assert _pick_difficulty(windows) == 22
+            # "Android" without "Mobi" → tablet → desktop band.
+            assert _pick_difficulty(android_tablet) == 22
+
+    def test_empty_ua_falls_back_to_desktop(self):
+        import icv_waf.conf as conf_mod
+        from icv_waf.services.challenge_service import _pick_difficulty
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 20),
+        ):
+            assert _pick_difficulty("") == 22
+
+    def test_device_key_none_falls_back_to_single_value(self):
+        """Setting desktop/mobile to None makes _pick_difficulty fall through
+        to ICV_WAF_CHALLENGE_DIFFICULTY — the legacy single-value path."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.services.challenge_service import _pick_difficulty
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 20),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", None),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", None),
+        ):
+            assert _pick_difficulty("Mozilla/5.0 (iPhone) Mobi") == 20
+            assert _pick_difficulty("Mozilla/5.0 (Windows)") == 20
+
+
+# ---------------------------------------------------------------------------
+# PoW bit-counting helper (regression: v0.10.4 counted bytes, not bits)
+# ---------------------------------------------------------------------------
+
+
+class TestDigestHasLeadingZeroBits:
+    def test_zero_bits_always_true(self):
+        """Difficulty 0 means no work — every digest passes."""
+        from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+        assert _digest_has_leading_zero_bits(b"\xff\xff", 0) is True
+
+    def test_one_bit_checks_msb_of_first_byte(self):
+        from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+        # 0x7F = 0111_1111 — MSB is zero, passes 1-bit.
+        assert _digest_has_leading_zero_bits(b"\x7f", 1) is True
+        # 0x80 = 1000_0000 — MSB is one, fails 1-bit.
+        assert _digest_has_leading_zero_bits(b"\x80", 1) is False
+
+    def test_eight_bits_requires_full_zero_byte(self):
+        from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+        assert _digest_has_leading_zero_bits(b"\x00\xff", 8) is True
+        assert _digest_has_leading_zero_bits(b"\x01\xff", 8) is False
+
+    def test_partial_byte_boundary(self):
+        from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+        # 12 bits = one zero byte + top 4 bits of next byte zero.
+        # 0x00 0x0F = 0000_0000 0000_1111 — top 4 bits of second byte zero, passes.
+        assert _digest_has_leading_zero_bits(b"\x00\x0f", 12) is True
+        # 0x00 0x10 = 0000_0000 0001_0000 — bit 11 (from MSB) is one, fails.
+        assert _digest_has_leading_zero_bits(b"\x00\x10", 12) is False
+
+    def test_short_digest_returns_false(self):
+        from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+        # Need at least one byte to check 1 bit.
+        assert _digest_has_leading_zero_bits(b"", 1) is False
+
+
+# ---------------------------------------------------------------------------
 # issue_challenge
 # ---------------------------------------------------------------------------
 
@@ -776,6 +881,8 @@ class TestIssueChallenge:
 
         with (
             patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 4),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 4),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 4),
             patch.object(conf_mod, "ICV_WAF_CHALLENGE_COOKIE_TTL", 3600),
         ):
             token_obj = issue_challenge("10.0.0.1", redis)
@@ -794,6 +901,8 @@ class TestIssueChallenge:
 
         with (
             patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 4),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 4),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 4),
             patch.object(conf_mod, "ICV_WAF_CHALLENGE_COOKIE_TTL", 3600),
         ):
             issue_challenge("10.0.0.2", redis)
@@ -817,6 +926,8 @@ class TestIssueChallenge:
 
         with (
             patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY", 6),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 6),
+            patch.object(conf_mod, "ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE", 6),
             patch.object(conf_mod, "ICV_WAF_CHALLENGE_COOKIE_TTL", 3600),
         ):
             token_obj = issue_challenge("10.0.0.3", redis)
@@ -876,11 +987,16 @@ class TestIssueChallenge:
 
 class TestVerifyChallengeService:
     def _valid_nonce(self, token: str, difficulty: int) -> str:
-        """Brute-force a nonce that satisfies the proof-of-work for the given token."""
+        """Brute-force a nonce that satisfies the proof-of-work for the given token.
+
+        Counts leading zero **bits** to match the production verifier.
+        """
+        from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
         for n in range(1_000_000):
             nonce = str(n)
             digest = hashlib.sha256(f"{token}{nonce}".encode()).digest()
-            if all(b == 0 for b in digest[:difficulty]):
+            if _digest_has_leading_zero_bits(digest, difficulty):
                 return nonce
         raise RuntimeError("Could not find a valid nonce within 1,000,000 iterations")
 
@@ -985,7 +1101,8 @@ class TestVerifyChallengeService:
         """A nonce that fails proof-of-work raises ChallengeInvalidError."""
         token_obj = ChallengeTokenFactory(
             ip_address="1.2.3.4",
-            difficulty=4,  # Difficult enough that "wrong_nonce" won't pass
+            # 24 bits — chance of accidental pass with a fixed wrong nonce is 1/16M.
+            difficulty=24,
             status=ChallengeStatus.PENDING,
         )
 


### PR DESCRIPTION

### Fixed

- **Proof-of-work difficulty counted in bytes instead of bits** (lockout
  regression). `verify_challenge_solution` and the JS solver both required
  `difficulty` leading zero **bytes** in the SHA-256 digest, while the
  README and inline comments documented the field as leading zero **bits**.
  At the default of 4, average work was `256^4 ≈ 4.3 billion` hashes —
  unsolvable in a browser. Combined with `ICV_WAF_CHALLENGE_ESCALATION_THRESHOLD=10`,
  legitimate users challenged by the WAF were auto-blocked within seconds.

  **Fix**: server verifier and JS solver now count leading zero **bits**,
  matching the documented semantics. Difficulty selection is now
  device-aware: desktop UAs get `ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP`
  (default 22, ~1–2s on a laptop), mobile UAs get `..._MOBILE` (default 18,
  ~1–3s on a budget phone). The legacy `ICV_WAF_CHALLENGE_DIFFICULTY`
  remains as a single-value fallback (default 20). The token's stored
  difficulty drives the solver, so it never drifts from the verifier.

- **Per-request urlconf routing broke challenge redirects**
  (django-hosts and similar). The middleware called
  `reverse("icv_waf:challenge")` with no `urlconf` argument and cached the
  result on the middleware instance. With per-request urlconf routing the
  first host to trigger a challenge froze its resolved path for every
  subsequent request on every host, until the process restarted.

  **Fix**: the resolved paths are no longer cached — `_get_challenge_paths`
  consults the active urlconf on every call. Two new settings,
  `ICV_WAF_CHALLENGE_URL` and `ICV_WAF_VERIFY_URL`, let operators bypass
  `reverse()` entirely with literal paths when the icv_waf URLs are not
  mounted on every host.

### Added

- **Device-aware challenge difficulty**: `ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP`
  and `ICV_WAF_CHALLENGE_DIFFICULTY_MOBILE` (set either to `None` to fall
  back to the single-value setting).
- **Challenge URL overrides**: `ICV_WAF_CHALLENGE_URL` /
  `ICV_WAF_VERIFY_URL` for projects with per-request urlconf routing.
- **Challenge UI progress bar + ETA**, so slow devices see legible progress
  rather than a stalled spinner.
- **Django system check** (`icv_waf.E002` / `W001` / `W002` / `E001` /
  `icv_waf.checks.check_challenge_difficulty`) that refuses to start with a
  PoW difficulty that would lock users out, and warns on values that are
  too high for low-end phones or too low to deter bots.

### Changed

- **Default difficulty raised** from `4` to `20` bits. With the previous
  byte-counting bug fixed, 4 bits ≈ 16 hashes — effectively no PoW. The
  new default targets ~1–2s of work, visible as a "verifying" signal
  without being painful.


---

### Why this PR exists

Two regressions in v0.10.4 caused a production lockout for a downstream
site (Django 6 + django-hosts). Reported and reproduced; both root causes
confirmed in code before changes. See CHANGELOG for full detail.

### Verification

- `pytest`: **489 passed** (+18 new tests covering both regressions and
  the new system check).
- `ruff check` + `ruff format --check`: clean.
- `manage.py check` with `ICV_WAF_CHALLENGE_DIFFICULTY_DESKTOP=40`
  exits with `icv_waf.E002` and the exact remediation hint — the v0.10.4
  lockout configuration can no longer start a site.

### What to eyeball in review

- `src/icv_waf/services/challenge_service.py` — `_digest_has_leading_zero_bits`
  (server) must match the solver in `templates/icv_waf/challenge.html`
  (`hasLeadingZeroBits`). Same divmod logic, same mask.
- `src/icv_waf/middleware.py` — `_get_challenge_paths` no longer caches.
- Backwards compatibility: existing operators on default settings get a
  default difficulty bump (4 → 20 bits, deliberate; old default was the
  bug). Operators who set `ICV_WAF_CHALLENGE_DIFFICULTY` themselves keep
  that value, but it's now interpreted as bits (matching the docs they
  were already reading).
