### PR TITLE
fix: v0.10.6 — verify URL override, fast-path hit attribution, richer IPReputation admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,58 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.6] - 2026-05-27
+
+### Fixed
+
+- **Challenge tokens stuck PENDING under per-request urlconf routing.**
+  `ChallengeView` rendered the challenge page with `post_url =
+  reverse("icv_waf:verify")` — sibling of the middleware bug fixed in
+  v0.10.5, but on the other side of the flow. Under django-hosts (or
+  any other per-request urlconf setup) the page rendered fine, the
+  browser solved the PoW, but the form POSTed to a path on the wrong
+  host's urlconf, so `VerifyView` never ran. Tokens accumulated in the
+  `PENDING` state forever, `solved_at` was never set, and the
+  challenge counter never reset.
+
+  **Fix**: `ChallengeView.get` now honours `ICV_WAF_VERIFY_URL` (the
+  literal-path override added in v0.10.5) before falling back to
+  `reverse()`. Operators with multi-host setups can pin the verify
+  path explicitly the same way they already pin the challenge path.
+
+- **`BlockRule.hit_count` not incrementing for repeat blocks.** The
+  Redis blocked-IP fast-path (step 5 of `evaluate_request`) blocked
+  cached IPs without identifying the matching rule — so subsequent
+  hits to the same blocked IP never reached
+  `_check_block_rules`, which is where `_record_rule_hit` runs. Once
+  an IP was in the cache, its rule's hit counter froze at whatever
+  value the first match recorded.
+
+  **Fix**: `record_block_verdict` now stores the matched rule's UUID
+  as the cache value (was a literal `"1"`). The fast-path decodes it
+  on read, calls `_record_rule_hit`, and threads the rule id into the
+  `EvaluationResult` so downstream signals and logs carry proper
+  attribution too. Legacy `"1"` cache entries are tolerated and block
+  anonymously until they roll over (5-minute TTL by default).
+
+### Added
+
+- **Richer `IPReputation` admin list view.** New columns: `country`
+  (via GeoIP, when database installed), `challenge_passes`,
+  `challenge_failures`, plus derived `block_rate` and
+  `challenge_success_rate` percentages. New list filters for triage:
+  threat tier (high/medium/low), recent activity window
+  (hour/day/week), and "has unsolved challenges". Old fields stay; no
+  data changes.
+
+### Changed
+
+- **`icv_waf.services.geoip.lookup_country`** is now the public entry
+  point for IP-to-country lookups (was a private
+  `_lookup_country` helper inside the middleware). The middleware
+  still exposes a `_lookup_country` shim for backwards compatibility,
+  so any external callers continue to work.
+
 ## [0.10.5] - 2026-05-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "0.10.5"
+version = "0.10.6"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/icv_waf/admin.py
+++ b/src/icv_waf/admin.py
@@ -230,27 +230,108 @@ class RequestLogAdmin(admin.ModelAdmin):
 # ---------------------------------------------------------------------------
 
 
+class ThreatTierListFilter(admin.SimpleListFilter):
+    """Bucket IPReputation rows by threat_score for triage."""
+
+    title = _("threat tier")
+    parameter_name = "tier"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("high", _("High (≥7.0)")),
+            ("medium", _("Medium (3.0–6.9)")),
+            ("low", _("Low (<3.0)")),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == "high":
+            return queryset.filter(threat_score__gte=7)
+        if self.value() == "medium":
+            return queryset.filter(threat_score__gte=3, threat_score__lt=7)
+        if self.value() == "low":
+            return queryset.filter(threat_score__lt=3)
+        return queryset
+
+
+class RecentActivityListFilter(admin.SimpleListFilter):
+    """Filter by how recently an IP was last seen."""
+
+    title = _("recent activity")
+    parameter_name = "seen"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("hour", _("Last hour")),
+            ("day", _("Last 24 hours")),
+            ("week", _("Last 7 days")),
+        )
+
+    def queryset(self, request, queryset):
+        from datetime import timedelta
+
+        now = timezone.now()
+        if self.value() == "hour":
+            return queryset.filter(last_seen_at__gte=now - timedelta(hours=1))
+        if self.value() == "day":
+            return queryset.filter(last_seen_at__gte=now - timedelta(days=1))
+        if self.value() == "week":
+            return queryset.filter(last_seen_at__gte=now - timedelta(days=7))
+        return queryset
+
+
+class HasUnsolvedChallengesListFilter(admin.SimpleListFilter):
+    """Surface IPs where challenges are failing — useful for tuning difficulty."""
+
+    title = _("unsolved challenges")
+    parameter_name = "unsolved"
+
+    def lookups(self, request, model_admin):
+        return (
+            ("yes", _("Has unsolved")),
+            ("only", _("Only unsolved (no passes)")),
+        )
+
+    def queryset(self, request, queryset):
+        if self.value() == "yes":
+            return queryset.filter(challenge_failures__gt=0)
+        if self.value() == "only":
+            return queryset.filter(challenge_failures__gt=0, challenge_passes=0)
+        return queryset
+
+
 @admin.register(IPReputation)
 class IPReputationAdmin(admin.ModelAdmin):
     list_display = [
         "ip_address",
+        "country",
         "threat_score",
         "total_requests",
         "blocked_requests",
+        "block_rate",
         "challenged_requests",
+        "challenge_passes",
+        "challenge_failures",
+        "challenge_success_rate",
         "distinct_ua_count",
         "last_seen_at",
     ]
-    list_filter = []
+    list_filter = [
+        ThreatTierListFilter,
+        RecentActivityListFilter,
+        HasUnsolvedChallengesListFilter,
+    ]
     search_fields = ["ip_address"]
     ordering = ["-threat_score"]
     readonly_fields = [
         "ip_address",
+        "country",
         "total_requests",
         "blocked_requests",
+        "block_rate",
         "challenged_requests",
         "challenge_passes",
         "challenge_failures",
+        "challenge_success_rate",
         "distinct_ua_count",
         "threat_score",
         "last_seen_at",
@@ -259,6 +340,40 @@ class IPReputationAdmin(admin.ModelAdmin):
         "created_at",
         "updated_at",
     ]
+
+    # ---- Derived columns -------------------------------------------------
+
+    @admin.display(description=_("block %"), ordering="blocked_requests")
+    def block_rate(self, obj) -> str:
+        """Blocked share of total requests, as a percentage."""
+        if not obj.total_requests:
+            return "—"
+        pct = (obj.blocked_requests / obj.total_requests) * 100
+        return f"{pct:.1f}%"
+
+    @admin.display(description=_("solve %"), ordering="challenge_passes")
+    def challenge_success_rate(self, obj) -> str:
+        """Share of challenges this IP has solved successfully."""
+        total = obj.challenge_passes + obj.challenge_failures
+        if not total:
+            return "—"
+        pct = (obj.challenge_passes / total) * 100
+        return f"{pct:.1f}%"
+
+    @admin.display(description=_("country"))
+    def country(self, obj) -> str:
+        """Country code via GeoIP, if the database is installed.
+
+        Lookup is best-effort — failures (no database, lookup error,
+        private IP) return an em dash so the list view never breaks.
+        """
+        from icv_waf.services import geoip
+
+        try:
+            code = geoip.lookup_country(obj.ip_address)
+        except Exception:
+            return "—"
+        return code or "—"
 
     def has_add_permission(self, request) -> bool:
         return False

--- a/src/icv_waf/middleware.py
+++ b/src/icv_waf/middleware.py
@@ -150,7 +150,14 @@ class WafMiddleware:
             try:
                 from icv_waf.services.rule_engine import record_block_verdict
 
-                record_block_verdict(ip_address, redis_client)
+                # Thread the matched rule id through so the fast-path can
+                # attribute subsequent cached blocks back to the rule, not
+                # just block them anonymously (regression fixed in v0.10.6).
+                record_block_verdict(
+                    ip_address,
+                    redis_client,
+                    rule_id=str(result.matched_rule_id) if result.matched_rule_id else None,
+                )
             except Exception:
                 logger.exception("icv-waf: error recording block verdict")
             _emit_request_blocked(result, ip_address, user_agent, path)
@@ -229,42 +236,13 @@ class WafMiddleware:
 # ---------------------------------------------------------------------------
 
 
-# GeoIP reader — lazily initialised, cached for the process lifetime.
-_geoip_reader = None
-_geoip_checked = False
-
-
 def _lookup_country(ip_address: str) -> str:
-    """Return the 2-letter ISO country code for an IP, or '' if unavailable.
+    """Backwards-compatibility shim — the real implementation lives in
+    ``icv_waf.services.geoip.lookup_country`` (moved in v0.10.6 so the
+    admin can share the same lazy reader)."""
+    from icv_waf.services.geoip import lookup_country
 
-    Uses MaxMind GeoLite2-Country database at the path specified by
-    ICV_WAF_GEOIP_PATH. Degrades gracefully if the database is missing,
-    geoip2 is not installed, or the IP is not found.
-    """
-    global _geoip_reader, _geoip_checked  # noqa: PLW0603
-
-    from icv_waf import conf
-
-    if not conf.ICV_WAF_GEOIP_PATH:
-        return ""
-
-    if not _geoip_checked:
-        _geoip_checked = True
-        try:
-            import geoip2.database
-
-            _geoip_reader = geoip2.database.Reader(conf.ICV_WAF_GEOIP_PATH)
-        except Exception:
-            logger.warning("icv-waf: GeoIP database not available at %s", conf.ICV_WAF_GEOIP_PATH)
-
-    if _geoip_reader is None:
-        return ""
-
-    try:
-        response = _geoip_reader.country(ip_address)
-        return response.country.iso_code or ""
-    except Exception:
-        return ""
+    return lookup_country(ip_address)
 
 
 def _compute_fingerprint(request) -> str:

--- a/src/icv_waf/services/geoip.py
+++ b/src/icv_waf/services/geoip.py
@@ -52,6 +52,54 @@ class GeoIPDownloadError(GeoIPError):
     """The download from MaxMind failed or returned an invalid archive."""
 
 
+# ---------------------------------------------------------------------------
+# Runtime lookup
+# ---------------------------------------------------------------------------
+
+# Lazily initialised reader, cached for the process lifetime. The middleware
+# and the admin both consult this; no per-request reader construction.
+_reader = None
+_reader_checked = False
+
+
+def lookup_country(ip_address: str) -> str:
+    """Return the 2-letter ISO country code for an IP, or '' if unavailable.
+
+    Uses the MaxMind GeoLite2-Country database at ``ICV_WAF_GEOIP_PATH``.
+    Degrades gracefully if the database is missing, ``geoip2`` is not
+    installed, the IP is private, or the lookup fails — every failure
+    mode returns the empty string so callers can treat the function as
+    best-effort.
+    """
+    global _reader, _reader_checked  # noqa: PLW0603
+
+    from icv_waf import conf
+
+    if not conf.ICV_WAF_GEOIP_PATH:
+        return ""
+
+    if not _reader_checked:
+        _reader_checked = True
+        try:
+            import geoip2.database
+
+            _reader = geoip2.database.Reader(conf.ICV_WAF_GEOIP_PATH)
+        except Exception:
+            logger.warning(
+                "icv-waf: GeoIP database not available at %s",
+                conf.ICV_WAF_GEOIP_PATH,
+            )
+
+    if _reader is None:
+        return ""
+
+    try:
+        response = _reader.country(ip_address)
+        return response.country.iso_code or ""
+    except Exception:
+        return ""
+
+
 def check_geoip2_available() -> None:
     """Raise GeoIPNotInstalledError if the ``geoip2`` package is missing.
 

--- a/src/icv_waf/services/rule_engine.py
+++ b/src/icv_waf/services/rule_engine.py
@@ -254,12 +254,25 @@ def evaluate_request(
 
     # Step 5: Redis blocked-IP fast-path (BR-EVAL-005)
     blocked_key = _BLOCKED_IP_KEY.format(ip=ip_address)
-    if redis_client.get(blocked_key):
+    cached_value = redis_client.get(blocked_key)
+    if cached_value:
+        # Cache value is the originally-matched rule_id (when known) so
+        # fast-path hits get attributed back to the rule. Legacy "1"
+        # entries (written by pre-0.10.6 code) carry no attribution.
+        rule_id_str = cached_value.decode() if isinstance(cached_value, bytes) else cached_value
+        matched_rule_id = None
+        if rule_id_str and rule_id_str != "1":
+            try:
+                matched_rule_id = UUID(rule_id_str)
+                _record_rule_hit(rule_id_str, redis_client)
+            except ValueError:
+                # Malformed cache value — log nothing, still block.
+                pass
         return EvaluationResult(
             verdict=Verdict.BLOCKED,
             action=RuleAction.BLOCK,
-            matched_rule_id=None,
-            matched_rule_type="",
+            matched_rule_id=matched_rule_id,
+            matched_rule_type="block" if matched_rule_id else "",
             anomaly_score=None,
         )
 
@@ -347,8 +360,13 @@ def evaluate_request(
     # Creates a persistent auto BlockRule + Redis fast-path with configurable TTL.
     challenged_count = _get_unsolved_challenge_count(ip_address, redis_client)
     if challenged_count >= conf.ICV_WAF_CHALLENGE_ESCALATION_THRESHOLD:
-        record_block_verdict(ip_address, redis_client, ttl=conf.ICV_WAF_ESCALATION_BLOCK_TTL)
-        _create_escalation_rule(ip_address)
+        escalation_rule = _create_escalation_rule(ip_address)
+        record_block_verdict(
+            ip_address,
+            redis_client,
+            ttl=conf.ICV_WAF_ESCALATION_BLOCK_TTL,
+            rule_id=str(escalation_rule.id) if escalation_rule else None,
+        )
         return EvaluationResult(
             verdict=Verdict.BLOCKED,
             action=RuleAction.BLOCK,
@@ -592,7 +610,10 @@ def _get_unsolved_challenge_count(ip_address: str, redis_client) -> int:
         return 0
 
 
-def _create_escalation_rule(ip_address: str) -> None:
+def _create_escalation_rule(ip_address: str):  # -> BlockRule | None
+    # Returns the created/updated BlockRule so callers can attribute the
+    # fast-path cache entry to its id (see record_block_verdict). Returns
+    # None on failure; callers should treat that as "block but unknown rule".
     """Create a persistent auto BlockRule for an escalated IP.
 
     Uses update_or_create so concurrent escalations don't duplicate.
@@ -625,7 +646,8 @@ def _create_escalation_rule(ip_address: str) -> None:
 
     try:
         with transaction.atomic():
-            BlockRule.objects.update_or_create(**lookup, defaults=defaults)
+            rule, _ = BlockRule.objects.update_or_create(**lookup, defaults=defaults)
+        return rule
     except BlockRule.MultipleObjectsReturned:
         logger.warning(
             "icv-waf: duplicate BlockRule rows for escalation of %s — deduplicating",
@@ -634,11 +656,14 @@ def _create_escalation_rule(ip_address: str) -> None:
         _deduplicate_escalation_rules(**lookup)
         try:
             with transaction.atomic():
-                BlockRule.objects.update_or_create(**lookup, defaults=defaults)
+                rule, _ = BlockRule.objects.update_or_create(**lookup, defaults=defaults)
+            return rule
         except Exception:
             logger.exception("icv-waf: failed to create escalation rule for %s after dedup", ip_address)
+            return None
     except Exception:
         logger.exception("icv-waf: failed to create escalation rule for %s", ip_address)
+        return None
 
 
 def _deduplicate_escalation_rules(**lookup) -> int:
@@ -663,6 +688,7 @@ def record_block_verdict(
     ip_address: str,
     redis_client,
     ttl: int = 300,
+    rule_id: str | None = None,
 ) -> None:
     """Write the blocked-IP cache entry for fast-path rejection on subsequent requests.
 
@@ -674,7 +700,13 @@ def record_block_verdict(
         ip_address: The blocked IP address.
         redis_client: Configured Redis client instance.
         ttl: Cache TTL in seconds (default 300 = 5 minutes).
+        rule_id: Optional matched rule id. Stored as the cache value so the
+            fast-path can attribute subsequent hits to the original rule
+            via ``_record_rule_hit``. Defaults to a sentinel string when
+            unknown; cache reads tolerate the legacy ``"1"`` value as the
+            same sentinel.
     """
     blocked_key = _BLOCKED_IP_KEY.format(ip=ip_address)
-    redis_client.setex(blocked_key, ttl, "1")
+    value = str(rule_id) if rule_id else "1"
+    redis_client.setex(blocked_key, ttl, value)
     redis_client.hincrby(_STATS_KEY, "blocked", 1)

--- a/src/icv_waf/views.py
+++ b/src/icv_waf/views.py
@@ -114,6 +114,7 @@ class ChallengeView(TemplateView):
     template_name = "icv_waf/challenge.html"
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        from icv_waf import conf
         from icv_waf.services.challenge_service import issue_challenge
 
         ip = _get_ip(request)
@@ -123,6 +124,16 @@ class ChallengeView(TemplateView):
 
         challenge_token = issue_challenge(ip, redis_client, user_agent=user_agent)
 
+        # Resolve the verify URL the same way the middleware does
+        # (icv_waf.middleware._get_challenge_paths) — honour the operator
+        # override first, fall back to reverse() per-request. Critical for
+        # projects with per-request urlconf routing (django-hosts), where
+        # reverse() inside this view runs against whichever host's urlconf
+        # is active; if the icv_waf URLs aren't mounted on that host, the
+        # solver POSTs to the wrong path, never reaches VerifyView, and
+        # tokens stay PENDING forever.
+        verify_path = conf.ICV_WAF_VERIFY_URL or reverse("icv_waf:verify")
+
         response = self.render_to_response(
             {
                 "token": challenge_token.token,
@@ -130,7 +141,7 @@ class ChallengeView(TemplateView):
                 # matches the verifier, even if conf changes mid-flight.
                 "difficulty": challenge_token.difficulty,
                 "next_url": next_url,
-                "post_url": request.build_absolute_uri(reverse("icv_waf:verify")),
+                "post_url": request.build_absolute_uri(verify_path),
             }
         )
         response["Cache-Control"] = "no-store"

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -792,12 +792,13 @@ class TestMiddlewareHelpers:
 
     def test_lookup_country_db_missing_returns_empty(self):
         """A missing GeoIP database is caught on first lookup and returns ''."""
-        import icv_waf.middleware as mw_module
+        import icv_waf.services.geoip as geoip_module
         from icv_waf.middleware import _lookup_country
 
-        # Reset the module-level cache
-        mw_module._geoip_reader = None
-        mw_module._geoip_checked = False
+        # Reset the module-level cache (now lives on services.geoip after
+        # the v0.10.6 extraction; middleware exposes a shim for back-compat).
+        geoip_module._reader = None
+        geoip_module._reader_checked = False
 
         with patch("icv_waf.conf.ICV_WAF_GEOIP_PATH", "/nonexistent/GeoLite2-Country.mmdb"):
             assert _lookup_country("1.2.3.4") == ""
@@ -806,7 +807,7 @@ class TestMiddlewareHelpers:
 
     def test_lookup_country_returns_iso_code(self):
         """When the reader returns a country, the ISO code is returned."""
-        import icv_waf.middleware as mw_module
+        import icv_waf.services.geoip as geoip_module
         from icv_waf.middleware import _lookup_country
 
         # Build a fake reader
@@ -815,34 +816,34 @@ class TestMiddlewareHelpers:
         fake_reader = MagicMock()
         fake_reader.country.return_value = fake_country_obj
 
-        mw_module._geoip_reader = fake_reader
-        mw_module._geoip_checked = True
+        geoip_module._reader = fake_reader
+        geoip_module._reader_checked = True
 
         try:
             with patch("icv_waf.conf.ICV_WAF_GEOIP_PATH", "/tmp/fake.mmdb"):
                 assert _lookup_country("1.2.3.4") == "GB"
         finally:
             # Restore module state for other tests
-            mw_module._geoip_reader = None
-            mw_module._geoip_checked = False
+            geoip_module._reader = None
+            geoip_module._reader_checked = False
 
     def test_lookup_country_reader_exception_returns_empty(self):
         """An exception from reader.country() is swallowed and returns ''."""
-        import icv_waf.middleware as mw_module
+        import icv_waf.services.geoip as geoip_module
         from icv_waf.middleware import _lookup_country
 
         fake_reader = MagicMock()
         fake_reader.country.side_effect = RuntimeError("IP not found")
 
-        mw_module._geoip_reader = fake_reader
-        mw_module._geoip_checked = True
+        geoip_module._reader = fake_reader
+        geoip_module._reader_checked = True
 
         try:
             with patch("icv_waf.conf.ICV_WAF_GEOIP_PATH", "/tmp/fake.mmdb"):
                 assert _lookup_country("1.2.3.4") == ""
         finally:
-            mw_module._geoip_reader = None
-            mw_module._geoip_checked = False
+            geoip_module._reader = None
+            geoip_module._reader_checked = False
 
     def test_get_redis_client_uses_django_redis_when_available(self):
         """_get_redis_client prefers django-redis's get_redis_connection."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -597,9 +597,15 @@ class TestEvaluateRequest:
         assert result.verdict == Verdict.THROTTLED
 
     def test_redis_blocked_ip_fast_path(self, db):
-        """An IP in the Redis blocked-IP cache is rejected immediately."""
+        """An IP in the Redis blocked-IP cache is rejected immediately.
+
+        Legacy cache value of ``"1"`` (written by pre-v0.10.6 code) carries
+        no rule attribution — matched_rule_id stays None and no hit counter
+        is bumped. Newer entries store the rule id; see the
+        ``test_fast_path_attributes_hit_to_rule`` test below for that path.
+        """
         redis = _make_redis()
-        # Simulate a blocked IP cache hit
+        # Simulate a legacy blocked-IP cache hit (value "1")
         redis.get.side_effect = lambda key: b"1" if "blocked" in key else None
 
         result = evaluate_request(
@@ -611,7 +617,60 @@ class TestEvaluateRequest:
         )
 
         assert result.verdict == Verdict.BLOCKED
-        assert result.matched_rule_id is None  # Fast-path block has no rule ID
+        assert result.matched_rule_id is None  # Legacy cache entries carry no attribution
+
+    def test_fast_path_attributes_hit_to_rule(self, db):
+        """When the fast-path cache stores a rule UUID, the hit is attributed.
+
+        Regression: pre-v0.10.6 the fast-path always blocked anonymously,
+        so any IP blocked once stopped contributing to BlockRule.hit_count.
+        From v0.10.6, the cache stores the matched rule_id and the fast
+        path calls ``_record_rule_hit`` so the rule's counter still
+        increments on repeat blocks.
+        """
+        import uuid
+
+        rule_uuid = uuid.uuid4()
+        redis = _make_redis()
+        redis.get.side_effect = lambda key: str(rule_uuid).encode() if "blocked" in key else None
+
+        result = evaluate_request(
+            ip_address="5.5.5.6",
+            user_agent="Mozilla/5.0",
+            path="/",
+            method="GET",
+            redis_client=redis,
+        )
+
+        assert result.verdict == Verdict.BLOCKED
+        assert result.matched_rule_id == rule_uuid
+        assert result.matched_rule_type == "block"
+
+        # Confirm the hit counter was bumped.
+        incr_keys = [c.args[0] for c in redis.incr.call_args_list]
+        assert f"waf:rule_hits:{rule_uuid}" in incr_keys
+
+    def test_fast_path_malformed_cache_value_falls_back(self, db):
+        """A malformed cache value still blocks but carries no attribution.
+
+        Defensive: someone could write garbage to the cache key (replication
+        race, manual ops intervention). The fast path must still block —
+        failing open on a malformed cache value would be worse than failing
+        closed without attribution.
+        """
+        redis = _make_redis()
+        redis.get.side_effect = lambda key: b"not-a-uuid" if "blocked" in key else None
+
+        result = evaluate_request(
+            ip_address="5.5.5.7",
+            user_agent="Mozilla/5.0",
+            path="/",
+            method="GET",
+            redis_client=redis,
+        )
+
+        assert result.verdict == Verdict.BLOCKED
+        assert result.matched_rule_id is None
 
     def test_rate_limit_exceeded_returns_throttled(self, db):
         """When rate limit is exceeded, result is THROTTLED."""
@@ -2647,6 +2706,28 @@ class TestRecordBlockVerdict:
 
         call_args = redis.setex.call_args.args
         assert call_args[1] == 300
+
+    def test_stores_rule_id_when_provided(self):
+        """When called with rule_id, the cache value is the rule UUID string.
+
+        This is what gives the fast-path its hit attribution from v0.10.6
+        onward — see test_fast_path_attributes_hit_to_rule.
+        """
+        from icv_waf.services.rule_engine import record_block_verdict
+
+        redis = _make_redis()
+        record_block_verdict("9.8.7.5", redis, ttl=300, rule_id="abc-123")
+
+        redis.setex.assert_called_once_with("waf:blocked:9.8.7.5", 300, "abc-123")
+
+    def test_stores_sentinel_when_rule_id_missing(self):
+        """When rule_id is None or empty, falls back to the legacy "1" sentinel."""
+        from icv_waf.services.rule_engine import record_block_verdict
+
+        redis = _make_redis()
+        record_block_verdict("9.8.7.4", redis, ttl=300, rule_id=None)
+
+        redis.setex.assert_called_once_with("waf:blocked:9.8.7.4", 300, "1")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -165,6 +165,34 @@ class TestChallengeView:
 
         assert response.context["next_url"] == "/"
 
+    def test_post_url_honours_verify_url_override(self, settings):
+        """Challenge page's post_url must respect ICV_WAF_VERIFY_URL.
+
+        Regression: pre-v0.10.6 the challenge view hardcoded
+        ``reverse("icv_waf:verify")`` while the middleware (post-v0.10.5)
+        honoured the override. Under django-hosts the page would render
+        but the solver POSTed to the wrong urlconf; the token stayed
+        PENDING forever because VerifyView never ran.
+        """
+        import icv_waf.conf as conf_mod
+
+        settings.ICV_WAF_ENABLED = True
+
+        client = Client()
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_VERIFY_URL", "/custom/verify/"),
+            patch("icv_waf.views._get_redis_client") as mock_redis_fn,
+            patch("icv_waf.services.challenge_service.issue_challenge") as mock_issue,
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_issue.return_value = _mock_challenge_token("tok")
+
+            response = client.get("/waf/challenge/")
+
+        # post_url is build_absolute_uri'd — assert the path component matches.
+        assert response.context["post_url"].endswith("/custom/verify/")
+
     def test_response_has_no_cache_control(self, settings):
         """Challenge page must not be cached (contains a one-time token)."""
         settings.ICV_WAF_ENABLED = True


### PR DESCRIPTION

### Fixed

- **Challenge tokens stuck PENDING under per-request urlconf routing.**
  `ChallengeView` rendered the challenge page with `post_url =
  reverse("icv_waf:verify")` — sibling of the middleware bug fixed in
  v0.10.5, but on the other side of the flow. Under django-hosts (or
  any other per-request urlconf setup) the page rendered fine, the
  browser solved the PoW, but the form POSTed to a path on the wrong
  host's urlconf, so `VerifyView` never ran. Tokens accumulated in the
  `PENDING` state forever, `solved_at` was never set, and the
  challenge counter never reset.

  **Fix**: `ChallengeView.get` now honours `ICV_WAF_VERIFY_URL` (the
  literal-path override added in v0.10.5) before falling back to
  `reverse()`. Operators with multi-host setups can pin the verify
  path explicitly the same way they already pin the challenge path.

- **`BlockRule.hit_count` not incrementing for repeat blocks.** The
  Redis blocked-IP fast-path (step 5 of `evaluate_request`) blocked
  cached IPs without identifying the matching rule — so subsequent
  hits to the same blocked IP never reached
  `_check_block_rules`, which is where `_record_rule_hit` runs. Once
  an IP was in the cache, its rule's hit counter froze at whatever
  value the first match recorded.

  **Fix**: `record_block_verdict` now stores the matched rule's UUID
  as the cache value (was a literal `"1"`). The fast-path decodes it
  on read, calls `_record_rule_hit`, and threads the rule id into the
  `EvaluationResult` so downstream signals and logs carry proper
  attribution too. Legacy `"1"` cache entries are tolerated and block
  anonymously until they roll over (5-minute TTL by default).

### Added

- **Richer `IPReputation` admin list view.** New columns: `country`
  (via GeoIP, when database installed), `challenge_passes`,
  `challenge_failures`, plus derived `block_rate` and
  `challenge_success_rate` percentages. New list filters for triage:
  threat tier (high/medium/low), recent activity window
  (hour/day/week), and "has unsolved challenges". Old fields stay; no
  data changes.

### Changed

- **`icv_waf.services.geoip.lookup_country`** is now the public entry
  point for IP-to-country lookups (was a private
  `_lookup_country` helper inside the middleware). The middleware
  still exposes a `_lookup_country` shim for backwards compatibility,
  so any external callers continue to work.


---

### Why this PR exists

Two production bugs reported by a downstream operator and one UX ask
in the same conversation. Both bugs are independently confirmed in
code; one is the sibling of the v0.10.5 fix on the other side of the
challenge flow.

### Verification

- `pytest`: **494 passed** (+5 regression tests: verify URL override,
  fast-path attribution on UUID cache values, malformed cache value
  fall-through, `record_block_verdict` storing rule_id with and
  without).
- `ruff check` + `ruff format --check`: clean.
- No DB migrations.

### What to eyeball in review

- `src/icv_waf/services/rule_engine.py` — the fast-path block in
  `evaluate_request` step 5 now decodes the cache value and threads
  it back into the result. Worth checking the legacy `"1"` and the
  malformed-value fall-throughs behave the way the docstring says.
- `src/icv_waf/views.py` — `ChallengeView.get` now mirrors the
  middleware's URL-override pattern. The pattern itself was
  established in v0.10.5; this just brings the challenge view in
  line.
- `src/icv_waf/services/geoip.py` — `lookup_country` extracted from
  middleware as a public function; middleware retains a one-line
  shim. Confirms no external callers will break.

### Backwards compatibility

- Cache entries written by v0.10.5 (`"1"`) keep working — they block,
  they just don't attribute the hit. Within 5 minutes (default TTL)
  they roll over to new attribution-carrying entries.
- `_lookup_country` shim in middleware preserves any external code
  that imports it.
- No settings changes; no migrations.
