### PR TITLE
feat(forms): v0.11.0 form-protection PRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,113 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-05-27
+
+### Added
+
+- **Form-protection subsystem.** Defence-in-depth at the form layer,
+  composing eight defences into a single chain per protected form. See
+  README "Form protection" for the operator guide. Highlights:
+
+    - **Eight defences**: `render_token` (signed payload + Redis
+      one-shot marker), `honeypot` (rotating hidden fields per form_id),
+      `time_trap` (too-fast / too-slow / expired), `ua_consistency`
+      (UA hash captured at render vs. submit), `js_touch` (sentinel
+      cleared by JS to detect headless clients), `credential_throttle`
+      (per-IP + per-account login-failure counters — enumeration-safe),
+      `signup_velocity` (per-IP completed-signup throttle), `pow_gate`
+      (per-submission proof-of-work, ~50ms desktop / ~200ms mobile).
+
+    - **Three entry points**: `ProtectedForm` Django Form mixin (the
+      recommended path), `@waf_protect_post` view decorator (for views
+      that bypass Django's Form layer), `{% waf_protect %}` template
+      tag (pairs with the decorator on handwritten HTML forms). All
+      three route to the same `FormProtection` orchestrator.
+
+    - **HTMX-aware token lifecycle**: the render-token Redis marker is
+      consumed only on a PASS verdict. Failed validations preserve the
+      marker so re-submitting the corrected form works without
+      re-tokening.
+
+    - **Challenge-replay** (opt-in via
+      `ICV_WAF_FORM_CHALLENGE_ON_FLAG=True`, default): FLAGGED
+      submissions stash their POST data in `request.session`, redirect
+      the user through `/waf/challenge/?form_replay=<token>`, and
+      automatically re-issue the original POST after the challenge
+      passes. Sensitive fields (password / secret / csrf / api_key /
+      token) are stripped before storage — operators see "please
+      re-enter your password" on login replays. Replay token is signed,
+      IP-bound, 60s TTL, one-shot.
+
+    - **Per-form configuration** via `FormProtection(...)` kwargs:
+      `defences=`, `defence_weights=`, `skip_for_authenticated=`, plus
+      any per-defence override (e.g. `min_fill_seconds=0.8` for short
+      newsletter forms).
+
+    - **Four signals**: `form_submission_passed` (opt-in via
+      `ICV_WAF_FORM_EMIT_PASSED_SIGNAL`, off by default — hot path),
+      `form_submission_flagged`, `form_submission_blocked`, and
+      `credential_attack_observed` (observation-only, never affects
+      user-visible response — operators wire up email-to-owner
+      handlers here).
+
+    - **Structured logging**: one `waf.form_submission` log entry per
+      submission with verdict, total score, per-defence outcomes and
+      reasons. PASSED entries sampled at `ICV_WAF_LOG_SAMPLE_RATE`;
+      FLAGGED + BLOCKED always logged. `X-WAF-Form-Verdict` debug
+      header attached in `DEBUG=True` only.
+
+- **`ICV_WAF_SIGNING_KEY`** — package-wide HMAC secret, separate from
+  Django's `SECRET_KEY`. Used by every signed artefact the WAF issues
+  (currently form render tokens + replay tokens). Defaults to a
+  `SECRET_KEY`-derived value with a new `icv_waf.W003` system check
+  warning so v0.10.x → v0.11.0 upgrades are seamless. Set to a
+  dedicated key in production to rotate WAF signatures independently
+  of Django sessions.
+
+- **`icv_waf.W003`** system check — warns when `ICV_WAF_SIGNING_KEY`
+  is unset and the package is falling back to a `SECRET_KEY`-derived
+  value.
+
+### Internal
+
+- Defence-chain canonical ordering ensures `render_token` always runs
+  first, with its verified payload threaded onto subsequent defences'
+  `EvaluateContext` so `time_trap`, `ua_consistency`, `js_touch`, and
+  `pow_gate` can read it without re-verifying.
+
+- A defence exception is caught + logged + treated as a silent pass.
+  A bug in any one defence cannot lock legitimate users out.
+
+- `pow_gate` reuses `_digest_has_leading_zero_bits` from v0.10.5 (the
+  page-level challenge's bit-counting helper) rather than maintaining
+  a parallel implementation — no drift risk between the two PoWs.
+
+### Documentation
+
+- README gains a "Form protection" section under Settings Reference
+  with usage examples for all three entry points, plus per-form
+  configuration patterns and HTMX integration notes.
+
+- PRD lives at `docs/specs/forms/PRD.md` (the design that drove this
+  release).
+
+### Backwards compatibility
+
+- **No DB migrations.** All state is in Redis (counters, token markers)
+  or in signed tokens (no server-side state for the token itself).
+
+- **Opt-in per form.** Adding `ProtectedForm` to a form is one line.
+  Upgrading django-waf to v0.11.0 changes nothing until a form opts
+  in via the mixin / decorator / template tag.
+
+- **No changes to existing settings.** All new settings are additive.
+
+- **Existing signals unchanged.** The four new signals
+  (`form_submission_passed/_flagged/_blocked`, `credential_attack_observed`)
+  are additions; existing `request_blocked`, `challenge_failed`, etc.
+  are untouched.
+
 ## [0.10.6] - 2026-05-27
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ all configurable without a reverse-proxy vendor.
 - **Collective threat feed** — opt-in sync of anonymised threat intelligence
   across deployments
 - **Staff dashboard** — HTMX-powered real-time analytics with anomaly management
+- **Form protection** — defence-in-depth at the form layer: signed render
+  tokens, honeypots, time-trap, UA-consistency, JS-touch, credential
+  throttle (enumeration-safe), signup velocity, per-submission PoW.
+  Mixin / decorator / template-tag entry points; per-form configuration;
+  optional challenge-replay for false-positive rescue
 - **Fail-open design** — Redis outage never breaks the site
 
 ## Requirements
@@ -196,6 +201,114 @@ All settings are namespaced under `ICV_WAF_*` and have sensible defaults.
 | `ICV_WAF_FEED_REPORT` | `False` | Report local detections back to the feed (opt-in) |
 | `ICV_WAF_FEED_REPORT_URL` | `"https://threats.icv.dev/v1/report"` | Telemetry reporting endpoint |
 | `ICV_WAF_FEED_API_KEY` | `""` | API key for feed authentication |
+
+### Form protection (v0.11.0)
+
+The form-protection subsystem is **opt-in per form**. Defaults are inert
+until a form opts in via the mixin, decorator, or template tag.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `ICV_WAF_SIGNING_KEY` | `""` | Package-wide HMAC secret. Separate from Django's `SECRET_KEY` so rotation lifecycles are independent. Empty → derives from `SECRET_KEY` and `icv_waf.W003` warns at startup |
+| `ICV_WAF_FORM_PROTECTION_ENABLED` | `True` | Master kill switch. `False` makes the mixin/decorator/tag short-circuit to pass without running defences |
+| `ICV_WAF_FORM_FLAG_THRESHOLD` | `2.0` | Aggregate score crossing this triggers FLAGGED |
+| `ICV_WAF_FORM_BLOCK_THRESHOLD` | `5.0` | Aggregate score crossing this triggers BLOCKED |
+| `ICV_WAF_FORM_CHALLENGE_ON_FLAG` | `True` | Redirect FLAGGED submissions through `/waf/challenge/` (then replay the POST). `False` returns a generic rejection |
+| `ICV_WAF_FORM_EMIT_PASSED_SIGNAL` | `False` | Fire `form_submission_passed` on every PASS. Off by default — busy sites would burn cycles on the hot path; the structured log already records (sampled) passes |
+| `ICV_WAF_FORM_TOKEN_TTL` | `3600` | Render-token lifetime in seconds; also the Redis marker TTL |
+| `ICV_WAF_FORM_HONEYPOT_FIELD_NAMES` | `["url", "website", "homepage", "email_confirm"]` | Pool of names for the per-form rotating honeypot fields |
+| `ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS` | `1.5` | Below this → flag; below 0.5 → block (hard floor) |
+| `ICV_WAF_FORM_TIME_TRAP_MAX_SECONDS` | `3600` | Above this → flag (stale form) |
+| `ICV_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW` | `900` | Sliding window for credential-failure counters (seconds) |
+| `ICV_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT` | `5` | Per-account threshold. Observation-only (drives `credential_attack_observed` signal); never user-visible |
+| `ICV_WAF_FORM_CREDENTIAL_IP_LIMIT` | `20` | Per-IP threshold. **Drives the user-visible challenge** — same behaviour regardless of which accounts were tried (enumeration-safe) |
+| `ICV_WAF_FORM_SIGNUP_VELOCITY_WINDOW` | `86400` | Window for completed-signup counter (24h) |
+| `ICV_WAF_FORM_SIGNUP_VELOCITY_LIMIT` | `5` | Successful signups per IP before next attempt is flagged |
+| `ICV_WAF_FORM_POW_DIFFICULTY` | `12` | Per-submission PoW difficulty (bits). 12 ≈ 4k SHA-256 hashes ≈ 50ms desktop / ~200ms mobile |
+| `ICV_WAF_FORM_REPLAY_STORE` | `"session"` | Where to stash FLAGGED POST data for replay. Only `"session"` is implemented |
+| `ICV_WAF_FORM_DEFENCE_WEIGHTS` | (see code) | Per-defence score weights; overridable per-form via `FormProtection(defence_weights={...})` |
+
+**Usage** — Django Form mixin (recommended for new forms):
+
+```python
+from django import forms
+from icv_waf.forms import FormProtection, ProtectedForm
+
+class ContactForm(ProtectedForm, forms.Form):
+    name = forms.CharField()
+    email = forms.EmailField()
+    message = forms.CharField(widget=forms.Textarea)
+
+    waf = FormProtection(
+        form_id="contact",
+        defences=("render_token", "honeypot", "time_trap", "ua_consistency"),
+    )
+```
+
+In the view:
+
+```python
+def contact_view(request):
+    form = ContactForm(request.POST or None, request=request)
+    if request.method == "POST" and form.is_valid():
+        # form.waf_result holds the FormEvaluationResult.
+        ...
+```
+
+In the template:
+
+```html
+<form method="post">
+  {% csrf_token %}
+  {{ form.waf_fields }}
+  {{ form.as_p }}
+  <button type="submit">Send</button>
+</form>
+```
+
+**Handwritten HTML** (forms that bypass Django's Form layer):
+
+```python
+# views.py
+from icv_waf.forms import waf_protect_post
+
+@waf_protect_post(form_id="contact-handwritten",
+                  defences=("honeypot", "time_trap"))
+def contact_view(request):
+    if request.method == "POST":
+        ...
+```
+
+```html
+<!-- contact.html -->
+{% load waf_form_tags %}
+<form method="post">
+  {% csrf_token %}
+  {% waf_protect form_id="contact-handwritten" %}
+  <input type="email" name="email">
+  <button type="submit">Send</button>
+</form>
+```
+
+**HTMX compatibility** — the form-protection render token persists
+across HTMX re-renders of the same form (a user fixing a validation
+error keeps the same token). The Redis marker that backs replay
+protection is consumed only on a PASS verdict, so submitting twice
+in succession after a validation error works correctly. Operators
+must ensure the HTMX target includes `{{ form.waf_fields }}` /
+`{% waf_protect %}` in the swapped fragment.
+
+**Authenticated forms** — set `skip_for_authenticated=True` on
+`FormProtection` to drop the spam-style defences for logged-in users
+while keeping `render_token` for integrity:
+
+```python
+waf = FormProtection(
+    form_id="team-invite",
+    defences=("render_token",),
+    skip_for_authenticated=True,
+)
+```
 
 ## Celery Beat Schedule
 

--- a/docs/specs/forms/PRD.md
+++ b/docs/specs/forms/PRD.md
@@ -1,0 +1,1169 @@
+# PRD — Form Protection (v0.11.0)
+
+**Status:** Draft for review
+**Target release:** django-waf v0.11.0
+**Author:** Nigel Copley
+**Reviewers needed:** consumer project leads (Vendably first)
+**Implementation branch:** `feat/v0.11.0-form-protection`
+
+---
+
+## 1. Context and goals
+
+django-waf currently protects at the request layer: rate limiting, anomaly
+scoring, challenges, and rule-based blocking. The middleware sees every
+request but has no semantic knowledge of forms — it can't distinguish a
+contact-form spam attempt from a login brute-force from a paginated GET on
+a list view.
+
+This PRD specifies a **form-protection subsystem** that runs at the form
+layer, between Django's `Form.is_valid()` and the view's normal handling.
+It complements the WAF rather than duplicating it: form defences feed
+their findings back into the same per-IP escalation counter the WAF
+already uses, so a bot that abuses both layers gets blocked sooner.
+
+### 1.1 In scope (threats this subsystem defends against)
+
+1. **Spam submissions** on public forms (contact, signup, comment,
+   newsletter): bots filling fields with junk.
+2. **Credential stuffing / brute force** on auth forms: per-account and
+   per-IP attempt tracking with challenge escalation.
+3. **Mass automated signup**: per-IP velocity throttling on registration.
+4. **Bot-driven form submissions**: headless browsers and scripted POSTs
+   against any protected form.
+
+### 1.2 Explicitly out of scope
+
+- **CAPTCHA fallback**. The subsystem uses honeypots + PoW + behavioural
+  signals. Adding image/audio CAPTCHA is a separate decision with its
+  own privacy and accessibility implications. Deferred to a later
+  release if PoW proves insufficient.
+- **File-upload replay through challenge**. Multipart bodies are too
+  large to round-trip via session. Forms with file fields that get
+  flagged for challenge show a "please resubmit after verification"
+  page rather than re-POSTing the data.
+- **Async / Channels forms**. v0.11.0 targets sync Django views.
+  WebSocket form handling is uncommon and would benefit from a separate
+  design.
+- **IP allow/deny override of defences**. Operators who need to bypass
+  defences for an IP do so via the existing WAF exempt-path mechanism
+  or by setting `skip_for_authenticated=True` on per-form
+  `FormProtection`. There is intentionally no per-IP-allowlist API on
+  the form-protection layer — that lives at the WAF layer.
+
+### 1.3 Non-goals (deliberately weaker than they could be)
+
+- **Defences are not exact rejections**. They emit scored verdicts that
+  aggregate. A single defence rarely blocks alone; the orchestrator
+  decides based on cumulative score. This keeps false-positive damage
+  bounded.
+- **No new database tables**. All defence state lives in Redis
+  (counters, token markers) and signed tokens (no server state for
+  tokens themselves). Operators upgrading to v0.11.0 do not run a
+  migration.
+
+---
+
+## 2. Architecture
+
+### 2.1 Three entry points, one orchestrator
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    Consumer integration                      │
+│                                                              │
+│  Option A: Django Form mixin                                 │
+│     class ContactForm(ProtectedForm, forms.Form):            │
+│         waf = FormProtection(form_id="contact", ...)         │
+│                                                              │
+│  Option B: View decorator (for non-Form views)               │
+│     @waf_protect_post(form_id="contact-handwritten",         │
+│                       defences=("honeypot", "time_trap"))    │
+│     def contact_view(request): ...                           │
+│                                                              │
+│  Option C: Template tag (for handwritten HTML forms)         │
+│     <form method="post">                                     │
+│       {% csrf_token %}                                       │
+│       {% waf_protect form_id="contact-handwritten" %}        │
+│       ...inputs...                                           │
+│     </form>                                                  │
+└────────────────────────┬────────────────────────────────────┘
+                         │
+                         ▼
+              ┌──────────────────────┐
+              │   FormProtection     │
+              │      (per-form)      │
+              │                      │
+              │  - Holds defence     │
+              │    config + weights  │
+              │  - render_fields()   │
+              │  - evaluate()        │
+              │  - resolve_verdict() │
+              └──────────┬───────────┘
+                         │
+                         ▼
+              ┌──────────────────────┐
+              │   Defence chain      │
+              │                      │
+              │  HoneypotDefence     │
+              │  TimeTrapDefence     │
+              │  RenderTokenDefence  │
+              │  UaConsistencyDefenc │
+              │  JsTouchDefence      │
+              │  CredentialThrottle  │
+              │  SignupVelocity      │
+              │  PowGateDefence      │
+              └──────────┬───────────┘
+                         │
+                         ▼
+              ┌──────────────────────┐
+              │   Outcome aggregator │
+              │                      │
+              │  - sum scores        │
+              │  - cross thresholds  │
+              │  - emit signals      │
+              │  - log structured    │
+              │  - bump WAF counter  │
+              └──────────────────────┘
+```
+
+The three integration points (mixin, decorator, template tag) all
+construct or reference the same `FormProtection` object. The mixin is
+the recommended path for new Django Form subclasses; the decorator and
+template tag together cover handwritten HTML forms that don't go
+through Django's Form layer (which Vendably's `contact.html` is an
+example of).
+
+### 2.2 Why three entry points
+
+| Entry point | When to use | Pros | Cons |
+|---|---|---|---|
+| `ProtectedForm` mixin | Standard Django Forms | Cleanest API; runs in `clean()`; no view changes | Requires `forms.Form` subclass |
+| `@waf_protect_post` decorator | Handwritten POST handlers | Works without Form; explicit at the view | Has to manually pull fields from `request.POST` |
+| `{% waf_protect %}` template tag | Handwritten HTML forms | Pairs with the decorator for HTML-only forms | Template-side only — must combine with decorator |
+
+The template tag *renders* the protected fields (honeypot, token,
+JsTouch); the decorator *validates* them on POST. Used together they
+cover any form, including those bypassing Django's Form layer.
+
+### 2.3 Module layout
+
+```
+src/icv_waf/forms/
+    __init__.py              — re-exports ProtectedForm, FormProtection,
+                               waf_protect_post
+    protection.py            — FormProtection orchestrator class
+    fields.py                — HoneypotField, RenderTokenField, JsTouchField
+    mixin.py                 — ProtectedForm mixin
+    decorators.py            — waf_protect_post
+    templatetags/
+        __init__.py
+        waf_form_tags.py     — {% waf_protect %}
+    defences/
+        __init__.py
+        base.py              — Defence ABC, Outcome dataclass, contexts
+        honeypot.py
+        time_trap.py
+        render_token.py
+        ua_consistency.py
+        js_touch.py
+        credential_throttle.py
+        signup_velocity.py
+        pow_gate.py
+    services/
+        tokens.py            — issue/verify signed form tokens (HMAC)
+        markers.py           — Redis one-shot markers for replay protection
+        counters.py          — per-IP / per-account / per-form counters
+        replay.py            — challenge-replay session/store handling
+    signals.py               — form_submission_passed / _flagged / _blocked
+                               + credential_attack_observed
+```
+
+Tests mirror the structure under `tests/forms/`.
+
+---
+
+## 3. The defences
+
+Each defence implements:
+
+```python
+class Defence(Protocol):
+    name: str  # stable identifier (snake_case)
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        """Hidden inputs (or empty dict) to inject into the rendered form.
+
+        Called once per render. Receives the request, the form_id, and
+        the per-defence config from FormProtection.
+        """
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        """Inspect submitted data + request. Return a single Outcome."""
+```
+
+```python
+@dataclass(frozen=True)
+class Outcome:
+    verdict: Literal["pass", "flag", "block"]
+    score: float = 0.0
+    reason: str = ""           # logged + emitted in structured event
+    public_message: str = ""   # shown to user if this defence blocks (rare)
+```
+
+### 3.1 HoneypotDefence
+
+**Threat:** Spam, scraping
+
+**Mechanism:** Renders one or more hidden inputs with names drawn from
+`ICV_WAF_FORM_HONEYPOT_FIELD_NAMES` (default `["url", "website",
+"homepage", "email_confirm"]`). The set rotates per-form by hashing
+`form_id` — same form always gets the same honeypot names (so caching
+works) but different forms get different names (so bots can't learn
+one set globally).
+
+**Accessibility:**
+- Visually hidden via `position: absolute; left: -9999px;` (not
+  `display: none`, which most modern bots detect).
+- `autocomplete="off"` to defeat password manager autofill.
+- `tabindex="-1"` to skip in keyboard navigation.
+- Visible screen-reader-only label: "Leave this field empty — anti-spam".
+- `aria-hidden="false"` (deliberately not hidden from AT — we *want*
+  screen-reader users to be told to skip, not for the field to be
+  invisible to them).
+
+**Verdict:** Any honeypot field with a non-empty value → `block`
+verdict, score `5.0`, reason `"honeypot:<field_name>"`.
+
+**Settings:**
+- `ICV_WAF_FORM_HONEYPOT_FIELD_NAMES` — pool of names to draw from.
+
+**False-positive considerations:** Aggressive password managers
+auto-fill these. The accessibility properties above mitigate; if
+operators see false positives, they can downweight via
+`defence_weights`.
+
+### 3.2 TimeTrapDefence
+
+**Threat:** Spam
+
+**Mechanism:** The render token records `render_time` (server time, not
+client). On submit, defence checks `now - render_time` against
+`ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS` (default `1.5`) and
+`ICV_WAF_FORM_TIME_TRAP_MAX_SECONDS` (default `3600`).
+
+**Verdict:**
+- `delta < 0.5s` → `block`, score `5.0`, reason `"time_trap:too_fast"`.
+- `0.5s ≤ delta < min` → `flag`, score `2.0`, reason
+  `"time_trap:fast"`.
+- `delta > max` → `flag`, score `2.0`, reason `"time_trap:expired"`.
+- Otherwise → `pass`.
+
+**Settings:**
+- `ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS` (default `1.5`)
+- `ICV_WAF_FORM_TIME_TRAP_MAX_SECONDS` (default `3600`)
+
+**False-positive considerations:** Power users on simple forms (1-2
+fields) can submit in under 1.5s. The `0.5s` hard block is for clearly
+non-human speeds; the flag tier between 0.5 and 1.5 is the noisier
+band.
+
+**Per-form override is the recommended pattern** for short forms.
+Newsletter signup (one email field) might set `min_fill_seconds=0.8`;
+a long contact form can leave the default. The setting is exposed
+both globally (`ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS`) and per-form
+(`FormProtection(min_fill_seconds=...)`), with the per-form value
+taking precedence.
+
+**HTMX interaction:** `render_time` is from the *original* render, not
+the most recent HTMX re-render. A user with multiple validation errors
+isn't penalised. See §4.3.
+
+### 3.3 RenderTokenDefence
+
+**Threat:** All — this is the foundation defence
+
+**Mechanism:** A signed token in a hidden field carries the form
+identifier, IP, optional user id, render time, and a nonce. A Redis
+marker keyed on the nonce is set at render time with TTL
+`ICV_WAF_FORM_TOKEN_TTL`. On `pass` verdict from the overall chain,
+the marker is deleted; on any other verdict it persists, so the user
+can resubmit (e.g. after fixing a validation error).
+
+**Token format:** HMAC-SHA256 over:
+```
+form_id | ip | user_id_or_empty | render_time_iso | nonce_hex
+```
+
+**Signing key:** Reads `ICV_WAF_SIGNING_KEY` (new in v0.11.0, package-wide;
+see §7.5). This is **separate from Django's `SECRET_KEY`** so that
+rotating one doesn't force rotating the other. If
+`ICV_WAF_SIGNING_KEY` is empty, the package falls back to a
+`SECRET_KEY`-derived value and a Django system check emits a Warning
+recommending an explicit key. Operators are expected to set a
+dedicated key in production.
+
+**Verdict:**
+- Missing/malformed/wrong-signature → `block`, score `5.0`, reason
+  `"render_token:invalid"`.
+- Signature OK but Redis marker absent and `delta > 5s` → `block`,
+  reason `"render_token:replayed"`. (5s grace allows for re-submits
+  during the marker-delete race window after a successful pass.)
+- Signature OK, marker present, `expires_at < now` → `block`, reason
+  `"render_token:expired"`.
+- IP changed since render → `flag`, score `3.0`, reason
+  `"render_token:ip_changed"`. (Mobile networks change IP; reduces
+  false positives vs. blocking.)
+
+**Settings:**
+- `ICV_WAF_FORM_TOKEN_TTL` (default `3600`)
+- `ICV_WAF_SIGNING_KEY` (package-wide; see §7.5)
+
+**HTMX interaction:** See §4.3 — token persists across re-renders;
+marker only deleted on successful `pass`.
+
+### 3.4 UaConsistencyDefence
+
+**Threat:** Scraping
+
+**Mechanism:** The render token also carries a SHA-256 hash of the
+User-Agent at render time. On submit, compare to the current UA hash.
+
+**Verdict:**
+- Hashes differ → `flag`, score `2.0`, reason
+  `"ua_consistency:changed"`.
+- Match → `pass`.
+
+**False-positive considerations:** Browser updates mid-session
+(extremely rare in practice — happens on restart, not mid-form). At
+`2.0` it cannot block alone; only contributes alongside another flag.
+
+### 3.5 JsTouchDefence
+
+**Threat:** Headless bots without JS
+
+**Mechanism:** A hidden field `waf_js_touch` rendered with value
+`unset`. Inline `<script>` runs on DOM ready and sets it to a
+short-lived signed value derived from the render token. Bots without
+JS submit the field still containing `unset`.
+
+**Verdict:**
+- Field contains `unset` → `flag`, score `1.5`, reason
+  `"js_touch:not_set"`.
+- Field contains a value that doesn't match the expected derivation →
+  `flag`, score `1.5`, reason `"js_touch:invalid"`.
+- Correct value → `pass`.
+
+**Accessibility:** `aria-hidden="true"`, `tabindex="-1"`, hidden via
+the same CSS as honeypots. Some assistive tools clear hidden field
+values; the `1.5` weight ensures this can't single-handedly block.
+
+### 3.6 CredentialThrottleDefence
+
+**Threat:** Credential stuffing, brute force
+
+**Mechanism:** Two counters in Redis:
+- `waf:form:cred_fail:account:<sha256(identifier)>` — per-account
+  failure count, identifier hashed for privacy. Increments on every
+  failed login regardless of whether the account exists (see §3.6.1).
+- `waf:form:cred_fail:ip:<ip>` — per-IP failure count across all
+  accounts.
+
+Both have window TTL `ICV_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW` (default
+`900` seconds, 15 min).
+
+**Hooking into login flow:** This defence runs in `evaluate()` *after*
+the form's `is_valid()` returns `False` (i.e. authentication failed).
+The mixin handles this; for the decorator, the consumer calls
+`waf_record_credential_failure(request, identifier)` explicitly when
+auth fails.
+
+**Verdict on submit:**
+- Per-IP count ≥ `ICV_WAF_FORM_CREDENTIAL_IP_LIMIT` (default `20`)
+  → `flag`, score `5.0`, reason `"credential_throttle:ip"`. Triggers
+  challenge redirect.
+- Per-account count ≥ `ICV_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT`
+  (default `5`) → does **not** affect form verdict; emits
+  `credential_attack_observed` signal only (see §3.6.1).
+- Otherwise → `pass`.
+
+#### 3.6.1 Account enumeration safety
+
+**Critical constraint:** The form's user-visible behaviour must not
+reveal whether an account exists. Three implications baked into the
+design:
+
+1. **The per-account counter increments on every failed login**, not
+   only when the account exists. A bot trying `admin / wrongpass` and
+   `nonexistent / wrongpass` both increment counters under their
+   respective typed identifiers. The counter operates on the hashed
+   identifier string, not on a database lookup.
+
+2. **User-visible escalation fires on the per-IP counter, not the
+   per-account.** If per-account triggered a visible challenge, it
+   would leak: "your account is being attacked" tells the attacker
+   the username was right. The per-account counter is
+   observation-only.
+
+3. **Constant-time defence evaluation.** All defences run before the
+   form's password check. The defence chain takes the same wall-clock
+   regardless of which fields were typed. Django's
+   `AuthenticationForm` already runs `bcrypt` against a dummy hash
+   when the user doesn't exist, so the auth check itself doesn't leak
+   timing.
+
+**The `credential_attack_observed` signal** is emitted when a
+per-account counter crosses its threshold. Consumer projects connect a
+handler to email the legitimate account holder (if the account exists),
+notify ops, or both. The signal does not affect the response to the
+attacker.
+
+**Settings:**
+- `ICV_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW` (default `900`)
+- `ICV_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT` (default `5`)
+- `ICV_WAF_FORM_CREDENTIAL_IP_LIMIT` (default `20`)
+
+### 3.7 SignupVelocityDefence
+
+**Threat:** Mass automated signup
+
+**Mechanism:** Counter `waf:form:signup:<ip>` increments on each
+*successful* form pass (so it counts completed registrations, not
+attempts). Window TTL
+`ICV_WAF_FORM_SIGNUP_VELOCITY_WINDOW` (default `86400`, 24h).
+
+**Verdict:**
+- Count ≥ `ICV_WAF_FORM_SIGNUP_VELOCITY_LIMIT` (default `5`) → `flag`,
+  score `5.0`, reason `"signup_velocity:ip"`. Challenge required for
+  the next submission.
+- Otherwise → `pass`. The increment happens after the form passes, so
+  the user that crosses the threshold sees their challenge on the
+  *next* signup, not the current one.
+
+**Settings:**
+- `ICV_WAF_FORM_SIGNUP_VELOCITY_WINDOW` (default `86400`)
+- `ICV_WAF_FORM_SIGNUP_VELOCITY_LIMIT` (default `5`)
+
+### 3.8 PowGateDefence
+
+**Threat:** All — adds a constant CPU cost per submission
+
+**Mechanism:** Reuses the existing WAF PoW infrastructure rather than
+duplicating it. Specifically:
+
+- **Server verification** calls
+  `icv_waf.services.challenge_service._digest_has_leading_zero_bits`
+  — the same helper the page-level challenge uses (introduced in
+  v0.10.5). One source of bit-counting logic, no risk of drift.
+- **JS solver** is the same `hasLeadingZeroBits` function shipped in
+  `templates/icv_waf/challenge.html`. The form's protected-fields
+  partial includes a minimal solver script that imports the same
+  function shape; we extract it into a static asset so both the
+  page-level challenge template and the form partial reference the
+  same code (refactor done as part of this work).
+- **Difficulty source:** form-level PoW is *lighter* than the page
+  challenge by default — `ICV_WAF_FORM_POW_DIFFICULTY` (default
+  `12` bits, ~4k hashes, ~50ms on desktop, ~200ms on mobile). The
+  page-level challenge defaults are 22 (desktop) / 18 (mobile);
+  form-level is intentionally lower because it runs on *every*
+  submission while the page challenge fires once per session.
+
+The token shape (digest of `form_token + nonce`) and the verifier
+contract are identical to the page-level PoW, so any future
+improvements to the PoW (e.g. argon2-based instead of SHA-256) land
+once and benefit both.
+
+**Solver runs on render**, not on submit. Submit reads the nonce
+from the hidden field — submit itself is instant. If operators want
+a guarantee the PoW is done before submit, they set
+`data-waf-pow-block-submit="true"` on the form element; this disables
+the submit button until the solver writes the nonce.
+
+**Verdict:**
+- Nonce missing or doesn't satisfy bit difficulty → `block`, score
+  `5.0`, reason `"pow_gate:invalid"`.
+- Valid → `pass`.
+
+**Settings:**
+- `ICV_WAF_FORM_POW_DIFFICULTY` (default `12` bits)
+
+**Why a separate form-level PoW at all (vs. just relying on the page
+challenge)?** The page challenge runs once per session and grants a
+cookie; after that, every submission from that session is free. A
+form-level PoW costs the bot per-submission, which is what slows
+high-volume spam. The two PoWs are complementary, not redundant.
+
+---
+
+## 4. Token lifecycle (deep dive)
+
+### 4.1 Issuance
+
+On render (form GET, or any HTMX re-render that hits
+`render_fields()`):
+
+```
+nonce        = secrets.token_hex(16)
+render_time  = timezone.now()
+ua_hash      = sha256(request.META["HTTP_USER_AGENT"])
+payload      = f"{form_id}|{ip}|{user_id_or_empty}|{render_time.isoformat()}|{nonce}|{ua_hash}"
+signature    = hmac.new(signing_key, payload.encode(), sha256).hexdigest()
+token        = base64url(payload + "|" + signature)
+
+redis.setex(f"waf:form:token:{nonce}", token_ttl, "1")
+```
+
+The token is the hidden field's value. The Redis marker (`"1"`) is
+the one-shot indicator — its presence means "this token has not yet
+been spent on a successful submission."
+
+### 4.2 Verification (in `evaluate()`)
+
+```
+token = request.POST["waf_token"]
+payload, sig = decode(token)
+expected_sig = hmac(...)
+if not constant_time_eq(sig, expected_sig):
+    return Outcome(block, "render_token:invalid")
+
+form_id, ip_at_render, user_at_render, render_time, nonce, ua_hash = parse(payload)
+
+if render_time + token_ttl < now:
+    return Outcome(block, "render_token:expired")
+
+marker_exists = redis.exists(f"waf:form:token:{nonce}")
+if not marker_exists:
+    delta = now - render_time
+    if delta > 5:  # grace window for marker-delete race
+        return Outcome(block, "render_token:replayed")
+
+if ip_at_render != current_ip:
+    return Outcome(flag, score=3.0, "render_token:ip_changed")
+
+return Outcome(pass)
+```
+
+### 4.3 HTMX re-render semantics
+
+Vendably (and others) re-render forms via HTMX after validation
+errors. The semantics must be: **the same token survives all
+re-renders of the same form session.**
+
+Rule: **the Redis marker is only deleted when the orchestrator's
+overall verdict is `pass`.** On `flag`, `block`, or form-level
+`is_valid() == False`, the marker stays. So:
+
+| Scenario | Marker after submit |
+|---|---|
+| Form passed validation + defences | Deleted |
+| Form failed Django validation (e.g. missing field) | Kept |
+| Form passed validation, defence flagged | Kept (challenge replay) |
+| Form passed validation, defence blocked | Kept (no replay benefit but no harm) |
+
+When the user fixes the form and re-submits with the same token, the
+marker is still there. Token TTL still bounds the window: a user with
+50 validation errors over an hour eventually hits expiry and gets a
+new token on the next render.
+
+**Constraint for consumers:** When using HTMX, the protected fields
+must be in the swapped fragment. If `hx-target` excludes them, the
+form loses its token on re-render and the next submit will fail.
+Document this in the operator runbook.
+
+### 4.4 Token replay window analysis
+
+- Between issuance and first submit: marker present → replay impossible.
+- Between successful submit and marker delete: ~5ms in normal Redis,
+  bounded by the 5s grace window. An attacker would need to intercept
+  the response and replay the token in under 5s; in practice, the
+  CSRF token rotates on session updates so this is doubly bounded.
+- After successful submit + marker delete: marker absent + delta > 5s
+  → block. Replay closed.
+- After TTL: token expired regardless of marker. Replay closed.
+
+---
+
+## 5. Challenge replay flow
+
+When the orchestrator's verdict is `flag` and
+`ICV_WAF_FORM_CHALLENGE_ON_FLAG=True` (default), the user is
+redirected to the existing WAF challenge view, then the form is
+re-POSTed automatically after the challenge passes.
+
+### 5.1 Sequence
+
+```
+1. User submits form.
+2. FormProtection.evaluate() returns Outcome(flag, score=3.5,
+   defences=["time_trap", "ua_consistency"]).
+3. FormProtection persists submitted POST data to
+   request.session["waf_form_replay"]:
+     {
+       "form_id": "contact",
+       "post_url": "/contact/",
+       "data": {sanitized_post_data},
+       "files": [<list of file fields excluded from replay>],
+       "csrf_token": <new CSRF token bound to session>,
+       "expires_at": now + 60s,
+     }
+   Password fields and file fields are EXCLUDED from replay data.
+4. Bump waf:challenged:<ip> counter (cross-layer escalation).
+5. Emit form_submission_flagged signal.
+6. Return HttpResponseRedirect to
+     /waf/challenge/?next=/contact/&form_replay=<token>
+   where <token> is a short-lived signed reference to the
+   session-stored replay data.
+7. User solves the challenge.
+8. WAF VerifyView, on success, checks for form_replay parameter.
+9. If present, validate the replay token, fetch the data from session,
+   re-construct the POST, and dispatch the original view with the
+   restored data.
+10. The view sees a normal POST. The form's defences run again — but
+    this time the user has a valid waf_pass cookie, so the
+    UaConsistencyDefence sees a fresh UA (it does — first submit was
+    pre-challenge, second is post-challenge with same UA) and the
+    RenderToken has been refreshed... actually this needs care.
+```
+
+### 5.2 Token state on replay
+
+The challenge passes do **not** automatically re-issue a form token.
+The original render token is still in the replay data and gets POSTed
+along. The RenderTokenDefence re-evaluates it; on the replay POST, the
+flags that triggered the challenge (time_trap, ua_consistency) might
+re-fire. To prevent an infinite loop:
+
+**Rule:** When the VerifyView replays a POST, it adds a header
+`X-WAF-Challenge-Passed: <signed marker>` and the FormProtection
+orchestrator treats this as "skip behavioural defences this submit"
+(but **not** integrity defences like render_token and honeypot — those
+still run, because the data is the same as the original submit and
+those didn't fire then anyway).
+
+Defences are classified:
+- **Integrity** (always run): RenderToken, Honeypot, PowGate.
+- **Behavioural** (skipped on challenge replay): TimeTrap, UaConsistency,
+  JsTouch.
+- **Throttle** (always run): CredentialThrottle, SignupVelocity.
+
+### 5.3 Sensitive data omission
+
+Replay data **must not** contain:
+- Password fields (any field name matching `/pass(word)?/i`).
+- File upload fields (multipart bodies; oversized for session
+  storage).
+- Any field marked `sensitive=True` in the form definition (custom
+  marker for operators who want to exclude additional fields).
+
+For login forms: the password field is omitted, so on challenge
+replay the user is shown a "please re-enter your password" page
+rather than auto-replayed. Acceptable UX cost for the security
+benefit.
+
+For forms with file uploads: the user is shown "verification
+successful, please resubmit your form" with the form data
+pre-filled from session except the file fields.
+
+### 5.4 CSRF rotation
+
+A fresh CSRF token is generated when the challenge passes and bound
+to the replayed POST. This prevents CSRF attacks that exploit the
+challenge as a CSRF bypass.
+
+### 5.5 Failure modes
+
+| Failure | Behaviour |
+|---|---|
+| Session storage unavailable | Fall back to form-level rejection (no replay) |
+| Replay token expired (60s TTL) | Show form pre-filled, ask user to resubmit |
+| Form fields changed between original POST and replay | Show form pre-filled, ask user to resubmit |
+| User navigates away during challenge | Session expires; form data lost |
+
+The replay flow is best-effort UX. Failing back to "please resubmit"
+is always safe.
+
+---
+
+## 6. Score aggregation and verdict resolution
+
+After all defences run, the orchestrator computes a final verdict.
+
+```python
+def resolve_verdict(outcomes: list[Outcome]) -> FormVerdict:
+    if any(o.verdict == "block" for o in outcomes):
+        return FormVerdict.BLOCKED
+
+    total = sum(o.score for o in outcomes if o.verdict == "flag")
+
+    if total >= ICV_WAF_FORM_BLOCK_THRESHOLD:  # default 5.0
+        return FormVerdict.BLOCKED
+    if total >= ICV_WAF_FORM_FLAG_THRESHOLD:   # default 2.0
+        return FormVerdict.FLAGGED
+    return FormVerdict.PASSED
+```
+
+### 6.1 Verdict actions
+
+| Verdict | Form behaviour | Logging | Counter | Signal |
+|---|---|---|---|---|
+| `PASSED` | Form validates normally | Sampled (`ICV_WAF_LOG_SAMPLE_RATE`) | — | `form_submission_passed` |
+| `FLAGGED` | Challenge redirect (or generic error if challenge disabled) | Always logged | Bump `waf:challenged:<ip>` | `form_submission_flagged` |
+| `BLOCKED` | `forms.ValidationError("submission rejected")` | Always logged | Bump `waf:challenged:<ip>` | `form_submission_blocked` |
+
+The challenge counter bump on FLAGGED is the cross-layer integration:
+form defences and WAF request defences share the same escalation
+threshold (`ICV_WAF_CHALLENGE_ESCALATION_THRESHOLD`), so a bot abusing
+both layers gets auto-blocked sooner.
+
+---
+
+## 7. Configuration
+
+### 7.1 Top-level settings
+
+```python
+ICV_WAF_FORM_PROTECTION_ENABLED          = True
+ICV_WAF_FORM_FLAG_THRESHOLD              = 2.0
+ICV_WAF_FORM_BLOCK_THRESHOLD             = 5.0
+ICV_WAF_FORM_CHALLENGE_ON_FLAG           = True
+ICV_WAF_FORM_REPLAY_STORE                = "session"  # "session" | "redis"
+ICV_WAF_FORM_EMIT_PASSED_SIGNAL          = False      # opt-in; busy sites
+                                                      # don't want the hot
+                                                      # path firing signals
+```
+
+Plus the **package-wide signing key** (see §7.4):
+
+```python
+ICV_WAF_SIGNING_KEY                      = ""         # dedicated WAF HMAC
+                                                      # secret; falls back to
+                                                      # SECRET_KEY-derived
+                                                      # value with W003
+                                                      # warning if unset
+```
+
+### 7.2 Per-defence settings
+
+```python
+ICV_WAF_FORM_HONEYPOT_FIELD_NAMES        = ["url", "website", "homepage", "email_confirm"]
+ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS       = 1.5
+ICV_WAF_FORM_TIME_TRAP_MAX_SECONDS       = 3600
+ICV_WAF_FORM_TOKEN_TTL                   = 3600
+ICV_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW  = 900
+ICV_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT   = 5
+ICV_WAF_FORM_CREDENTIAL_IP_LIMIT         = 20
+ICV_WAF_FORM_SIGNUP_VELOCITY_WINDOW      = 86400
+ICV_WAF_FORM_SIGNUP_VELOCITY_LIMIT       = 5
+ICV_WAF_FORM_POW_DIFFICULTY              = 12
+```
+
+### 7.3 Global score weights (overridable per-form)
+
+```python
+ICV_WAF_FORM_DEFENCE_WEIGHTS = {
+    "honeypot": 5.0,
+    "time_trap": 2.0,
+    "render_token": 5.0,
+    "ua_consistency": 2.0,
+    "js_touch": 1.5,
+    "credential_throttle": 5.0,
+    "signup_velocity": 5.0,
+    "pow_gate": 5.0,
+}
+```
+
+### 7.4 Package-wide signing key
+
+```python
+ICV_WAF_SIGNING_KEY = os.environ.get("ICV_WAF_SIGNING_KEY", "")
+```
+
+**New in v0.11.0.** A dedicated signing secret for any HMAC the WAF
+issues — form render tokens, future signed verdicts, and challenge
+tokens (which currently derive from `SECRET_KEY`; the v0.11.0 work
+migrates them onto this key so all WAF-issued signatures share one
+rotation lifecycle).
+
+**Why separate from `SECRET_KEY`:** rotating `SECRET_KEY` invalidates
+all Django sessions; coupling the WAF's signed tokens to it means
+rotating one forces rotating the other and vice versa. A dedicated
+key lets operators rotate WAF signatures on a security-driven cadence
+without logging users out.
+
+**Defaults and fallback:** if `ICV_WAF_SIGNING_KEY` is empty, the
+package derives a key from `SECRET_KEY` (so v0.10.x → v0.11.0
+upgrades don't break) and a Django system check (`icv_waf.W003`)
+emits a warning at startup recommending an explicit key. The fallback
+is not silently failing; it's documented and surfaced.
+
+**Operational guidance:** generate with
+`python -c "import secrets; print(secrets.token_urlsafe(64))"` and
+load from environment, the same pattern as `SECRET_KEY`.
+
+### 7.5 Per-form override
+
+```python
+class ContactForm(ProtectedForm, forms.Form):
+    waf = FormProtection(
+        form_id="contact",
+        defences=("honeypot", "time_trap", "render_token", "ua_consistency"),
+        defence_weights={"time_trap": 4.0},  # this form's bots are faster
+        min_fill_seconds=1.0,                 # this form is short, allow 1s
+        skip_for_authenticated=False,         # public form
+        challenge_on_flag=True,               # explicit
+    )
+```
+
+---
+
+## 8. Signals
+
+```python
+# Emitted on PASSED submissions only when
+# ICV_WAF_FORM_EMIT_PASSED_SIGNAL=True (default False). Busy sites can
+# have 1000× more passed submissions than flagged/blocked; firing a
+# signal on every one is a hidden cost in the hot path. Operators who
+# want pass-event analytics opt in; everyone else pulls from the
+# structured log (which already records passed submissions, sampled).
+form_submission_passed = Signal()
+# kwargs: form_id, ip, user_agent, user_id (or None)
+
+# Emitted when score crosses ICV_WAF_FORM_FLAG_THRESHOLD.
+form_submission_flagged = Signal()
+# kwargs: form_id, ip, user_agent, user_id, total_score, defences (list of Outcome)
+
+# Emitted on BLOCKED verdict (defence block OR score >= block threshold).
+form_submission_blocked = Signal()
+# kwargs: form_id, ip, user_agent, user_id, total_score, defences, reason
+
+# Emitted when per-account credential failure counter crosses threshold.
+# Consumer-side handler decides what to do (email user, alert ops, etc.).
+credential_attack_observed = Signal()
+# kwargs: identifier_hash, attempt_count, window_seconds, ip
+```
+
+All signals emitted from a non-atomic context. Receivers must not
+raise; failures are logged but never propagate to the caller.
+
+---
+
+## 9. Logging
+
+Every submission produces one structured log line at `INFO`:
+
+```python
+logger.info(
+    "waf.form_submission",
+    extra={
+        "event": "waf.form_submission",
+        "form_id": "contact",
+        "verdict": "flagged",         # passed | flagged | blocked
+        "ip": "1.2.3.4",
+        "user_agent": "...",
+        "user_id": None,
+        "total_score": 3.5,
+        "defences": [
+            {"name": "honeypot", "verdict": "pass", "score": 0.0},
+            {"name": "time_trap", "verdict": "flag", "score": 2.0,
+             "reason": "time_trap:fast"},
+            {"name": "ua_consistency", "verdict": "flag", "score": 1.5,
+             "reason": "ua_consistency:changed"},
+        ],
+    },
+)
+```
+
+Goes to the existing `icv_waf` logger.
+
+### 9.1 Sampling
+
+- `passed` submissions: sampled at `ICV_WAF_LOG_SAMPLE_RATE` (same
+  setting that drives request-level log sampling).
+- `flagged` and `blocked`: always logged, never sampled.
+
+### 9.2 Debug header (DEBUG=True only)
+
+In development, the response includes:
+
+```
+X-WAF-Form-Verdict: flagged; score=3.5; defences=time_trap,ua_consistency
+```
+
+Off in production (`DEBUG=False`). Lets developers reproduce blocking
+without grepping logs.
+
+---
+
+## 10. Operator runbook
+
+### 10.1 "Why did legitimate user X get blocked?"
+
+1. Grep logs for the user's IP and form_id:
+   ```
+   grep 'waf.form_submission' app.log | jq 'select(.ip == "1.2.3.4")'
+   ```
+2. Look at the `defences` array. Each entry has `name`, `verdict`,
+   `score`, and `reason`. The reasons are structured strings —
+   `time_trap:fast`, `ua_consistency:changed`, etc.
+3. If the user reproduces the block in a dev environment, the
+   `X-WAF-Form-Verdict` header surfaces the same info inline.
+4. Common fixes:
+   - User is a password-manager user → downweight `honeypot` or use
+     fewer field names.
+   - User is on mobile with frequent IP changes → downweight
+     `render_token` IP-changed flag (`ip_changed_score=0.5`).
+   - User fills forms very fast → lower the form's `min_fill_seconds`.
+
+### 10.2 "Bots are still getting through"
+
+1. Check the log for `verdict: passed` entries on the form_id. Look
+   at the defences array — which ones are running, which aren't?
+2. If the bot has a valid render token, it's solving the PoW and
+   honeypot. Consider enabling PoW (`defences=(..., "pow_gate")`).
+3. Check `total_score` distribution. If passing submissions are
+   scoring 1.0–1.9 (just under the flag threshold), the threshold
+   may need lowering for that form.
+
+### 10.3 "Challenge-replay flow isn't working"
+
+1. Check `request.session` is configured and writable.
+2. Check the replay token in the redirect URL hasn't expired (60s
+   TTL).
+3. Check the form fields haven't changed between original POST and
+   replay (e.g. dynamic field generation based on user state).
+4. Disable with `ICV_WAF_FORM_CHALLENGE_ON_FLAG=False` as a workaround
+   while investigating; flagged submissions get a generic rejection.
+
+---
+
+## 11. Backwards compatibility
+
+- **No DB migrations.** All defence state in Redis or signed tokens.
+- **Opt-in per form.** Adding `ProtectedForm` to a base class is one
+  line per form. Upgrading django-waf to v0.11.0 changes nothing
+  until a form opts in.
+- **No changes to existing settings** (no defaults shifted, no
+  semantics changed). All new settings are additive.
+- **Existing signals unchanged.** New signals are added; existing
+  ones (`request_blocked`, `challenge_failed`, etc.) are untouched.
+- **Public API surface added:**
+  - `icv_waf.forms.ProtectedForm`
+  - `icv_waf.forms.FormProtection`
+  - `icv_waf.forms.waf_protect_post` (decorator)
+  - `{% load waf_form_tags %}` and `{% waf_protect %}` (template tag)
+  - 4 new signals
+
+The version bump to v0.11.0 reflects the new public API. No breaking
+changes to v0.10.x callers.
+
+---
+
+## 12. Test plan
+
+Target ≥90% coverage on the new modules, matching existing project
+standard.
+
+### 12.1 Per-defence tests
+
+One module per defence under `tests/forms/`:
+
+- `test_honeypot.py` — empty field passes, non-empty blocks, rotating
+  field names per form_id, accessibility attributes rendered.
+- `test_time_trap.py` — fast submission blocks (<0.5s), slow flag
+  band (0.5–min), expiry flag (>max), passes between min and max.
+- `test_render_token.py` — issue, verify, replay protection, IP
+  binding, UA binding, signature verification, expiry, marker
+  lifecycle.
+- `test_ua_consistency.py` — match passes, mismatch flags.
+- `test_js_touch.py` — sentinel unchanged flags, correct value
+  passes, invalid value flags.
+- `test_credential_throttle.py` — per-account counter increments on
+  failure, per-IP counter crosses threshold, account enumeration
+  safety (same behaviour whether account exists), window expiry.
+- `test_signup_velocity.py` — increments on pass, blocks when
+  threshold crossed, window expiry.
+- `test_pow_gate.py` — missing nonce blocks, invalid nonce blocks,
+  valid nonce passes, bit-counting parity with verifier.
+
+### 12.2 Integration tests
+
+- `test_orchestrator.py` — score aggregation, threshold crossing,
+  block precedence over flag.
+- `test_mixin.py` — field injection, clean() flow, signal emission,
+  skip_for_authenticated behaviour.
+- `test_decorator.py` — POST handling, defence chain runs, signal
+  emission.
+- `test_template_tag.py` — renders correct fields, integrates with
+  decorator.
+- `test_challenge_replay.py` — full flow: flag → session store →
+  redirect → challenge pass → replay → form succeeds. Plus failure
+  modes (expired token, missing session, file upload).
+- `test_htmx_re_render.py` — same token survives re-render with
+  validation errors, marker not deleted until successful pass.
+- `test_signals.py` — all 4 signals fire on appropriate verdicts.
+- `test_cross_layer_escalation.py` — form flag bumps
+  `waf:challenged:<ip>`, subsequent WAF challenge failure escalates
+  to block.
+- `test_enumeration_timing.py` — measure response time for existing
+  vs. nonexistent accounts on a protected login form; assert delta
+  under threshold.
+
+### 12.3 What we deliberately don't test
+
+- The exact PoW solve time on a real browser (CI is too variable).
+- Cross-browser JS solver compatibility (manual smoke test pre-release).
+- Real-world false-positive rate (only measurable in production).
+
+---
+
+## 13. Estimated work
+
+| Block | Code | Tests | Days |
+|---|---|---|---|
+| Token + marker services | ~150 | ~250 | 0.5 |
+| 8 defences (~80 LOC each) | ~640 | ~1100 | 3.0 |
+| Orchestrator + mixin | ~250 | ~400 | 1.0 |
+| Decorator + template tag | ~120 | ~200 | 0.5 |
+| Challenge-replay flow | ~200 | ~400 | 1.0 |
+| Signals + logging | ~80 | ~150 | 0.5 |
+| Docs (README, CHANGELOG, runbook) | ~500 | — | 0.5 |
+| **Total** | **~1940** | **~2500** | **~7 days** |
+
+About one focused week. Commits land defence-by-defence within the
+branch — each defence is independently testable and reviewable.
+
+---
+
+## 14. Resolved design decisions
+
+The six questions originally posed during PRD review, with the
+decisions taken. Resolved 2026-05-27.
+
+1. **Challenge replay scope** — **In v0.11.0 behind a setting.**
+   `ICV_WAF_FORM_CHALLENGE_ON_FLAG` defaults to `True`. If it lands
+   buggy in production, operators flip it to `False` and flagged
+   submissions get a generic rejection. Implementation lands last in
+   the branch so the simpler defences are stable first.
+
+2. **Token signing key** — **Separate, package-wide
+   `ICV_WAF_SIGNING_KEY`.** Coupling WAF signatures to `SECRET_KEY`
+   means rotating one forces rotating the other (and logs every user
+   out). The new setting is package-wide because future signed-token
+   uses (challenge tokens, signed verdicts) should share one key, not
+   per-feature ones. See §7.4. Falls back to a `SECRET_KEY`-derived
+   value with a Django system check (`icv_waf.W003`) warning if
+   unset, so v0.10 → v0.11 upgrades don't break.
+
+3. **Default `time_trap` min** — **1.5s, with per-form override
+   prominently documented.** Newsletter-signup-style short forms set
+   `min_fill_seconds=0.8` (or lower) on their `FormProtection`.
+   1.5s is the right default for a typical 3–5 field form.
+
+4. **PoW default difficulty** — **Reuse the existing PoW
+   infrastructure** rather than building a parallel implementation.
+   Calls the same `_digest_has_leading_zero_bits` helper introduced
+   in v0.10.5 server-side and the same `hasLeadingZeroBits` JS
+   helper from the page challenge. Form-level default is `12` bits
+   (~50ms desktop, ~200ms mobile) — lighter than the page challenge
+   (22/18) because it runs on every submission, not once per session.
+   See §3.8.
+
+5. **HTMX documentation** — **Framework-agnostic.** Single "HTMX
+   integration" subsection in the operator guide describing the
+   token-survives-re-render rule (§4.3) and the
+   protected-fields-must-be-in-swap constraint. No project-specific
+   examples in the package; consumer projects document their own
+   patterns.
+
+6. **`form_submission_passed` default** — **Off by default**
+   (`ICV_WAF_FORM_EMIT_PASSED_SIGNAL = False`). Busy sites have 1000×
+   more passed submissions than flagged/blocked, so firing the signal
+   on every one is a hidden cost in the hot path. The structured log
+   already records passed submissions (sampled at
+   `ICV_WAF_LOG_SAMPLE_RATE`). Operators who want pass-event analytics
+   opt in explicitly. `form_submission_flagged` and `_blocked` always
+   fire regardless of this setting.
+
+---
+
+## 15. Explicitly deferred
+
+- **CAPTCHA fallback** for when PoW proves insufficient against
+  determined adversaries.
+- **Async / Channels forms.** v0.11.0 is sync-only.
+- **File upload replay** through challenge. Multipart bodies aren't
+  round-tripped; user resubmits.
+- **Per-IP allowlists** at the form-protection layer. Use the WAF
+  exempt-path mechanism.
+- **Machine learning** for defence weighting. Static weights; tune
+  via configuration.
+- **Distributed counter coordination** across multiple Redis
+  instances. Single-instance Redis is the assumption (same as the
+  rest of django-waf).
+
+---
+
+## Appendix A — Glossary
+
+- **Defence**: a single check (honeypot, time_trap, ...) that
+  produces one `Outcome`.
+- **Outcome**: a defence's result — verdict (pass/flag/block) plus
+  score and reason.
+- **Verdict**: the orchestrator's aggregate decision — `PASSED`,
+  `FLAGGED`, or `BLOCKED`.
+- **Render token**: HMAC-signed payload embedded in the form at render
+  time, verified on submit.
+- **Marker**: short-lived Redis key indicating a token hasn't been
+  spent on a successful submission yet.
+- **Form ID**: stable string identifier for a form, used as a
+  counter-bucket key and to namespace per-form settings.
+
+---
+
+## Appendix B — Settings cheat sheet
+
+```python
+# Package-wide
+ICV_WAF_SIGNING_KEY                      = ""     # dedicated HMAC secret;
+                                                  # falls back to
+                                                  # SECRET_KEY-derived value
+                                                  # with W003 warning if unset
+
+# Top-level
+ICV_WAF_FORM_PROTECTION_ENABLED          = True
+ICV_WAF_FORM_FLAG_THRESHOLD              = 2.0
+ICV_WAF_FORM_BLOCK_THRESHOLD             = 5.0
+ICV_WAF_FORM_CHALLENGE_ON_FLAG           = True
+ICV_WAF_FORM_REPLAY_STORE                = "session"
+ICV_WAF_FORM_EMIT_PASSED_SIGNAL          = False  # opt-in; off by default
+
+# Tokens (uses package-wide ICV_WAF_SIGNING_KEY for signature)
+ICV_WAF_FORM_TOKEN_TTL                   = 3600
+
+# Honeypot
+ICV_WAF_FORM_HONEYPOT_FIELD_NAMES        = ["url", "website", "homepage", "email_confirm"]
+
+# Time trap
+ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS       = 1.5
+ICV_WAF_FORM_TIME_TRAP_MAX_SECONDS       = 3600
+
+# Credential throttle
+ICV_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW  = 900
+ICV_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT   = 5
+ICV_WAF_FORM_CREDENTIAL_IP_LIMIT         = 20
+
+# Signup velocity
+ICV_WAF_FORM_SIGNUP_VELOCITY_WINDOW      = 86400
+ICV_WAF_FORM_SIGNUP_VELOCITY_LIMIT       = 5
+
+# PoW
+ICV_WAF_FORM_POW_DIFFICULTY              = 12
+
+# Score weights (overridable per-form via defence_weights kwarg)
+ICV_WAF_FORM_DEFENCE_WEIGHTS = {
+    "honeypot": 5.0, "time_trap": 2.0, "render_token": 5.0,
+    "ua_consistency": 2.0, "js_touch": 1.5,
+    "credential_throttle": 5.0, "signup_velocity": 5.0,
+    "pow_gate": 5.0,
+}
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "0.10.6"
+version = "0.11.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/icv_waf/checks.py
+++ b/src/icv_waf/checks.py
@@ -11,6 +11,11 @@ Expected attempts is ``2 ** difficulty``. Thresholds:
 * ``> 28`` (~268M hashes, > 60s on most laptops) — Error.
 * ``> 24`` (~16M hashes, ~5–20s on phones) — Warning.
 * ``< 8``  (256 hashes, no real bot deterrence) — Warning.
+
+The signing-key check (``icv_waf.W003``) was added in v0.11.0 alongside
+the form-protection subsystem. It surfaces when the package is falling
+back to a ``SECRET_KEY``-derived signing key — fine for development but
+worth a deliberate decision in production.
 """
 
 from __future__ import annotations
@@ -73,3 +78,32 @@ def check_challenge_difficulty(app_configs, **kwargs):
             )
 
     return messages
+
+
+@register()
+def check_signing_key(app_configs, **kwargs):
+    """Warn when ``ICV_WAF_SIGNING_KEY`` is unset and the package falls back
+    to a ``SECRET_KEY``-derived value.
+
+    Falling back is supported — it's how v0.10.x → v0.11.0 upgrades stay
+    seamless — but tying WAF signatures to ``SECRET_KEY`` means rotating
+    one forces rotating the other and logs every user out. The W003
+    warning nudges operators toward an explicit dedicated key.
+    """
+    from icv_waf import conf
+
+    if not conf.ICV_WAF_SIGNING_KEY:
+        return [
+            Warning(
+                "ICV_WAF_SIGNING_KEY is not set — falling back to a SECRET_KEY-derived signing key for WAF tokens.",
+                hint=(
+                    'Generate a dedicated key with `python -c "import '
+                    'secrets; print(secrets.token_urlsafe(64))"` and set '
+                    "ICV_WAF_SIGNING_KEY in your environment. Keeping the "
+                    "WAF key separate from SECRET_KEY lets you rotate "
+                    "either independently."
+                ),
+                id="icv_waf.W003",
+            )
+        ]
+    return []

--- a/src/icv_waf/conf.py
+++ b/src/icv_waf/conf.py
@@ -11,6 +11,20 @@ from django.conf import settings
 # Enable or disable the WAF middleware entirely.
 ICV_WAF_ENABLED: bool = getattr(settings, "ICV_WAF_ENABLED", True)
 
+# Package-wide HMAC signing secret. Used by every signed artefact the WAF
+# issues — form render tokens (v0.11.0), and any future signed verdicts
+# or challenge tokens that migrate off ``SECRET_KEY``. Kept deliberately
+# separate from Django's ``SECRET_KEY`` so operators can rotate WAF
+# signatures on a security-driven cadence without invalidating sessions.
+#
+# When empty (the default for backwards compatibility) callers must use
+# the helper in ``icv_waf.services.tokens.get_signing_key()`` which falls
+# back to a ``SECRET_KEY``-derived value and the ``icv_waf.W003`` system
+# check emits a warning at startup. In production, set this to a value
+# generated with ``python -c "import secrets; print(secrets.token_urlsafe(64))"``
+# and load it from environment.
+ICV_WAF_SIGNING_KEY: str = getattr(settings, "ICV_WAF_SIGNING_KEY", "")
+
 # Proof-of-work challenge difficulty — number of leading zero **bits** the
 # SHA-256(token + nonce) digest must contain. Average solve cost is
 # ``2 ** difficulty`` hashes. Acts as the single-value fallback when the

--- a/src/icv_waf/conf.py
+++ b/src/icv_waf/conf.py
@@ -25,6 +25,107 @@ ICV_WAF_ENABLED: bool = getattr(settings, "ICV_WAF_ENABLED", True)
 # and load it from environment.
 ICV_WAF_SIGNING_KEY: str = getattr(settings, "ICV_WAF_SIGNING_KEY", "")
 
+# ---------------------------------------------------------------------------
+# Form-protection subsystem (v0.11.0)
+# ---------------------------------------------------------------------------
+# All settings below are read by the form-protection defences and
+# orchestrator. Nothing in the existing middleware uses them. Adding
+# ``ProtectedForm`` (or the decorator / template tag) to a form is the
+# opt-in step; until that happens these settings are inert.
+
+# Master kill switch for the form-protection subsystem. When False,
+# ``ProtectedForm.clean()`` and the decorator/template-tag short-circuit
+# to pass without running any defences. Useful for incident response.
+ICV_WAF_FORM_PROTECTION_ENABLED: bool = getattr(settings, "ICV_WAF_FORM_PROTECTION_ENABLED", True)
+
+# Aggregate-score thresholds. The orchestrator sums ``flag`` scores;
+# crossing FLAG triggers logging + signal + (optionally) challenge
+# redirect; crossing BLOCK rejects the submission outright. A single
+# defence returning ``block`` short-circuits the chain regardless of
+# total.
+ICV_WAF_FORM_FLAG_THRESHOLD: float = getattr(settings, "ICV_WAF_FORM_FLAG_THRESHOLD", 2.0)
+ICV_WAF_FORM_BLOCK_THRESHOLD: float = getattr(settings, "ICV_WAF_FORM_BLOCK_THRESHOLD", 5.0)
+
+# Whether to redirect flagged submissions through the existing
+# /waf/challenge/ flow rather than rejecting them. When True (default)
+# false-positive users get a way through; when False they get a
+# generic form error.
+ICV_WAF_FORM_CHALLENGE_ON_FLAG: bool = getattr(settings, "ICV_WAF_FORM_CHALLENGE_ON_FLAG", True)
+
+# Whether the orchestrator fires the ``form_submission_passed`` signal.
+# Off by default — busy sites have 1000× more passed submissions than
+# flagged/blocked ones and firing in the hot path is wasted work. The
+# structured log still records passes (sampled). Operators who want
+# pass-event analytics opt in here.
+ICV_WAF_FORM_EMIT_PASSED_SIGNAL: bool = getattr(settings, "ICV_WAF_FORM_EMIT_PASSED_SIGNAL", False)
+
+# Lifetime of a render token. After this many seconds the token is
+# expired and the user gets a fresh one on the next render. Also the
+# TTL of the Redis marker that backs replay protection.
+ICV_WAF_FORM_TOKEN_TTL: int = getattr(settings, "ICV_WAF_FORM_TOKEN_TTL", 3600)
+
+# Honeypot field-name pool. The HoneypotDefence picks names from this
+# list by hashing form_id, so a given form gets a stable set of names
+# (cache-friendly) but different forms get different names (bots can't
+# learn one global set).
+ICV_WAF_FORM_HONEYPOT_FIELD_NAMES: list[str] = getattr(
+    settings,
+    "ICV_WAF_FORM_HONEYPOT_FIELD_NAMES",
+    ["url", "website", "homepage", "email_confirm"],
+)
+
+# Time-trap thresholds in seconds. Submissions faster than the min are
+# flagged; faster than 0.5s are blocked outright. Submissions older
+# than the max have either been sitting open too long (UA changed, IP
+# changed) or are replays — flagged either way.
+ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS: float = getattr(settings, "ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS", 1.5)
+ICV_WAF_FORM_TIME_TRAP_MAX_SECONDS: float = getattr(settings, "ICV_WAF_FORM_TIME_TRAP_MAX_SECONDS", 3600)
+
+# Credential-throttle settings. Per-IP threshold drives the visible
+# challenge (enumeration-safe — same behaviour whether the typed
+# username exists). Per-account threshold drives an observation-only
+# ``credential_attack_observed`` signal so consumers can email the
+# legitimate owner.
+ICV_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW: int = getattr(settings, "ICV_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW", 900)
+ICV_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT: int = getattr(settings, "ICV_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT", 5)
+ICV_WAF_FORM_CREDENTIAL_IP_LIMIT: int = getattr(settings, "ICV_WAF_FORM_CREDENTIAL_IP_LIMIT", 20)
+
+# Signup-velocity settings. Counts *successful* signups per IP, so the
+# user crossing the threshold sees a challenge on their *next* attempt.
+ICV_WAF_FORM_SIGNUP_VELOCITY_WINDOW: int = getattr(settings, "ICV_WAF_FORM_SIGNUP_VELOCITY_WINDOW", 86400)
+ICV_WAF_FORM_SIGNUP_VELOCITY_LIMIT: int = getattr(settings, "ICV_WAF_FORM_SIGNUP_VELOCITY_LIMIT", 5)
+
+# Form-level PoW difficulty (leading zero bits). Lighter than the
+# page-level challenge because it runs per-submission rather than once
+# per session. 12 bits ≈ 4k SHA-256 hashes ≈ 50ms desktop, ~200ms
+# mobile. Reuses the same _digest_has_leading_zero_bits verifier as
+# the page challenge (no parallel implementation, no drift risk).
+ICV_WAF_FORM_POW_DIFFICULTY: int = getattr(settings, "ICV_WAF_FORM_POW_DIFFICULTY", 12)
+
+# Replay-store backend. ``session`` uses Django's session framework
+# (signed cookie + server-side data); ``redis`` uses the same Redis
+# the rest of the WAF talks to. Most sites use session.
+ICV_WAF_FORM_REPLAY_STORE: str = getattr(settings, "ICV_WAF_FORM_REPLAY_STORE", "session")
+
+# Global per-defence score weights. Overridable per-form via the
+# ``defence_weights={...}`` kwarg on ``FormProtection``. The dict
+# collapses what would otherwise be eight separate weight settings
+# into one declaration.
+ICV_WAF_FORM_DEFENCE_WEIGHTS: dict[str, float] = getattr(
+    settings,
+    "ICV_WAF_FORM_DEFENCE_WEIGHTS",
+    {
+        "honeypot": 5.0,
+        "time_trap": 2.0,
+        "render_token": 5.0,
+        "ua_consistency": 2.0,
+        "js_touch": 1.5,
+        "credential_throttle": 5.0,
+        "signup_velocity": 5.0,
+        "pow_gate": 5.0,
+    },
+)
+
 # Proof-of-work challenge difficulty — number of leading zero **bits** the
 # SHA-256(token + nonce) digest must contain. Average solve cost is
 # ``2 ** difficulty`` hashes. Acts as the single-value fallback when the

--- a/src/icv_waf/forms/__init__.py
+++ b/src/icv_waf/forms/__init__.py
@@ -1,0 +1,37 @@
+"""Public API for the icv_waf form-protection subsystem.
+
+The flat surface is small on purpose — consumers integrate via one of
+three entry points:
+
+* ``ProtectedForm`` — Django Form mixin (block 5).
+* ``waf_protect_post`` — view decorator (block 6).
+* ``{% waf_protect %}`` — template tag (block 6).
+
+Plus the orchestrator and signals for advanced use.
+"""
+
+from __future__ import annotations
+
+from icv_waf.forms.mixin import ProtectedForm
+from icv_waf.forms.protection import (
+    FormEvaluationResult,
+    FormProtection,
+    FormVerdict,
+)
+from icv_waf.forms.signals import (
+    credential_attack_observed,
+    form_submission_blocked,
+    form_submission_flagged,
+    form_submission_passed,
+)
+
+__all__ = [
+    "FormEvaluationResult",
+    "FormProtection",
+    "FormVerdict",
+    "ProtectedForm",
+    "credential_attack_observed",
+    "form_submission_blocked",
+    "form_submission_flagged",
+    "form_submission_passed",
+]

--- a/src/icv_waf/forms/decorators.py
+++ b/src/icv_waf/forms/decorators.py
@@ -85,43 +85,152 @@ def waf_protect_post(
     def decorator(view_func: Callable) -> Callable:
         @wraps(view_func)
         def wrapper(request, *args, **kwargs):
+            # Challenge-replay: GET with ?form_replay=<token> means the
+            # user just passed the WAF challenge after a FLAGGED submit.
+            # Re-issue the original POST from the session.
+            if request.method == "GET" and request.GET.get("form_replay"):
+                replayed = _try_replay(request, form_id=form_id)
+                if replayed is not None:
+                    request = replayed  # falls through to the POST branch
+                    # Need to actually invoke the post-handling path:
+                    return _handle_post(request, view_func, args, kwargs, form_id, protection)
+
             if request.method != "POST":
                 return view_func(request, *args, **kwargs)
 
-            result = protection.evaluate(request, submitted_data=dict(request.POST))
-
-            # Structured log — happens regardless of verdict so logs
-            # always reflect the chain's verdict.
-            log_form_submission(form_id=form_id, request=request, result=result)
-
-            if result.verdict == FormVerdict.BLOCKED:
-                # 403 + generic body. Operators see detail in the log.
-                # Returning HttpResponse rather than HttpResponseForbidden
-                # so we control the body shape exactly.
-                response = HttpResponse(
-                    "Submission rejected. Please try again.",
-                    status=403,
-                )
-                _maybe_attach_debug_header(response, form_id, result)
-                return response
-
-            # PASSED or FLAGGED → call the view. The view-author
-            # decides what to do with FLAGGED (consult
-            # request.waf_form_result). Block 7 will introduce
-            # automatic challenge redirect on FLAGGED.
-            request.waf_form_result = result
-            response = view_func(request, *args, **kwargs)
-            _maybe_attach_debug_header(response, form_id, result)
-
-            # Consume the token marker only on PASSED.
-            if result.verdict == FormVerdict.PASSED:
-                protection.consume_token_marker(result.token_payload)
-
-            return response
+            return _handle_post(request, view_func, args, kwargs, form_id, protection)
 
         return wrapper
 
     return decorator
+
+
+def _handle_post(request, view_func, args, kwargs, form_id, protection):
+    """Run the protection chain and dispatch the verdict.
+
+    Extracted from the wrapper so the GET-replay path can reuse it
+    without duplicating the verdict logic.
+    """
+    result = protection.evaluate(request, submitted_data=dict(request.POST))
+
+    # Structured log — happens regardless of verdict so logs
+    # always reflect the chain's verdict.
+    log_form_submission(form_id=form_id, request=request, result=result)
+
+    if result.verdict == FormVerdict.BLOCKED:
+        # 403 + generic body. Operators see detail in the log.
+        # Returning HttpResponse rather than HttpResponseForbidden
+        # so we control the body shape exactly.
+        response = HttpResponse(
+            "Submission rejected. Please try again.",
+            status=403,
+        )
+        _maybe_attach_debug_header(response, form_id, result)
+        return response
+
+    if result.verdict == FormVerdict.FLAGGED:
+        challenge_response = _maybe_redirect_to_challenge(request=request, form_id=form_id, result=result)
+        if challenge_response is not None:
+            _maybe_attach_debug_header(challenge_response, form_id, result)
+            return challenge_response
+        # Challenge redirect disabled or unavailable → fall
+        # through to view. The view-author can still inspect
+        # request.waf_form_result.
+
+    # PASSED or FLAGGED-without-challenge → call the view.
+    request.waf_form_result = result
+    response = view_func(request, *args, **kwargs)
+    _maybe_attach_debug_header(response, form_id, result)
+
+    # Consume the token marker only on PASSED.
+    if result.verdict == FormVerdict.PASSED:
+        protection.consume_token_marker(result.token_payload)
+
+    return response
+
+
+def _try_replay(request, *, form_id: str):
+    """Detect a valid form_replay token on a GET; return a request
+    mutated to look like the original POST.
+
+    Returns ``None`` if no valid replay is available (token missing,
+    malformed, expired, IP mismatch, session missing, or session
+    record gone). The caller falls back to normal GET handling.
+
+    The mutation copies the original POST into request.POST and
+    discards the session record so the replay can't be re-used.
+    """
+    from django.http import QueryDict
+
+    from icv_waf.forms.services.replay import (
+        discard_from_session,
+        fetch_from_session,
+        verify_replay_token,
+    )
+
+    raw_token = request.GET.get("form_replay", "")
+    current_ip = request.META.get("REMOTE_ADDR", "")
+    payload = verify_replay_token(raw_token, current_ip=current_ip)
+    if payload is None or payload.get("form_id") != form_id:
+        return None
+
+    record = fetch_from_session(request, session_key=payload["session_key"])
+    if record is None or record.get("form_id") != form_id:
+        return None
+
+    # Convert stored dict back into a QueryDict for compatibility
+    # with code that reads request.POST as Django's MultiValueDict.
+    qd = QueryDict(mutable=True)
+    for k, v in record.get("data", {}).items():
+        if isinstance(v, list):
+            qd.setlist(k, v)
+        else:
+            qd[k] = v
+    qd._mutable = False
+    request.POST = qd
+    request.method = "POST"
+
+    # One-shot — discard so a replay can't be reused.
+    discard_from_session(request, session_key=payload["session_key"])
+    return request
+
+
+def _maybe_redirect_to_challenge(*, request, form_id: str, result):
+    """Stash POST data + return redirect to /waf/challenge/ when configured.
+
+    Returns ``None`` if challenge redirect is disabled
+    (ICV_WAF_FORM_CHALLENGE_ON_FLAG=False) or unavailable (no session).
+    Per PRD §5.
+    """
+    from urllib.parse import urlencode
+
+    from django.http import HttpResponseRedirect
+    from django.urls import reverse
+
+    from icv_waf import conf
+    from icv_waf.forms.services.replay import issue_replay_token, store_in_session
+
+    if not conf.ICV_WAF_FORM_CHALLENGE_ON_FLAG:
+        return None
+
+    post_url = request.path
+    ip = request.META.get("REMOTE_ADDR", "")
+
+    session_key = store_in_session(request, form_id=form_id, post_url=post_url, data=dict(request.POST))
+    if session_key is None:
+        # Session storage unavailable. Fall back to letting the view
+        # handle FLAGGED — operators see the verdict in the log.
+        logger.info("icv-waf: session storage unavailable for form replay; falling back")
+        return None
+
+    replay_token = issue_replay_token(form_id=form_id, ip=ip, session_key=session_key)
+
+    # Use the existing WAF challenge URL — honour ICV_WAF_CHALLENGE_URL
+    # override for django-hosts setups (same shape as middleware /
+    # ChallengeView from v0.10.5/v0.10.6).
+    challenge_path = conf.ICV_WAF_CHALLENGE_URL or reverse("icv_waf:challenge")
+    params = urlencode({"next": post_url, "form_replay": replay_token})
+    return HttpResponseRedirect(f"{challenge_path}?{params}")
 
 
 def _maybe_attach_debug_header(response, form_id: str, result) -> None:

--- a/src/icv_waf/forms/decorators.py
+++ b/src/icv_waf/forms/decorators.py
@@ -1,0 +1,148 @@
+"""View decorator for the form-protection orchestrator.
+
+Pairs with the ``{% waf_protect %}`` template tag for forms that
+don't go through Django's Form layer (handwritten HTML). The
+decorator validates POSTs; the tag renders the hidden fields.
+
+The mixin (block 5) handles Django Forms — that's the recommended
+path. The decorator exists because some sites have hand-rolled HTML
+forms that bypass the Form layer, and they still need protection.
+
+Per PRD §2.1 (entry-point B).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from functools import wraps
+from typing import Any
+
+from django.http import HttpResponse
+
+from icv_waf.forms.logging import log_form_submission
+from icv_waf.forms.protection import (
+    FormProtection,
+    FormVerdict,
+)
+
+logger = logging.getLogger("icv_waf.forms")
+
+
+# Registry of FormProtection objects keyed by form_id so the template
+# tag can find the same instance the decorator constructed. Populated
+# at decoration time (import time, effectively).
+_PROTECTIONS: dict[str, FormProtection] = {}
+
+
+def _registry_get(form_id: str) -> FormProtection | None:
+    return _PROTECTIONS.get(form_id)
+
+
+def _registry_set(form_id: str, protection: FormProtection) -> None:
+    # Allow re-registration (e.g. tests construct the same form_id
+    # repeatedly). Last decoration wins.
+    _PROTECTIONS[form_id] = protection
+
+
+def waf_protect_post(
+    *,
+    form_id: str,
+    defences: tuple[str, ...] = ("render_token", "honeypot", "time_trap"),
+    **protection_kwargs: Any,
+) -> Callable:
+    """Wrap a view so POST requests run through the form-protection chain.
+
+    Usage::
+
+        @waf_protect_post(form_id='contact-handwritten',
+                          defences=('honeypot', 'time_trap'))
+        def contact_view(request):
+            ...
+
+    The decorator:
+
+    1. On import, constructs a FormProtection and registers it in the
+       per-form_id registry so the template tag can find it.
+    2. On each POST, runs ``protection.evaluate(request, request.POST)``
+       before the view sees the request.
+    3. On BLOCKED, returns 403 with the generic message (enumeration
+       safety — no defence name in the response).
+    4. On PASSED, calls the view, then consumes the token marker.
+    5. On FLAGGED, calls the view. The challenge-redirect flow lands
+       in block 7; until then, FLAGGED views run normally — operators
+       see the verdict in logs and can act on it themselves.
+    6. GET requests pass through untouched (defences only run on
+       POST; render happens via the template tag).
+    """
+    protection = FormProtection(
+        form_id=form_id,
+        defences=defences,
+        **protection_kwargs,
+    )
+    _registry_set(form_id, protection)
+
+    def decorator(view_func: Callable) -> Callable:
+        @wraps(view_func)
+        def wrapper(request, *args, **kwargs):
+            if request.method != "POST":
+                return view_func(request, *args, **kwargs)
+
+            result = protection.evaluate(request, submitted_data=dict(request.POST))
+
+            # Structured log — happens regardless of verdict so logs
+            # always reflect the chain's verdict.
+            log_form_submission(form_id=form_id, request=request, result=result)
+
+            if result.verdict == FormVerdict.BLOCKED:
+                # 403 + generic body. Operators see detail in the log.
+                # Returning HttpResponse rather than HttpResponseForbidden
+                # so we control the body shape exactly.
+                response = HttpResponse(
+                    "Submission rejected. Please try again.",
+                    status=403,
+                )
+                _maybe_attach_debug_header(response, form_id, result)
+                return response
+
+            # PASSED or FLAGGED → call the view. The view-author
+            # decides what to do with FLAGGED (consult
+            # request.waf_form_result). Block 7 will introduce
+            # automatic challenge redirect on FLAGGED.
+            request.waf_form_result = result
+            response = view_func(request, *args, **kwargs)
+            _maybe_attach_debug_header(response, form_id, result)
+
+            # Consume the token marker only on PASSED.
+            if result.verdict == FormVerdict.PASSED:
+                protection.consume_token_marker(result.token_payload)
+
+            return response
+
+        return wrapper
+
+    return decorator
+
+
+def _maybe_attach_debug_header(response, form_id: str, result) -> None:
+    """In DEBUG, attach X-WAF-Form-Verdict for development convenience.
+
+    Off in production (DEBUG=False). Lets developers see why a form
+    blocked without grepping logs. Per PRD §9.2.
+    """
+    from django.conf import settings
+
+    if not getattr(settings, "DEBUG", False):
+        return
+
+    defence_names = (
+        ",".join(
+            outcome.reason.split(":", 1)[0]
+            for outcome in result.outcomes
+            if outcome.verdict in ("flag", "block") and ":" in outcome.reason
+        )
+        or "none"
+    )
+    response["X-WAF-Form-Verdict"] = (
+        f"{result.verdict.value}; score={result.total_score:.1f}; defences={defence_names}; form_id={form_id}"
+    )

--- a/src/icv_waf/forms/defences/base.py
+++ b/src/icv_waf/forms/defences/base.py
@@ -1,0 +1,169 @@
+"""Defence contract for the form-protection subsystem.
+
+A defence is one focused check (honeypot, time-trap, render-token, ...)
+that produces a single ``Outcome``. The orchestrator
+(``FormProtection``) composes defences into a chain and aggregates
+their outcomes into a final verdict.
+
+Defences are intentionally small and independently testable. A
+defence:
+
+* Reads its config from per-call ``RenderContext`` / ``EvaluateContext``
+  rather than reaching into ``conf`` directly — keeps tests
+  deterministic and avoids module-level state.
+* Returns a single ``Outcome`` per evaluation; never raises through.
+  Any internal failure should produce a ``flag`` or ``pass`` outcome
+  with a reason rather than blowing up the form.
+* Renders zero or more hidden inputs at form render time
+  (``render_fields``). Defences that don't need browser cooperation
+  (e.g. ``CredentialThrottleDefence``) return an empty dict.
+
+Per PRD §3 (the per-defence contract subsection).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Protocol
+
+from django.utils.safestring import SafeString
+
+Verdict = Literal["pass", "flag", "block"]
+"""The three states a single defence can return."""
+
+
+# ---------------------------------------------------------------------------
+# Outcome — a defence's single-call result
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class Outcome:
+    """A single defence's verdict on a submission.
+
+    Frozen so a defence can't accidentally mutate its outcome after
+    returning; the orchestrator only reads.
+
+    * ``verdict`` — pass / flag / block. ``block`` is reserved for
+      defences with deterministic certainty (honeypot non-empty,
+      invalid signature). ``flag`` adds to the orchestrator's
+      cumulative score and may cross the block threshold once enough
+      defences agree.
+    * ``score`` — added to the form's total only when the verdict is
+      ``flag``. A ``pass`` always contributes 0; a ``block`` short-
+      circuits the chain.
+    * ``reason`` — short structured string (``defence_name:detail``,
+      e.g. ``time_trap:too_fast``) for logs and the
+      ``X-WAF-Form-Verdict`` debug header. Must not contain
+      PII — the IP is logged separately at the orchestrator level.
+    * ``public_message`` — rarely populated. Only used when a defence
+      surfaces a user-facing error (e.g. \"please complete the
+      challenge\"). Empty by default so the orchestrator can show a
+      generic message.
+    """
+
+    verdict: Verdict
+    score: float = 0.0
+    reason: str = ""
+    public_message: str = ""
+
+
+# Convenience factories — defences read more clearly as
+# ``return passed()`` than ``return Outcome(verdict="pass")``.
+def passed() -> Outcome:
+    """Outcome shorthand for a clean pass."""
+    return Outcome(verdict="pass")
+
+
+def flagged(score: float, reason: str, public_message: str = "") -> Outcome:
+    """Outcome shorthand for a non-decisive flag."""
+    return Outcome(verdict="flag", score=score, reason=reason, public_message=public_message)
+
+
+def blocked(reason: str, score: float = 0.0, public_message: str = "") -> Outcome:
+    """Outcome shorthand for a hard block.
+
+    ``score`` is optional — most blocks short-circuit the chain and
+    the score is unused, but recording one lets the orchestrator log
+    the score that *would* have accrued if the chain had continued.
+    """
+    return Outcome(verdict="block", score=score, reason=reason, public_message=public_message)
+
+
+# ---------------------------------------------------------------------------
+# Render and evaluate contexts
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RenderContext:
+    """Inputs available to a defence at form render time.
+
+    ``form_id`` and ``request`` are always present. The defence reads
+    whatever else it needs from ``request`` (IP, user, UA) — kept
+    flexible so adding a new piece of context later doesn't force
+    every defence to update its signature.
+
+    ``config`` is the per-defence config dict, lifted out of the
+    ``FormProtection`` instance. Defences read settings from here, not
+    from the global ``conf`` module, so per-form overrides flow
+    through naturally and tests can construct contexts directly.
+    """
+
+    form_id: str
+    request: Any  # Django HttpRequest; typed as Any to keep imports light
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class EvaluateContext:
+    """Inputs available to a defence at submit time.
+
+    Mirrors ``RenderContext`` plus the parsed token payload (when the
+    render-token defence has already verified one — defences run in a
+    fixed order so later defences can rely on earlier ones having
+    populated this). ``token_payload`` is None when the render-token
+    defence isn't in the chain or hasn't yet been called.
+
+    ``submitted_data`` is the POST data the orchestrator received,
+    passed through so defences can read their own hidden fields
+    without each one re-parsing ``request.POST``.
+    """
+
+    form_id: str
+    request: Any
+    submitted_data: dict[str, Any]
+    config: dict[str, Any] = field(default_factory=dict)
+    token_payload: Any = None  # TokenPayload | None; deferred import to avoid cycles
+
+
+# ---------------------------------------------------------------------------
+# Defence protocol
+# ---------------------------------------------------------------------------
+
+
+class Defence(Protocol):
+    """Structural type that every defence implements.
+
+    Protocol (not ABC) because defences are usually short stateless
+    classes — duck-typing keeps the boilerplate down and makes test
+    doubles trivial to construct.
+
+    ``name`` is the stable snake_case identifier used in reasons,
+    log fields, the score-weights config, and the X-WAF-Form-Verdict
+    header. Don't change it casually — it's effectively public API.
+    """
+
+    name: str
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        """Return hidden inputs to inject into the rendered form.
+
+        Map of field name → already-safe HTML string. Empty dict if
+        this defence doesn't need browser cooperation.
+        """
+        ...
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        """Inspect the submitted data + request. Return a single Outcome."""
+        ...

--- a/src/icv_waf/forms/defences/credential_throttle.py
+++ b/src/icv_waf/forms/defences/credential_throttle.py
@@ -1,0 +1,83 @@
+"""CredentialThrottleDefence — per-IP + per-account failure tracking.
+
+The most security-sensitive defence. Per PRD §3.6.1 it carries a
+hard constraint: **the form's user-visible behaviour must not reveal
+whether an account exists**. This implementation enforces that by:
+
+* incrementing the per-account counter on every failed login
+  regardless of whether the account exists (the caller records the
+  failure unconditionally),
+* triggering the user-visible challenge on the **per-IP** counter only
+  — the per-account counter is observation-only,
+* emitting a separate ``credential_attack_observed`` signal when the
+  per-account counter crosses its threshold, for consumers to wire
+  up an email-to-owner handler.
+
+The defence runs at submit time, *before* the auth check. It reads
+the current per-IP count; if it's at-or-above threshold the
+submission is flagged (challenge redirect). The actual increment
+happens via the orchestrator's ``record_credential_failure`` call
+after auth fails — which the consuming project hooks into its
+login view.
+
+Per PRD §3.6 + §3.6.1.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from icv_waf.forms.defences.base import (
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+    flagged,
+    passed,
+)
+from icv_waf.forms.services.counters import credential_ip_count
+
+if TYPE_CHECKING:  # pragma: no cover
+    from django.utils.safestring import SafeString
+
+
+_FLAG_SCORE = 5.0
+
+
+class CredentialThrottleDefence:
+    """Per-IP credential-failure throttle (enumeration-safe)."""
+
+    name = "credential_throttle"
+
+    def __init__(self, redis_client_factory) -> None:
+        """``redis_client_factory`` matches the RenderTokenDefence pattern."""
+        self._redis = redis_client_factory
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        """No fields — this is a Redis-backed check."""
+        return {}
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        from icv_waf import conf
+
+        ip = ctx.request.META.get("REMOTE_ADDR", "") if ctx.request else ""
+        if not ip:
+            # No IP → no enforcement. The WAF's IP-extraction logic
+            # runs upstream; reaching here without one is anomalous
+            # but not actionable.
+            return passed()
+
+        limit = ctx.config.get("ip_limit", conf.ICV_WAF_FORM_CREDENTIAL_IP_LIMIT)
+
+        try:
+            count = credential_ip_count(self._redis(), ip=ip)
+        except Exception:
+            # Redis down → fail-open. Login attempts continue as
+            # normal; the throttle just doesn't fire.
+            return passed()
+
+        if count >= limit:
+            # The same reason for any IP, regardless of which accounts
+            # were tried — enumeration-safe.
+            return flagged(_FLAG_SCORE, "credential_throttle:ip")
+
+        return passed()

--- a/src/icv_waf/forms/defences/honeypot.py
+++ b/src/icv_waf/forms/defences/honeypot.py
@@ -1,0 +1,126 @@
+"""HoneypotDefence — hidden fields that humans can't fill in.
+
+Renders one or more hidden ``<input>`` fields with names drawn from
+``ICV_WAF_FORM_HONEYPOT_FIELD_NAMES``. The name set is rotated
+per-form by hashing the ``form_id``, so:
+
+* the same form always shows the same names (cache-friendly), and
+* different forms show different subsets (bots can't learn one global
+  list and skip it).
+
+A bot that fills every input field on the form trips this; a real
+user never sees the fields (visually hidden, ``autocomplete=off``,
+``tabindex=-1``, screen-reader label explicitly telling AT users to
+skip).
+
+Per PRD §3.1.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from django.utils.safestring import SafeString, mark_safe
+
+from icv_waf.forms.defences.base import (
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+    blocked,
+    passed,
+)
+
+# How many honeypot fields to render per form. Two is enough to make
+# random-fill bots fail reliably without producing a visually-jarring
+# DOM. Operators don't get to override this — it's a coverage choice,
+# not a security knob.
+_FIELDS_PER_FORM = 2
+
+# CSS used for the visually-hidden style. Specifically NOT
+# ``display:none`` — most scrapers detect that. The position-off-screen
+# pattern is the long-standing accessibility-friendly honeypot recipe.
+_HIDDEN_STYLE = "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"
+
+
+def _pick_field_names(form_id: str, pool: list[str], count: int) -> list[str]:
+    """Pick ``count`` field names from ``pool`` for a given ``form_id``.
+
+    Deterministic: same form_id + same pool → same names. Uses
+    SHA-256(form_id) to derive a starting offset and then walks the
+    pool, so two forms with similar names map to different honeypot
+    subsets.
+    """
+    if not pool:
+        return []
+    digest = hashlib.sha256(form_id.encode("utf-8")).digest()
+    offset = int.from_bytes(digest[:4], "big") % len(pool)
+    # Walk the pool starting at offset. If count > len(pool), the names
+    # will repeat — operators who really want more than the pool size
+    # should expand the pool, not get duplicates rendered.
+    return [pool[(offset + i) % len(pool)] for i in range(min(count, len(pool)))]
+
+
+def _render_field(name: str) -> str:
+    """Render a single honeypot hidden input as escaped HTML.
+
+    Built from a constant template; only the field name varies, and
+    we strip anything outside an aggressive whitelist before injection
+    so a misconfigured pool can't introduce XSS.
+    """
+    # Restrict the name to a safe subset. Any name containing
+    # characters outside [a-z0-9_-] is silently dropped — operators
+    # who add weird names to the pool find out via the unit test, not
+    # an injection.
+    safe_name = "".join(c for c in name if c.isalnum() or c in "_-")
+    if not safe_name:
+        return ""
+    return (
+        f'<input type="text" name="{safe_name}" value="" '
+        f'autocomplete="off" tabindex="-1" '
+        f'aria-label="Leave this field empty (anti-spam check)" '
+        f'style="{_HIDDEN_STYLE}">'
+    )
+
+
+class HoneypotDefence:
+    """Hidden honeypot inputs detect form-filling bots.
+
+    Stateless across requests — the defence reads its config from the
+    ``RenderContext``/``EvaluateContext`` rather than holding any
+    instance state.
+    """
+
+    name = "honeypot"
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        from icv_waf import conf
+
+        pool = ctx.config.get("field_names", conf.ICV_WAF_FORM_HONEYPOT_FIELD_NAMES)
+        names = _pick_field_names(ctx.form_id, pool, _FIELDS_PER_FORM)
+
+        if not names:
+            return {}
+
+        # Concatenate the inputs under a single synthetic key. The
+        # template tag / mixin renders all values as raw HTML, so the
+        # key is just for de-duplication when multiple defences
+        # contribute to the same form.
+        html = "".join(_render_field(n) for n in names)
+        return {"_waf_honeypot": mark_safe(html)}  # noqa: S308 — constant template, escaped name
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        from icv_waf import conf
+
+        pool = ctx.config.get("field_names", conf.ICV_WAF_FORM_HONEYPOT_FIELD_NAMES)
+        names = _pick_field_names(ctx.form_id, pool, _FIELDS_PER_FORM)
+
+        for name in names:
+            value = ctx.submitted_data.get(name) or ""
+            if value:
+                # Any non-empty value is a hard block. Use the field
+                # name in the reason so logs distinguish 'bot filled
+                # url' from 'bot filled email_confirm' — operators
+                # tune the pool when they see one consistently.
+                return blocked(f"honeypot:{name}", score=5.0)
+
+        return passed()

--- a/src/icv_waf/forms/defences/js_touch.py
+++ b/src/icv_waf/forms/defences/js_touch.py
@@ -1,0 +1,120 @@
+"""JsTouchDefence — flag submissions from clients that didn't execute JS.
+
+The classic non-JS detector. A hidden field starts with a known
+sentinel value; a tiny inline script writes a different value to it on
+page load. Bots that POST the form without running JS submit the
+field still containing the sentinel.
+
+Low score (1.5) — assistive tools and some password managers
+occasionally interact with hidden fields in surprising ways, so this
+must never block alone. It only contributes when a real bot also
+trips another flag.
+
+Per PRD §3.5.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+from django.utils.safestring import SafeString, mark_safe
+
+from icv_waf.forms.defences.base import (
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+    flagged,
+    passed,
+)
+from icv_waf.forms.services.tokens import get_signing_key
+
+# Field name + sentinel. Both stable for grep — operators see
+# ``waf_js_touch`` in their form's DOM and can identify it.
+FIELD_NAME = "waf_js_touch"
+_SENTINEL_UNSET = "unset"
+_FLAG_SCORE = 1.5
+
+# CSS — same off-screen pattern as the honeypot (display:none is
+# bot-detectable; off-screen is the accessibility-friendly recipe).
+_HIDDEN_STYLE = "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"
+
+
+def _expected_value(token_nonce: str) -> str:
+    """Compute the value the JS solver should write into the field.
+
+    Derived from the render-token nonce + the signing key so a bot
+    can't precompute the expected value without seeing the token.
+    Truncated to 16 hex chars — full SHA-256 would bloat the DOM
+    unnecessarily; 16 chars = 64 bits is plenty for this purpose
+    (the field isn't a security primitive, just a behavioural one).
+    """
+    mac = hmac.new(get_signing_key(), f"js_touch:{token_nonce}".encode(), hashlib.sha256)
+    return mac.hexdigest()[:16]
+
+
+def _render_html(nonce: str) -> str:
+    """Render the hidden field + inline script that clears it.
+
+    The script is intentionally inline (no external src) so the
+    behaviour is self-contained — a CSP that blocks external scripts
+    still permits this. ``nonce`` in the JS is a JS string literal,
+    not a CSP nonce.
+    """
+    expected = _expected_value(nonce)
+    # Both the field name and expected value are constant-template
+    # interpolations of non-user-controlled values, so mark_safe is
+    # XSS-safe by construction.
+    return (
+        f'<input type="hidden" name="{FIELD_NAME}" id="_waf_js_touch_input" '
+        f'value="{_SENTINEL_UNSET}" aria-hidden="true" tabindex="-1" '
+        f'style="{_HIDDEN_STYLE}">'
+        '<script type="text/javascript">'
+        f'(function(){{var el=document.getElementById("_waf_js_touch_input");'
+        f'if(el){{el.value="{expected}";}}}})();'
+        "</script>"
+    )
+
+
+class JsTouchDefence:
+    """Detects clients that POST without executing JS."""
+
+    name = "js_touch"
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        # We need the token nonce to derive the expected value. The
+        # token is rendered by RenderTokenDefence — but defences
+        # render independently and we don't have the payload here.
+        # Instead, derive a per-form nonce from form_id + a fresh
+        # secret. The expected value will be re-derived at evaluate
+        # time the same way.
+        #
+        # Actually, the orchestrator will provide the token's nonce
+        # via ctx.config so the values can be linked. Until that's
+        # wired (block 4 — orchestrator), fall back to form_id alone.
+        # The defence still detects no-JS clients; it just doesn't
+        # rotate per-render.
+        nonce = ctx.config.get("token_nonce", ctx.form_id)
+        return {FIELD_NAME: mark_safe(_render_html(nonce))}  # noqa: S308 — constant template
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        value = ctx.submitted_data.get(FIELD_NAME) or ""
+
+        # Sentinel never overwritten → JS didn't run.
+        if value == _SENTINEL_UNSET:
+            return flagged(_FLAG_SCORE, "js_touch:not_set")
+
+        # Missing field entirely is suspicious in a different way —
+        # the form was either constructed by hand or had the field
+        # stripped. Same low-score flag.
+        if not value:
+            return flagged(_FLAG_SCORE, "js_touch:missing")
+
+        # Wrong value → bot wrote *something* but didn't compute the
+        # expected derivation. Same score.
+        payload = ctx.token_payload
+        nonce = payload.nonce if payload is not None else ctx.config.get("token_nonce", ctx.form_id)
+        if value != _expected_value(nonce):
+            return flagged(_FLAG_SCORE, "js_touch:invalid")
+
+        return passed()

--- a/src/icv_waf/forms/defences/pow_gate.py
+++ b/src/icv_waf/forms/defences/pow_gate.py
@@ -1,0 +1,156 @@
+"""PowGateDefence — embedded proof-of-work per submission.
+
+Lighter than the page-level challenge because it runs per-submission
+(not once per session like the WAF's challenge view does). Default
+12 bits ≈ 4k SHA-256 hashes ≈ 50ms on desktop, ~200ms on mobile.
+Reuses the same bit-counting verifier as the page challenge so any
+future improvements land in one place (no parallel implementation,
+no drift risk).
+
+The JS solver runs on form render and writes the nonce into a hidden
+field. Submit itself is instant — the form just reads the prepared
+nonce. Operators who want a hard guarantee that the PoW finished
+before submit set ``data-waf-pow-block-submit="true"`` on the form
+element; the bundled JS disables the submit button until the nonce
+is present.
+
+Per PRD §3.8.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from django.utils.safestring import SafeString, mark_safe
+
+from icv_waf.forms.defences.base import (
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+    blocked,
+    passed,
+)
+from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+# Field names on the rendered form. Stable for grep.
+NONCE_FIELD = "waf_pow_nonce"
+_TOKEN_BIND_FIELD = "waf_pow_token"  # hidden mirror so we can verify without parsing the render token
+
+_HIDDEN_STYLE = "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"
+
+
+def _solver_script(token_nonce: str, difficulty: int) -> str:
+    """Render the inline JS that solves the PoW and writes the nonce.
+
+    The script:
+
+    1. Hashes ``token_nonce + counter`` until the digest has
+       ``difficulty`` leading zero bits.
+    2. Writes the winning ``counter`` value into the hidden
+       ``waf_pow_nonce`` field.
+    3. Sets ``data-waf-pow-ready="true"`` on the surrounding form
+       so operators can gate submit on it via attribute selectors.
+
+    Uses ``crypto.subtle.digest('SHA-256', ...)``, same API the
+    page-level challenge solver uses. Browsers without
+    ``crypto.subtle`` (very old) fall through with the field empty —
+    the defence will block on the missing nonce. Fine; those browsers
+    can't render modern sites anyway.
+    """
+    # The JS-side helper is the same bit-counting check as the
+    # server. It's intentionally a single-purpose function — we don't
+    # try to share code with the page-level challenge template
+    # because the form-level PoW runs on every form-bearing page and
+    # we don't want a second <script src=> request just for a 30-line
+    # function.
+    return (
+        '<script type="text/javascript">'
+        "(async function(){"
+        f"var token={token_nonce!r};"
+        f"var difficulty={difficulty};"
+        "var enc=new TextEncoder();"
+        "function leadingZeroBits(buf,bits){"
+        "  var bytes=new Uint8Array(buf);"
+        "  var full=bits>>>3, rem=bits&7;"
+        "  for(var i=0;i<full;i++){ if(bytes[i]!==0) return false; }"
+        "  if(rem===0) return true;"
+        "  var mask=(0xFF<<(8-rem))&0xFF;"
+        "  return (bytes[full]&mask)===0;"
+        "}"
+        "var n=0;"
+        "while(true){"
+        '  var msg=token+":"+n;'
+        '  var hash=await crypto.subtle.digest("SHA-256",enc.encode(msg));'
+        "  if(leadingZeroBits(hash,difficulty)){"
+        f"    var nonceEl=document.querySelector('input[name=\"{NONCE_FIELD}\"]');"
+        "    if(nonceEl) nonceEl.value=n.toString();"
+        "    var form=nonceEl ? nonceEl.form : null;"
+        '    if(form) form.setAttribute("data-waf-pow-ready","true");'
+        "    break;"
+        "  }"
+        "  n++;"
+        "  if(n%1000===0){ await new Promise(function(r){setTimeout(r,0);}); }"
+        "}"
+        "})();"
+        "</script>"
+    )
+
+
+def _verify_nonce(token_nonce: str, candidate_nonce: str, difficulty: int) -> bool:
+    """Server-side check matching the JS solver's hash construction."""
+    msg = f"{token_nonce}:{candidate_nonce}".encode()
+    digest = hashlib.sha256(msg).digest()
+    return _digest_has_leading_zero_bits(digest, difficulty)
+
+
+class PowGateDefence:
+    """Per-submission proof-of-work."""
+
+    name = "pow_gate"
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        from icv_waf import conf
+
+        difficulty = ctx.config.get("difficulty", conf.ICV_WAF_FORM_POW_DIFFICULTY)
+
+        # Need the render token's nonce to bind the PoW to this
+        # specific render. Until the orchestrator wires that through
+        # ctx.config (block 4), fall back to form_id so the defence
+        # still gates submissions — it just rotates per-form rather
+        # than per-render.
+        token_nonce = ctx.config.get("token_nonce", ctx.form_id)
+
+        # Hidden empty field for the solver to populate, plus the
+        # solver script itself, plus a hidden bind-token so we can
+        # recover the token_nonce on submit without reparsing the
+        # render token.
+        html = (
+            f'<input type="hidden" name="{NONCE_FIELD}" value="" '
+            f'style="{_HIDDEN_STYLE}">'
+            f'<input type="hidden" name="{_TOKEN_BIND_FIELD}" value="{token_nonce}" '
+            f'style="{_HIDDEN_STYLE}">' + _solver_script(token_nonce, difficulty)
+        )
+        return {NONCE_FIELD: mark_safe(html)}  # noqa: S308 — constant template, escaped nonce
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        from icv_waf import conf
+
+        difficulty = ctx.config.get("difficulty", conf.ICV_WAF_FORM_POW_DIFFICULTY)
+
+        candidate = ctx.submitted_data.get(NONCE_FIELD) or ""
+        if not candidate:
+            return blocked("pow_gate:missing", score=5.0)
+
+        # Recover the token_nonce. Prefer the verified token payload
+        # (set by the orchestrator after RenderTokenDefence runs); fall
+        # back to the bind field, which is what we render alongside.
+        payload = ctx.token_payload
+        if payload is not None:  # noqa: SIM108 — three-way precedence reads clearer as if/else
+            token_nonce = payload.nonce
+        else:
+            token_nonce = ctx.submitted_data.get(_TOKEN_BIND_FIELD) or ctx.form_id
+
+        if not _verify_nonce(token_nonce, candidate, difficulty):
+            return blocked("pow_gate:invalid", score=5.0)
+
+        return passed()

--- a/src/icv_waf/forms/defences/render_token.py
+++ b/src/icv_waf/forms/defences/render_token.py
@@ -1,0 +1,214 @@
+"""RenderTokenDefence — the foundation defence.
+
+A signed render token embedded in the form proves the submission
+originated from a real form render this server issued. Other defences
+read fields off the verified payload (time_trap, ua_consistency,
+js_touch), so render_token always runs first.
+
+Failure modes and outcomes (per PRD §3.3):
+
+* missing / malformed / wrong signature → block (`render_token:invalid`)
+* expired (render_time + TTL < now)     → block (`render_token:expired`)
+* marker missing past 5s grace window   → block (`render_token:replayed`)
+* IP changed since render               → flag (`render_token:ip_changed`)
+
+The 5s grace handles the marker-delete race between two near-
+simultaneous successful submits (e.g. double-clicked form). Inside
+the grace window the missing marker is tolerated as a non-failure.
+
+Per PRD §3.3 and §4.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+from django.utils.safestring import SafeString, mark_safe
+
+from icv_waf.forms.defences.base import (
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+    blocked,
+    flagged,
+    passed,
+)
+from icv_waf.forms.services.markers import issue_marker, marker_exists
+from icv_waf.forms.services.tokens import (
+    TokenPayload,
+    hash_user_agent,
+    issue_token,
+    verify_token,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    pass
+
+
+# Hidden field name the token rides in. Stable so consumer projects
+# can grep for it and so legacy forms can be detected by name.
+TOKEN_FIELD_NAME = "waf_token"
+
+# Grace window for the marker-delete race (PRD §4.4).
+_MARKER_GRACE_SECONDS = 5
+
+# Score weight when the IP changes between render and submit. Below
+# the flag threshold on its own (default 2.0 flag, ip_changed score
+# 3.0) so it crosses the threshold alone but can be downweighted by
+# operators on mobile-heavy sites.
+_IP_CHANGED_SCORE = 3.0
+
+
+def _extract_ip(request) -> str:
+    """Pull the client IP from the request.
+
+    Defence-time helper — the orchestrator already does the same
+    via the WAF's request_ip logic, but defences are also constructed
+    in tests where the orchestrator isn't in the loop. Falling back
+    to ``REMOTE_ADDR`` is fine because the WAF's trusted-proxy logic
+    runs upstream; by the time a defence sees the request the IP is
+    already authoritative.
+    """
+    return request.META.get("REMOTE_ADDR", "") if request else ""
+
+
+def _user_id(request) -> str:
+    """Return the authenticated user's primary key as a string, or ''.
+
+    Stored on the token so a token issued to one user can't be
+    replayed under a different session.
+    """
+    user = getattr(request, "user", None)
+    if user is None or not getattr(user, "is_authenticated", False):
+        return ""
+    pk = getattr(user, "pk", None)
+    return str(pk) if pk is not None else ""
+
+
+class RenderTokenDefence:
+    """Issues + verifies the form's render token.
+
+    Each ``FormProtection`` constructs one instance per form. Stateless
+    apart from the configured TTL; safe to share across requests, but
+    instantiated per-form by the orchestrator so per-form TTL
+    overrides flow through ``config``.
+    """
+
+    name = "render_token"
+
+    def __init__(self, redis_client_factory) -> None:
+        """``redis_client_factory`` is a zero-arg callable returning a
+        Redis client. Injected so tests can supply a MagicMock and so
+        the defence doesn't depend on the WAF's redis-resolution
+        path at import time.
+        """
+        self._redis = redis_client_factory
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        """Issue a new token + Redis marker for this render."""
+        from icv_waf import conf
+
+        ttl = ctx.config.get("token_ttl", conf.ICV_WAF_FORM_TOKEN_TTL)
+        token, payload = issue_token(
+            form_id=ctx.form_id,
+            ip=_extract_ip(ctx.request),
+            user_id=_user_id(ctx.request),
+            user_agent=ctx.request.META.get("HTTP_USER_AGENT", "") if ctx.request else "",
+        )
+
+        # Redis unavailable at render time → fail-open. The token still
+        # works for verification (signature is self-contained); the
+        # replay-protection guarantee weakens to \"no protection beyond
+        # TTL\", consistent with the rest of the WAF's policy.
+        with contextlib.suppress(Exception):
+            issue_marker(self._redis(), nonce=payload.nonce, ttl_seconds=ttl)
+
+        # The token is base64url-encoded — no HTML-special characters
+        # can appear in it, so mark_safe is XSS-safe by construction.
+        return {TOKEN_FIELD_NAME: mark_safe(token)}  # noqa: S308
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        """Verify the submitted token + check expiry, marker, IP."""
+        from icv_waf import conf
+
+        raw = ctx.submitted_data.get(TOKEN_FIELD_NAME) or ""
+        if not raw:
+            return blocked("render_token:missing", score=5.0)
+
+        try:
+            payload = verify_token(raw)
+        except ValueError:
+            return blocked("render_token:invalid", score=5.0)
+
+        # Expiry check uses the token's render_time + configured TTL.
+        ttl = ctx.config.get("token_ttl", conf.ICV_WAF_FORM_TOKEN_TTL)
+        now = datetime.now(tz=UTC)
+        # ``payload.render_time`` should already be UTC; coerce if naive
+        # (shouldn't happen but defends against a future bug).
+        rt = payload.render_time
+        if rt.tzinfo is None:
+            rt = rt.replace(tzinfo=UTC)
+        if rt + timedelta(seconds=ttl) < now:
+            return blocked("render_token:expired", score=5.0)
+
+        # Marker check. Missing marker is OK inside the 5s grace
+        # window (handles the marker-delete race for near-simultaneous
+        # submissions). Outside the window, treat as replay.
+        try:
+            present = marker_exists(self._redis(), payload.nonce)
+        except Exception:
+            # Redis down — fail-open on replay protection. Signature
+            # check has already passed, so the token is at least
+            # authentic.
+            present = True
+
+        if not present:
+            elapsed = (now - rt).total_seconds()
+            if elapsed > _MARKER_GRACE_SECONDS:
+                return blocked("render_token:replayed", score=5.0)
+
+        # IP-change check. Flag rather than block — mobile clients
+        # legitimately roam between networks mid-session.
+        if payload.ip and payload.ip != _extract_ip(ctx.request):
+            # Stash the verified payload on the context for later
+            # defences (time_trap, ua_consistency, js_touch). We can't
+            # mutate the frozen dataclass — the orchestrator constructs
+            # a fresh EvaluateContext with token_payload after this
+            # defence returns; see orchestrator in a later block. For
+            # now, returning the outcome is enough; the orchestrator
+            # threads the payload through.
+            return flagged(_IP_CHANGED_SCORE, "render_token:ip_changed")
+
+        return passed()
+
+
+# Re-exported for the orchestrator: when render_token returns pass or
+# flag, the orchestrator parses the payload again to thread it onto
+# subsequent EvaluateContexts. Exposing the helpers keeps that logic
+# in one place rather than duplicating it inside the orchestrator.
+def parse_submitted_payload(submitted_data: dict) -> TokenPayload | None:
+    """Best-effort parse of the token in submitted data.
+
+    Returns ``None`` if the token is missing or invalid — the
+    orchestrator uses this to populate ``EvaluateContext.token_payload``
+    for downstream defences. None means \"this submission had no
+    verifiable token,\" which downstream defences treat as
+    \"don't penalise further; render_token already blocked.\"
+    """
+    raw = submitted_data.get(TOKEN_FIELD_NAME) or ""
+    if not raw:
+        return None
+    try:
+        return verify_token(raw)
+    except ValueError:
+        return None
+
+
+__all__ = [
+    "TOKEN_FIELD_NAME",
+    "RenderTokenDefence",
+    "hash_user_agent",
+    "parse_submitted_payload",
+]

--- a/src/icv_waf/forms/defences/signup_velocity.py
+++ b/src/icv_waf/forms/defences/signup_velocity.py
@@ -1,0 +1,59 @@
+"""SignupVelocityDefence — per-IP signup-rate throttle.
+
+Counts *completed* signups per IP rather than attempts, so the user
+who crosses the threshold sees the challenge on their *next* submit
+— not the one that crossed it. The orchestrator calls
+``record_signup()`` only when the form's overall verdict is PASS.
+
+Per PRD §3.7.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from icv_waf.forms.defences.base import (
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+    flagged,
+    passed,
+)
+from icv_waf.forms.services.counters import signup_count
+
+if TYPE_CHECKING:  # pragma: no cover
+    from django.utils.safestring import SafeString
+
+
+_FLAG_SCORE = 5.0
+
+
+class SignupVelocityDefence:
+    """Throttle signup forms by completed-registration rate per IP."""
+
+    name = "signup_velocity"
+
+    def __init__(self, redis_client_factory) -> None:
+        self._redis = redis_client_factory
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        return {}
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        from icv_waf import conf
+
+        ip = ctx.request.META.get("REMOTE_ADDR", "") if ctx.request else ""
+        if not ip:
+            return passed()
+
+        limit = ctx.config.get("limit", conf.ICV_WAF_FORM_SIGNUP_VELOCITY_LIMIT)
+
+        try:
+            count = signup_count(self._redis(), ip=ip)
+        except Exception:
+            return passed()
+
+        if count >= limit:
+            return flagged(_FLAG_SCORE, "signup_velocity:ip")
+
+        return passed()

--- a/src/icv_waf/forms/defences/time_trap.py
+++ b/src/icv_waf/forms/defences/time_trap.py
@@ -1,0 +1,91 @@
+"""TimeTrapDefence — submissions that come back implausibly fast or slow.
+
+Reads ``render_time`` off the verified token payload (set on
+``EvaluateContext.token_payload`` by the orchestrator after
+``RenderTokenDefence`` succeeds) and compares to ``now``:
+
+* delta < 0.5s        → block (``time_trap:too_fast``)
+* 0.5s ≤ delta < min  → flag  (``time_trap:fast``)
+* delta > max         → flag  (``time_trap:expired``)
+* otherwise           → pass
+
+The 0.5s hard cutoff is the only deterministic threshold — anything
+that comes back in under half a second is mechanically impossible for
+a human to read-and-fill. The flag bands are configurable per-form
+(short forms like newsletter signups lower the min).
+
+No render-time fields needed (the token already carries the timestamp).
+
+Per PRD §3.2.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from icv_waf.forms.defences.base import (
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+    blocked,
+    flagged,
+    passed,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from django.utils.safestring import SafeString
+
+
+# Hard floor — any submission faster than this is mechanically
+# impossible for a human, regardless of form length or per-form
+# configuration. Block, don't flag.
+_TOO_FAST_THRESHOLD_SECONDS = 0.5
+
+# Default scores. Operators override via defence_weights, but these
+# defaults match PRD §3.2 and produce sensible behaviour when the
+# defence is used standalone.
+_TOO_FAST_SCORE = 5.0  # paired with block; recorded for logs
+_FAST_FLAG_SCORE = 2.0
+_EXPIRED_FLAG_SCORE = 2.0
+
+
+class TimeTrapDefence:
+    """Detect submissions too fast (bot) or too slow (stale/replay)."""
+
+    name = "time_trap"
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        """No fields needed — render time rides on the render token."""
+        return {}
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        # No token payload → render_token defence already blocked.
+        # Don't compound penalties; pass silently.
+        payload = ctx.token_payload
+        if payload is None:
+            return passed()
+
+        from icv_waf import conf
+
+        min_seconds = ctx.config.get("min_fill_seconds", conf.ICV_WAF_FORM_TIME_TRAP_MIN_SECONDS)
+        max_seconds = ctx.config.get("max_fill_seconds", conf.ICV_WAF_FORM_TIME_TRAP_MAX_SECONDS)
+
+        rt = payload.render_time
+        if rt.tzinfo is None:
+            rt = rt.replace(tzinfo=UTC)
+        delta = (datetime.now(tz=UTC) - rt).total_seconds()
+
+        # Negative deltas indicate clock skew between processes. Treat
+        # as too fast — better to flag a false positive than to ignore
+        # a genuine replay-from-the-future.
+        if delta < _TOO_FAST_THRESHOLD_SECONDS:
+            return blocked("time_trap:too_fast", score=_TOO_FAST_SCORE)
+
+        if delta < min_seconds:
+            return flagged(_FAST_FLAG_SCORE, "time_trap:fast")
+
+        if delta > max_seconds:
+            return flagged(_EXPIRED_FLAG_SCORE, "time_trap:expired")
+
+        return passed()

--- a/src/icv_waf/forms/defences/ua_consistency.py
+++ b/src/icv_waf/forms/defences/ua_consistency.py
@@ -1,0 +1,58 @@
+"""UaConsistencyDefence — flag when User-Agent changes between render and submit.
+
+Real browsers don't change their User-Agent header mid-form. A
+mismatch suggests either:
+
+* a scraped form being submitted from a different client (the bot
+  fetched the form once and now submits from a headless tool), or
+* a different process running on the same network (rare and benign).
+
+Score is low (2.0) so this never blocks alone — it only contributes
+when combined with another flag. A browser update happens on restart,
+not mid-session, so the false-positive rate is very small.
+
+Per PRD §3.4.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from icv_waf.forms.defences.base import (
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+    flagged,
+    passed,
+)
+from icv_waf.forms.services.tokens import hash_user_agent
+
+if TYPE_CHECKING:  # pragma: no cover
+    from django.utils.safestring import SafeString
+
+
+_FLAG_SCORE = 2.0
+
+
+class UaConsistencyDefence:
+    """Compare submit-time UA to the hash captured in the render token."""
+
+    name = "ua_consistency"
+
+    def render_fields(self, ctx: RenderContext) -> dict[str, SafeString]:
+        """No fields — UA hash rides on the render token."""
+        return {}
+
+    def evaluate(self, ctx: EvaluateContext) -> Outcome:
+        payload = ctx.token_payload
+        if payload is None:
+            # RenderTokenDefence already blocked; don't compound.
+            return passed()
+
+        current_ua = ctx.request.META.get("HTTP_USER_AGENT", "") if ctx.request else ""
+        current_hash = hash_user_agent(current_ua)
+
+        if current_hash != payload.ua_hash:
+            return flagged(_FLAG_SCORE, "ua_consistency:changed")
+
+        return passed()

--- a/src/icv_waf/forms/logging.py
+++ b/src/icv_waf/forms/logging.py
@@ -1,0 +1,170 @@
+"""Structured logging for form-protection events + signal dispatch.
+
+One ``waf.form_submission`` log entry per submission. Plus the four
+signals from ``signals.py`` fired at the appropriate verdicts.
+
+Per PRD §8 + §9.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import Any
+
+from icv_waf.forms.protection import FormEvaluationResult, FormVerdict
+from icv_waf.forms.signals import (
+    form_submission_blocked,
+    form_submission_flagged,
+    form_submission_passed,
+)
+
+logger = logging.getLogger("icv_waf.forms")
+
+
+def _extract_ip(request) -> str:
+    return request.META.get("REMOTE_ADDR", "") if request else ""
+
+
+def _extract_user_id(request) -> str | None:
+    user = getattr(request, "user", None)
+    if user is None or not getattr(user, "is_authenticated", False):
+        return None
+    return str(getattr(user, "pk", "") or "")
+
+
+def log_form_submission(*, form_id: str, request, result: FormEvaluationResult) -> None:
+    """Emit one structured log entry + the appropriate signal.
+
+    Sampling:
+      * PASSED → ``ICV_WAF_LOG_SAMPLE_RATE``
+      * FLAGGED / BLOCKED → always logged (sampling N/A)
+
+    Signal emission:
+      * PASSED  → form_submission_passed iff ICV_WAF_FORM_EMIT_PASSED_SIGNAL
+      * FLAGGED → form_submission_flagged
+      * BLOCKED → form_submission_blocked
+
+    Signal handlers are isolated via try/except so a misbehaving
+    receiver can't break the request lifecycle.
+    """
+    from icv_waf import conf
+
+    verdict_str = result.verdict.value
+    ip = _extract_ip(request)
+    user_agent = request.META.get("HTTP_USER_AGENT", "") if request else ""
+    user_id = _extract_user_id(request)
+
+    # Sampling decision for passed submissions.
+    if result.verdict == FormVerdict.PASSED:  # noqa: SIM102 — nested reads clearer with the comment
+        if random.random() >= conf.ICV_WAF_LOG_SAMPLE_RATE:
+            # Suppressed by sampling; still dispatch the signal if
+            # operators opted in.
+            _maybe_emit_passed_signal(form_id=form_id, ip=ip, user_agent=user_agent, user_id=user_id)
+            return
+
+    payload: dict[str, Any] = {
+        "event": "waf.form_submission",
+        "form_id": form_id,
+        "verdict": verdict_str,
+        "ip": ip,
+        "user_agent": user_agent,
+        "user_id": user_id,
+        "total_score": result.total_score,
+        "defences": [
+            {
+                "name": _name_from_reason(outcome.reason),
+                "verdict": outcome.verdict,
+                "score": outcome.score,
+                "reason": outcome.reason,
+            }
+            for outcome in result.outcomes
+        ],
+    }
+    # Log level mirrors the verdict so log routing can filter.
+    if result.verdict == FormVerdict.BLOCKED:
+        logger.warning("waf.form_submission", extra=payload)
+    elif result.verdict == FormVerdict.FLAGGED:
+        logger.info("waf.form_submission", extra=payload)
+    else:
+        logger.info("waf.form_submission", extra=payload)
+
+    _dispatch_signal(
+        form_id=form_id,
+        ip=ip,
+        user_agent=user_agent,
+        user_id=user_id,
+        result=result,
+    )
+
+
+def _name_from_reason(reason: str) -> str:
+    """Extract the defence name from a ``defence:detail`` reason string."""
+    if not reason:
+        return ""
+    return reason.split(":", 1)[0]
+
+
+def _maybe_emit_passed_signal(*, form_id: str, ip: str, user_agent: str, user_id: str | None) -> None:
+    from icv_waf import conf
+
+    if not conf.ICV_WAF_FORM_EMIT_PASSED_SIGNAL:
+        return
+    try:
+        form_submission_passed.send(
+            sender=None,
+            form_id=form_id,
+            ip=ip,
+            user_agent=user_agent,
+            user_id=user_id,
+        )
+    except Exception:
+        logger.exception("icv-waf: form_submission_passed receiver raised")
+
+
+def _dispatch_signal(
+    *,
+    form_id: str,
+    ip: str,
+    user_agent: str,
+    user_id: str | None,
+    result: FormEvaluationResult,
+) -> None:
+    """Fire the verdict-appropriate signal, swallowing any receiver errors."""
+    try:
+        if result.verdict == FormVerdict.PASSED:
+            _maybe_emit_passed_signal(form_id=form_id, ip=ip, user_agent=user_agent, user_id=user_id)
+        elif result.verdict == FormVerdict.FLAGGED:
+            form_submission_flagged.send(
+                sender=None,
+                form_id=form_id,
+                ip=ip,
+                user_agent=user_agent,
+                user_id=user_id,
+                total_score=result.total_score,
+                outcomes=result.outcomes,
+            )
+        else:  # BLOCKED
+            # Pick a representative reason — first block outcome, or
+            # the highest-scoring flag if scores crossed the block
+            # threshold without any single defence blocking.
+            reason = ""
+            for outcome in result.outcomes:
+                if outcome.verdict == "block":
+                    reason = outcome.reason
+                    break
+            if not reason and result.outcomes:
+                worst = max(result.outcomes, key=lambda o: o.score)
+                reason = worst.reason
+            form_submission_blocked.send(
+                sender=None,
+                form_id=form_id,
+                ip=ip,
+                user_agent=user_agent,
+                user_id=user_id,
+                total_score=result.total_score,
+                outcomes=result.outcomes,
+                reason=reason,
+            )
+    except Exception:
+        logger.exception("icv-waf: form-submission signal receiver raised")

--- a/src/icv_waf/forms/mixin.py
+++ b/src/icv_waf/forms/mixin.py
@@ -158,14 +158,29 @@ class ProtectedForm:
         )
         self.waf_result = result
 
-        # The view code decides what to do with FLAGGED (challenge
-        # redirect vs. plain rejection). The mixin only raises on
-        # BLOCKED, which terminates form validation outright.
+        # Structured log + signal dispatch. Done here (not in the
+        # orchestrator) because logging is an entry-point concern —
+        # mixin vs. decorator decide their own format choices, the
+        # orchestrator just produces the result.
+        from icv_waf.forms.logging import log_form_submission
+
+        log_form_submission(
+            form_id=self.waf.form_id,
+            request=self._waf_request,
+            result=result,
+        )
+
+        # Consume the token marker on PASS. FLAGGED keeps the marker
+        # so the user can retry (challenge replay or operator-decided
+        # rejection); BLOCKED never reaches here (raises below).
         from icv_waf.forms.protection import FormVerdict
+
+        if result.verdict == FormVerdict.PASSED:
+            self.waf.consume_token_marker(result.token_payload)
 
         if result.verdict == FormVerdict.BLOCKED:
             # Don't reveal which defence blocked. Operators consult
-            # the structured log (block 6) for the detail.
+            # the structured log for the detail.
             raise forms.ValidationError(_BLOCKED_MESSAGE, code="waf_blocked")
 
         return cleaned

--- a/src/icv_waf/forms/mixin.py
+++ b/src/icv_waf/forms/mixin.py
@@ -1,0 +1,171 @@
+"""ProtectedForm mixin — Django Form integration for the orchestrator.
+
+Subclasses declare a class-level ``waf = FormProtection(...)``. The
+mixin wires the orchestrator into the Django form lifecycle:
+
+* on instantiation, captures the bound request so ``clean()`` can run
+  the defences,
+* exposes ``waf_fields`` for the template to render the protected
+  hidden inputs,
+* in ``clean()``, runs the defence chain against ``self.data`` and
+  raises ``ValidationError`` on BLOCKED. FLAGGED is exposed via
+  ``self.waf_result`` so the view can decide whether to redirect
+  through the challenge flow.
+
+The mixin does NOT do the challenge redirect itself — that's a view
+concern, handled by block 6's decorator (and block 7's replay flow).
+Keeping the mixin scoped to form validation means it composes with
+any view, including class-based generic views.
+
+Per PRD §2.1 (entry-point A) and §6 (verdict actions).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from django import forms
+from django.core.exceptions import ImproperlyConfigured
+
+if TYPE_CHECKING:  # pragma: no cover
+    from icv_waf.forms.protection import FormEvaluationResult, FormProtection
+
+
+logger = logging.getLogger("icv_waf.forms")
+
+
+# Generic ValidationError message shown on BLOCKED. Deliberately
+# uninformative — telling an attacker exactly which defence fired
+# would help them tune around it. Operators see the structured log
+# for the details (block 6).
+_BLOCKED_MESSAGE = "Submission rejected. Please try again."
+
+
+class ProtectedForm:
+    """Django Form mixin that runs WAF defences during clean().
+
+    Usage::
+
+        from django import forms
+        from icv_waf.forms import FormProtection, ProtectedForm
+
+        class ContactForm(ProtectedForm, forms.Form):
+            name = forms.CharField()
+            email = forms.EmailField()
+            message = forms.CharField(widget=forms.Textarea)
+
+            waf = FormProtection(
+                form_id="contact",
+                defences=("render_token", "honeypot", "time_trap"),
+            )
+
+    Then in the view::
+
+        form = ContactForm(request.POST, request=request)
+
+    The mixin requires the ``request`` kwarg because defences need
+    access to ``request.META`` and ``request.user``. Forgetting to
+    pass it is a constructive error (raised at form instantiation),
+    not a silent fail-open.
+    """
+
+    # Subclasses MUST declare this.
+    waf: ClassVar[FormProtection]
+
+    # Populated by clean(); the view inspects this to decide whether
+    # to challenge or accept.
+    waf_result: FormEvaluationResult | None = None
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        # Pin the contract at class-definition time: subclasses must
+        # declare a `waf` attribute. We don't enforce the type
+        # strictly (duck-typing keeps tests trivial) but the attribute
+        # must exist.
+        if not hasattr(cls, "waf") or cls.waf is None:
+            raise ImproperlyConfigured(
+                f"{cls.__name__} subclasses ProtectedForm but has no `waf` "
+                "attribute. Declare one with: waf = FormProtection(form_id='...')"
+            )
+
+    def __init__(self, *args: Any, request: Any = None, **kwargs: Any) -> None:
+        """Accept a ``request`` kwarg in addition to Django's standard ones.
+
+        Stored on the instance so ``clean()`` and template rendering
+        can reach it without the consumer threading the request
+        everywhere.
+        """
+        if request is None:
+            raise ImproperlyConfigured(
+                f"{type(self).__name__} requires the `request` kwarg. "
+                "Construct as `Form(request.POST or None, request=request)`."
+            )
+        self._waf_request = request
+        super().__init__(*args, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Template hook
+    # ------------------------------------------------------------------
+
+    @property
+    def waf_fields(self) -> str:
+        """Concatenated HTML for the WAF's hidden inputs.
+
+        Render once in the form template::
+
+            <form method="post">
+                {% csrf_token %}
+                {{ form.waf_fields }}
+                {{ form.as_p }}
+                ...
+            </form>
+
+        Marked safe in each defence; concatenation here preserves
+        that. The mixin is the only place that decides ordering of
+        fragments, so the rendered DOM is deterministic.
+        """
+        from django.utils.safestring import mark_safe
+
+        fields = self.waf.render_fields(self._waf_request)
+        # Sort keys for deterministic output — eases testing and
+        # cache-key stability on HTMX re-renders.
+        html = "".join(fields[k] for k in sorted(fields))
+        return mark_safe(html)  # noqa: S308 — each fragment is already SafeString
+
+    # ------------------------------------------------------------------
+    # Validation hook
+    # ------------------------------------------------------------------
+
+    def clean(self) -> dict[str, Any]:
+        """Run the defence chain alongside the form's normal validation.
+
+        The mixin's clean() must run after the field-level clean(s) so
+        ``self.data`` and ``self.cleaned_data`` are both populated for
+        any defences that care to consult them. We call ``super().clean()``
+        first to let Django's normal validation populate ``cleaned_data``.
+        """
+        cleaned = super().clean() if hasattr(super(), "clean") else None
+        if cleaned is None:
+            cleaned = getattr(self, "cleaned_data", {}) or {}
+
+        # Run the orchestrator against the raw POST data — defences
+        # read their own hidden fields by name, not the cleaned form
+        # fields.
+        result = self.waf.evaluate(
+            self._waf_request,
+            submitted_data=dict(self.data),
+        )
+        self.waf_result = result
+
+        # The view code decides what to do with FLAGGED (challenge
+        # redirect vs. plain rejection). The mixin only raises on
+        # BLOCKED, which terminates form validation outright.
+        from icv_waf.forms.protection import FormVerdict
+
+        if result.verdict == FormVerdict.BLOCKED:
+            # Don't reveal which defence blocked. Operators consult
+            # the structured log (block 6) for the detail.
+            raise forms.ValidationError(_BLOCKED_MESSAGE, code="waf_blocked")
+
+        return cleaned

--- a/src/icv_waf/forms/protection.py
+++ b/src/icv_waf/forms/protection.py
@@ -1,0 +1,504 @@
+"""FormProtection orchestrator — composes defences into a chain.
+
+A ``FormProtection`` instance lives on a form class (or a decorated
+view) and holds the configured defence chain. It's responsible for:
+
+* constructing defence instances from a name tuple,
+* injecting per-defence config (weights + form-specific overrides),
+* threading the verified token payload from RenderTokenDefence onto
+  subsequent defences' EvaluateContexts,
+* running the chain in deterministic order,
+* aggregating Outcomes into a final ``FormVerdict``,
+* consuming the Redis marker on a PASS verdict (the
+  delete-on-pass-only rule that makes HTMX re-renders work).
+
+The orchestrator is intentionally separate from the entry-point
+mechanisms (mixin / decorator / template tag) — those each construct
+a FormProtection and call into it, but the composition logic lives
+here.
+
+Per PRD §2.1, §3 (per-defence sections), and §6 (score aggregation).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from icv_waf.forms.defences.base import (
+    Defence,
+    EvaluateContext,
+    Outcome,
+    RenderContext,
+)
+
+logger = logging.getLogger("icv_waf.forms")
+
+
+# ---------------------------------------------------------------------------
+# FormVerdict — the orchestrator's aggregate decision
+# ---------------------------------------------------------------------------
+
+
+class FormVerdict(str, Enum):
+    """Final verdict after all defences have run.
+
+    String values so logs / signals carry stable identifiers without
+    having to remember whether to log .name or .value.
+    """
+
+    PASSED = "passed"
+    FLAGGED = "flagged"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True, slots=True)
+class FormEvaluationResult:
+    """What ``FormProtection.evaluate()`` returns.
+
+    Carries the verdict plus the per-defence outcomes so callers can
+    log them, fire the right signal, and assemble the
+    ``X-WAF-Form-Verdict`` debug header.
+    """
+
+    verdict: FormVerdict
+    total_score: float
+    outcomes: list[Outcome] = field(default_factory=list)
+    # The verified token payload, if RenderTokenDefence produced one.
+    # Held so the orchestrator can consume the Redis marker on PASS.
+    token_payload: Any = None
+
+
+# ---------------------------------------------------------------------------
+# Defence registry
+# ---------------------------------------------------------------------------
+
+
+def _build_defence(name: str, redis_factory: Callable[[], Any] | None) -> Defence:
+    """Construct a defence instance by name.
+
+    Centralised so the orchestrator (and tests) have one place to go.
+    Defences that need a Redis client get the factory injected; the
+    rest ignore it.
+    """
+    if name == "render_token":
+        from icv_waf.forms.defences.render_token import RenderTokenDefence
+
+        if redis_factory is None:
+            raise ValueError("render_token defence requires a redis_client_factory")
+        return RenderTokenDefence(redis_client_factory=redis_factory)
+
+    if name == "honeypot":
+        from icv_waf.forms.defences.honeypot import HoneypotDefence
+
+        return HoneypotDefence()
+
+    if name == "time_trap":
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        return TimeTrapDefence()
+
+    if name == "ua_consistency":
+        from icv_waf.forms.defences.ua_consistency import UaConsistencyDefence
+
+        return UaConsistencyDefence()
+
+    if name == "js_touch":
+        from icv_waf.forms.defences.js_touch import JsTouchDefence
+
+        return JsTouchDefence()
+
+    if name == "credential_throttle":
+        from icv_waf.forms.defences.credential_throttle import CredentialThrottleDefence
+
+        if redis_factory is None:
+            raise ValueError("credential_throttle defence requires a redis_client_factory")
+        return CredentialThrottleDefence(redis_client_factory=redis_factory)
+
+    if name == "signup_velocity":
+        from icv_waf.forms.defences.signup_velocity import SignupVelocityDefence
+
+        if redis_factory is None:
+            raise ValueError("signup_velocity defence requires a redis_client_factory")
+        return SignupVelocityDefence(redis_client_factory=redis_factory)
+
+    if name == "pow_gate":
+        from icv_waf.forms.defences.pow_gate import PowGateDefence
+
+        return PowGateDefence()
+
+    raise ValueError(f"unknown defence: {name!r}")
+
+
+# Order in which defences run. Foundation first (render_token), then
+# behaviour signals that depend on its payload, then unconditional
+# checks, then per-form-specific ones.
+_CANONICAL_ORDER = (
+    "render_token",
+    "honeypot",
+    "time_trap",
+    "ua_consistency",
+    "js_touch",
+    "credential_throttle",
+    "signup_velocity",
+    "pow_gate",
+)
+
+
+def _order_defences(names: tuple[str, ...]) -> tuple[str, ...]:
+    """Return the configured names in canonical order.
+
+    Operators can pass defences in any order; we re-sort so the chain
+    runs deterministically and so render_token always runs first (its
+    payload feeds later defences).
+    """
+    name_set = set(names)
+    return tuple(n for n in _CANONICAL_ORDER if n in name_set)
+
+
+# ---------------------------------------------------------------------------
+# Default redis factory — used when the consumer doesn't supply one
+# ---------------------------------------------------------------------------
+
+
+def _default_redis_factory():
+    """Return the package-wide Redis client (or None on failure).
+
+    The factory shape (callable returning client) matches what
+    individual defences expect, so we can swap it for tests without
+    monkey-patching the conf module.
+    """
+    from icv_waf import conf
+
+    try:
+        from django_redis import get_redis_connection
+
+        return get_redis_connection(conf.ICV_WAF_REDIS_ALIAS)
+    except Exception:
+        try:
+            from django.core.cache import cache
+
+            return cache
+        except Exception:
+            return None
+
+
+# ---------------------------------------------------------------------------
+# FormProtection — the orchestrator
+# ---------------------------------------------------------------------------
+
+
+class FormProtection:
+    """Composes a defence chain for one protected form.
+
+    Construct one per form class (or per decorated view). Reused
+    across requests — the orchestrator is stateless apart from its
+    config; the defences themselves only hold the redis factory.
+
+    Usage in a form mixin (block 5):
+
+        class ContactForm(ProtectedForm, forms.Form):
+            waf = FormProtection(
+                form_id="contact",
+                defences=("honeypot", "time_trap", "render_token"),
+                defence_weights={"time_trap": 4.0},  # tighter than default
+                token_ttl=1800,                       # 30 min instead of 1h
+            )
+    """
+
+    def __init__(
+        self,
+        *,
+        form_id: str,
+        defences: tuple[str, ...] = ("render_token", "honeypot", "time_trap"),
+        defence_weights: dict[str, float] | None = None,
+        redis_client_factory: Callable[[], Any] | None = None,
+        skip_for_authenticated: bool = False,
+        **per_form_config: Any,
+    ) -> None:
+        """Construct the chain.
+
+        * ``form_id`` — stable identifier used in counter keys, the
+          honeypot's name rotation, the structured log, and the
+          ``X-WAF-Form-Verdict`` header.
+        * ``defences`` — names of defences to run. Re-sorted into
+          canonical order so render_token always runs first.
+        * ``defence_weights`` — per-defence score overrides; merged
+          over ``ICV_WAF_FORM_DEFENCE_WEIGHTS``. Unknown names are
+          accepted silently (operators may upweight future defences
+          without breaking the current chain).
+        * ``redis_client_factory`` — callable returning a Redis
+          client; defaults to the package-wide resolver. Tests inject
+          a MagicMock factory directly.
+        * ``skip_for_authenticated`` — when True, only render_token
+          runs for authenticated users; spam/timing defences are
+          skipped on in-product forms.
+        * ``per_form_config`` — any other kwarg becomes a per-defence
+          config entry. e.g. ``min_fill_seconds=0.8`` reaches
+          ``TimeTrapDefence`` via ``ctx.config['min_fill_seconds']``.
+        """
+        # Validate every name *before* re-ordering so unknown defences
+        # surface at construction (app-startup) rather than silently
+        # disappearing because _order_defences filters by the canonical
+        # set.
+        unknown = [n for n in defences if n not in _CANONICAL_ORDER]
+        if unknown:
+            raise ValueError(f"unknown defence(s): {', '.join(repr(n) for n in unknown)}")
+
+        self.form_id = form_id
+        self._raw_defence_names = defences
+        self._defence_names = _order_defences(defences)
+        self._weights = defence_weights or {}
+        self._redis_factory = redis_client_factory or _default_redis_factory
+        self.skip_for_authenticated = skip_for_authenticated
+        self._per_form_config = per_form_config
+
+        # Instantiate defences eagerly so construction-time errors
+        # (missing redis factory for redis-using defence) surface at
+        # app-startup rather than first-render.
+        self._defences: dict[str, Defence] = {
+            name: _build_defence(name, self._redis_factory) for name in self._defence_names
+        }
+
+    # ----- internal -------------------------------------------------------
+
+    def _config_for(self, defence_name: str, token_nonce: str | None = None) -> dict:
+        """Build the config dict passed to a defence at render/evaluate time.
+
+        Merges, in order:
+          1. ``per_form_config`` — what the operator passed to
+             ``FormProtection(...)``.
+          2. ``token_nonce`` if known — read by HoneypotDefence /
+             JsTouchDefence / PowGateDefence to bind their rendered
+             values to the active render.
+
+        Defence-specific keys read from this dict include:
+          * render_token : ``token_ttl``
+          * honeypot     : ``field_names``
+          * time_trap    : ``min_fill_seconds`` / ``max_fill_seconds``
+          * cred_throttle: ``ip_limit``
+          * signup_vel.  : ``limit``
+          * pow_gate     : ``difficulty`` / ``token_nonce``
+        """
+        cfg = dict(self._per_form_config)
+        if token_nonce is not None:
+            cfg["token_nonce"] = token_nonce
+        return cfg
+
+    def _is_authenticated(self, request) -> bool:
+        user = getattr(request, "user", None)
+        return bool(user is not None and getattr(user, "is_authenticated", False))
+
+    # ----- public ---------------------------------------------------------
+
+    @property
+    def defence_names(self) -> tuple[str, ...]:
+        """The defences configured for this form, in run order.
+
+        Public so the mixin/decorator/template tag can introspect
+        without reaching into the private attribute.
+        """
+        return self._defence_names
+
+    def render_fields(self, request) -> dict[str, str]:
+        """Collect hidden inputs from every defence for this request.
+
+        Returns a dict of ``synthetic_key → html_fragment``. Callers
+        concatenate the values into the form's template. The keys
+        are only used for de-duplication when multiple defences emit
+        fragments under the same key.
+        """
+        from icv_waf import conf
+
+        if not conf.ICV_WAF_FORM_PROTECTION_ENABLED:
+            return {}
+
+        # In skip_for_authenticated mode, still render render_token
+        # (it's the integrity check that survives across all user
+        # types) but skip everything else.
+        names = self._defence_names
+        if self.skip_for_authenticated and self._is_authenticated(request):
+            names = tuple(n for n in names if n == "render_token")
+
+        all_fields: dict[str, str] = {}
+        # First pass: render_token to learn the nonce (so we can pass
+        # it to honeypot / js_touch / pow_gate).
+        token_nonce: str | None = None
+        if "render_token" in names:
+            defence = self._defences["render_token"]
+            ctx = RenderContext(
+                form_id=self.form_id,
+                request=request,
+                config=self._config_for("render_token"),
+            )
+            try:
+                fragments = defence.render_fields(ctx)
+                all_fields.update(fragments)
+                # The token is in fragments[TOKEN_FIELD_NAME] — but
+                # the nonce is internal to it. Extract via the
+                # parse_submitted_payload helper (works because we
+                # just issued the token).
+                from icv_waf.forms.defences.render_token import (
+                    TOKEN_FIELD_NAME,
+                    parse_submitted_payload,
+                )
+
+                token_str = fragments.get(TOKEN_FIELD_NAME, "")
+                payload = parse_submitted_payload({TOKEN_FIELD_NAME: token_str})
+                if payload is not None:
+                    token_nonce = payload.nonce
+            except Exception:
+                # Per fail-open policy: render_token failure must not
+                # break form rendering. The form just renders without
+                # protection fields, and submission will fail open.
+                logger.exception("icv-waf: render_token render_fields failed")
+
+        # Second pass: every other defence, with token_nonce threaded in.
+        for name in names:
+            if name == "render_token":
+                continue
+            defence = self._defences[name]
+            ctx = RenderContext(
+                form_id=self.form_id,
+                request=request,
+                config=self._config_for(name, token_nonce=token_nonce),
+            )
+            try:
+                fragments = defence.render_fields(ctx)
+                all_fields.update(fragments)
+            except Exception:
+                logger.exception("icv-waf: %s render_fields failed", name)
+
+        return all_fields
+
+    def evaluate(self, request, submitted_data: dict) -> FormEvaluationResult:
+        """Run the defence chain against a submission, return the verdict.
+
+        Each defence's ``evaluate`` runs in canonical order. After
+        render_token verifies, its payload is threaded onto subsequent
+        defences' EvaluateContexts (time_trap, ua_consistency, js_touch,
+        pow_gate all read from it).
+
+        A defence returning ``block`` short-circuits the chain — no
+        further defences run, and the final verdict is BLOCKED.
+        Otherwise scores accumulate; crossing
+        ``ICV_WAF_FORM_BLOCK_THRESHOLD`` upgrades the verdict to
+        BLOCKED, crossing ``ICV_WAF_FORM_FLAG_THRESHOLD`` to FLAGGED.
+        """
+        from icv_waf import conf
+
+        if not conf.ICV_WAF_FORM_PROTECTION_ENABLED:
+            return FormEvaluationResult(verdict=FormVerdict.PASSED, total_score=0.0)
+
+        names = self._defence_names
+        if self.skip_for_authenticated and self._is_authenticated(request):
+            names = tuple(n for n in names if n == "render_token")
+
+        outcomes: list[Outcome] = []
+        token_payload: Any = None
+
+        for name in names:
+            defence = self._defences[name]
+            ctx = EvaluateContext(
+                form_id=self.form_id,
+                request=request,
+                submitted_data=submitted_data,
+                config=self._config_for(name, token_nonce=token_payload.nonce if token_payload else None),
+                token_payload=token_payload,
+            )
+            try:
+                outcome = defence.evaluate(ctx)
+            except Exception:
+                # Defence raised — log and treat as a silent pass so a
+                # bug in one defence can't block legitimate users.
+                logger.exception("icv-waf: defence %s raised; treating as pass", name)
+                outcome = Outcome(verdict="pass")
+            outcomes.append(outcome)
+
+            # Short-circuit on a hard block — no later defence's
+            # verdict can revert this.
+            if outcome.verdict == "block":
+                total = self._aggregate_score(outcomes)
+                return FormEvaluationResult(
+                    verdict=FormVerdict.BLOCKED,
+                    total_score=total,
+                    outcomes=outcomes,
+                    token_payload=token_payload,
+                )
+
+            # After render_token returns pass-or-flag, parse the
+            # payload so subsequent defences can use it.
+            if name == "render_token" and token_payload is None:
+                from icv_waf.forms.defences.render_token import parse_submitted_payload
+
+                token_payload = parse_submitted_payload(submitted_data)
+
+        total = self._aggregate_score(outcomes)
+        verdict = self._resolve_verdict(total)
+        return FormEvaluationResult(
+            verdict=verdict,
+            total_score=total,
+            outcomes=outcomes,
+            token_payload=token_payload,
+        )
+
+    def consume_token_marker(self, token_payload) -> None:
+        """Delete the Redis one-shot marker after a PASS verdict.
+
+        Called by the mixin / decorator after evaluate() returns
+        PASSED. The delete-on-PASS-only rule is what makes HTMX
+        re-renders work (PRD §4.3) — failed validations preserve the
+        marker so the same token can be re-submitted with the same
+        Redis state.
+        """
+        if token_payload is None:
+            return
+        try:
+            from icv_waf.forms.services.markers import consume_marker
+
+            consume_marker(self._redis_factory(), token_payload.nonce)
+        except Exception:
+            logger.exception("icv-waf: failed to consume token marker")
+
+    # ----- internal verdict resolution -----------------------------------
+
+    def _aggregate_score(self, outcomes: list[Outcome]) -> float:
+        """Sum flag scores, applying per-defence weight overrides.
+
+        Block outcomes contribute their own ``score`` field (which is
+        usually 0 since the verdict short-circuits) so the total in
+        the log reflects what the bot scored before the block landed.
+        """
+        from icv_waf import conf
+
+        weights = dict(conf.ICV_WAF_FORM_DEFENCE_WEIGHTS)
+        weights.update(self._weights)
+
+        total = 0.0
+        for outcome, name in zip(outcomes, self._defence_names, strict=False):
+            if outcome.verdict == "pass":
+                continue
+            # Block + flag both contribute their score field. Each
+            # defence already returns its canonical score; weights
+            # override on a per-defence basis.
+            score = outcome.score
+            if name in weights:
+                # If the operator supplied a weight, treat the
+                # defence's intrinsic score as a *unit* signal and
+                # scale by the weight. When weight equals the
+                # defence's canonical score this is a no-op.
+                score = weights[name] if outcome.verdict != "pass" else 0.0
+            total += score
+        return total
+
+    def _resolve_verdict(self, total_score: float) -> FormVerdict:
+        from icv_waf import conf
+
+        if total_score >= conf.ICV_WAF_FORM_BLOCK_THRESHOLD:
+            return FormVerdict.BLOCKED
+        if total_score >= conf.ICV_WAF_FORM_FLAG_THRESHOLD:
+            return FormVerdict.FLAGGED
+        return FormVerdict.PASSED

--- a/src/icv_waf/forms/services/counters.py
+++ b/src/icv_waf/forms/services/counters.py
@@ -1,0 +1,147 @@
+"""Redis counters used by throttle and velocity defences.
+
+A counter is a Redis INCR'd integer with a TTL. The TTL acts as the
+sliding window — when the key expires, the count resets. Coarse but
+matches what every other rate-limit-style defence in the WAF does.
+
+Keys:
+
+* ``waf:form:cred_fail:account:<sha256(identifier)>``
+* ``waf:form:cred_fail:ip:<ip>``
+* ``waf:form:signup:<ip>``
+
+The identifier is hashed (not stored raw) so a Redis dump doesn't
+leak attempted usernames.
+
+All operations fail-open on Redis errors — the rest of the WAF's
+fail-open policy applies. Callers receive 0 (counter unread) or
+silently swallowed (counter unincremented) rather than exceptions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+_CRED_ACCOUNT_KEY = "waf:form:cred_fail:account:{identifier_hash}"
+_CRED_IP_KEY = "waf:form:cred_fail:ip:{ip}"
+_SIGNUP_IP_KEY = "waf:form:signup:{ip}"
+
+
+def _hash_identifier(identifier: str) -> str:
+    """Return a stable hash of the typed identifier (username/email).
+
+    Hashed not for security per se (the identifier is on a wire we
+    control) but so a Redis dump doesn't expose typed credentials.
+    """
+    return hashlib.sha256(identifier.encode("utf-8", errors="replace")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Credential-fail counters
+# ---------------------------------------------------------------------------
+
+
+def record_credential_failure(redis_client, *, identifier: str, ip: str, window_seconds: int) -> tuple[int, int]:
+    """Increment both per-account and per-IP failure counters.
+
+    Returns ``(account_count, ip_count)`` after incrementing. Either
+    being 0 indicates a Redis failure was silently swallowed — the
+    caller can treat 0 as 'don't escalate'.
+
+    The increment must be unconditional with respect to whether the
+    account exists — see PRD §3.6.1's enumeration-safety constraint.
+    The caller is the login-flow code; it calls this every time the
+    password check fails, not just when the account exists.
+    """
+    if not identifier or not ip:
+        return (0, 0)
+
+    account_key = _CRED_ACCOUNT_KEY.format(identifier_hash=_hash_identifier(identifier))
+    ip_key = _CRED_IP_KEY.format(ip=ip)
+
+    try:
+        pipe = redis_client.pipeline()
+        pipe.incr(account_key)
+        pipe.expire(account_key, window_seconds)
+        pipe.incr(ip_key)
+        pipe.expire(ip_key, window_seconds)
+        results = pipe.execute()
+        # pipe.execute() returns [incr_a, expire_a, incr_b, expire_b];
+        # indices 0 and 2 are the INCR results.
+        account_count = int(results[0]) if results and len(results) >= 3 else 0
+        ip_count = int(results[2]) if results and len(results) >= 3 else 0
+        return account_count, ip_count
+    except Exception:
+        return (0, 0)
+
+
+def credential_ip_count(redis_client, *, ip: str) -> int:
+    """Read the current per-IP credential-failure count without incrementing.
+
+    Used by the defence's evaluate() at submission time before the
+    auth check has run, so the defence can choose to challenge on the
+    very next attempt after the threshold was crossed.
+    """
+    if not ip:
+        return 0
+    try:
+        raw = redis_client.get(_CRED_IP_KEY.format(ip=ip))
+        if raw is None:
+            return 0
+        return int(raw)
+    except Exception:
+        return 0
+
+
+def credential_account_count(redis_client, *, identifier: str) -> int:
+    """Read the current per-account credential-failure count.
+
+    Used for the observation-only signal emission (PRD §3.6.1) —
+    never returned to the user, so leaks don't matter operationally.
+    """
+    if not identifier:
+        return 0
+    try:
+        raw = redis_client.get(_CRED_ACCOUNT_KEY.format(identifier_hash=_hash_identifier(identifier)))
+        if raw is None:
+            return 0
+        return int(raw)
+    except Exception:
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Signup-velocity counter
+# ---------------------------------------------------------------------------
+
+
+def record_signup(redis_client, *, ip: str, window_seconds: int) -> int:
+    """Increment the per-IP signup counter; return the new value.
+
+    Called by the orchestrator after a signup form passes — counts
+    completed registrations, not attempts. The user who crosses the
+    threshold sees the challenge on their *next* attempt.
+    """
+    if not ip:
+        return 0
+    try:
+        pipe = redis_client.pipeline()
+        pipe.incr(_SIGNUP_IP_KEY.format(ip=ip))
+        pipe.expire(_SIGNUP_IP_KEY.format(ip=ip), window_seconds)
+        results = pipe.execute()
+        return int(results[0]) if results else 0
+    except Exception:
+        return 0
+
+
+def signup_count(redis_client, *, ip: str) -> int:
+    """Read the current signup count for ``ip`` without incrementing."""
+    if not ip:
+        return 0
+    try:
+        raw = redis_client.get(_SIGNUP_IP_KEY.format(ip=ip))
+        if raw is None:
+            return 0
+        return int(raw)
+    except Exception:
+        return 0

--- a/src/icv_waf/forms/services/markers.py
+++ b/src/icv_waf/forms/services/markers.py
@@ -1,0 +1,62 @@
+"""Redis one-shot markers for render-token replay protection.
+
+A marker is a short-lived Redis key whose **presence** means "this
+token has not yet been spent on a successful submission." Lifecycle:
+
+1. ``issue_marker(nonce)`` at form render — SETEX with ``token_ttl``.
+2. ``marker_exists(nonce)`` on submit — read; if absent and the token's
+   render-time is older than the 5-second grace window, treat as
+   replayed.
+3. ``consume_marker(nonce)`` **only on overall PASS verdict** — DEL
+   the key so the token can't be reused.
+
+The "only on PASS" rule is the load-bearing semantic for HTMX
+re-renders. A form that fails Django-level validation (missing field)
+keeps the same marker; the user can submit again with the same token
+once they've fixed the error. A form that passes consumes the marker
+and any subsequent reuse of the token is a replay.
+
+Per PRD §4.3.
+"""
+
+from __future__ import annotations
+
+_MARKER_KEY = "waf:form:token:{nonce}"
+
+
+def _key(nonce: str) -> str:
+    return _MARKER_KEY.format(nonce=nonce)
+
+
+def issue_marker(redis_client, nonce: str, ttl_seconds: int) -> None:
+    """Set the one-shot marker for a freshly-issued token.
+
+    Idempotent under Redis semantics — re-issuing the same nonce just
+    refreshes the TTL. In practice the nonce is random per call so
+    collisions don't happen, but the contract holds either way.
+    """
+    redis_client.setex(_key(nonce), ttl_seconds, "1")
+
+
+def marker_exists(redis_client, nonce: str) -> bool:
+    """Return True iff the marker for this nonce is still present.
+
+    A False return after a token's render-time has passed the grace
+    window indicates replay (the marker was consumed by a previous
+    successful submission, or expired by TTL).
+
+    Defensive against Redis returning a falsy non-None — coerced via
+    bool() rather than ``is not None`` so values of ``0`` from a wrong
+    key type don't read as "present."
+    """
+    return bool(redis_client.exists(_key(nonce)))
+
+
+def consume_marker(redis_client, nonce: str) -> None:
+    """Delete the marker after a successful submission.
+
+    Called only when the orchestrator's overall verdict is PASS.
+    Subsequent submissions with the same token will see the marker
+    missing and (if past the grace window) treat the token as replayed.
+    """
+    redis_client.delete(_key(nonce))

--- a/src/icv_waf/forms/services/replay.py
+++ b/src/icv_waf/forms/services/replay.py
@@ -1,0 +1,217 @@
+"""Challenge-replay storage + signed-reference helpers.
+
+When a form submission is FLAGGED and ICV_WAF_FORM_CHALLENGE_ON_FLAG
+is True, the orchestrator redirects to /waf/challenge/?next=...&form_
+replay=<token>. The replay token is a signed reference to data
+stashed in the request's session (or Redis, depending on
+ICV_WAF_FORM_REPLAY_STORE). On successful challenge, the verify view
+looks up the data and re-issues the POST.
+
+Sensitive-field omission: password-like fields and file uploads are
+never stored. Password fields force the user to re-enter their
+password on the replayed form (acceptable UX cost for security);
+file uploads show a 'verification successful, please resubmit' page.
+
+Per PRD §5.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import logging
+import re
+import secrets
+import time
+from typing import Any
+
+from icv_waf.forms.services.tokens import get_signing_key
+
+logger = logging.getLogger("icv_waf.forms")
+
+
+# Replay token lifetime — much shorter than the form-token TTL
+# because the only legitimate use is 'user solves challenge within
+# 60s and gets routed back'. Longer would widen the replay window
+# for an attacker who steals the token from a flagged response.
+_REPLAY_TTL_SECONDS = 60
+
+# Session key under which the orchestrator stashes replay data.
+_SESSION_KEY = "waf_form_replay"
+
+# Field names matching any of these patterns are stripped before
+# storage. Conservative — better to require a re-entry than to
+# round-trip a password through session storage.
+# Matches password / passwd, secret, token, api_key, csrf, anywhere in the
+# field name with reasonable boundary handling — so password1/password2
+# (Django's confirm-password convention), user_password, csrfmiddlewaretoken
+# all hit.
+_SENSITIVE_FIELD_RE = re.compile(
+    r"(?:pass(?:word|wd)?|secret|api[_-]?key|csrf|token)",
+    re.IGNORECASE,
+)
+
+# Multipart file fields can't be reliably round-tripped (the bytes
+# would have to live in session storage). When detected, the
+# orchestrator falls back to 'please resubmit'.
+_FILE_FIELD_MARKER = "__waf_has_file__"
+
+
+# ---------------------------------------------------------------------------
+# Sensitive-field detection
+# ---------------------------------------------------------------------------
+
+
+def is_sensitive_field(name: str) -> bool:
+    """Return True if ``name`` matches the sensitive-field pattern."""
+    return bool(_SENSITIVE_FIELD_RE.search(name))
+
+
+def filter_sensitive_fields(data: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of ``data`` with sensitive fields stripped.
+
+    Caller-visible keys are preserved (the form on the replayed page
+    can show 'password required' next to the empty field). The values
+    are what we drop.
+    """
+    return {k: v for k, v in data.items() if not is_sensitive_field(k)}
+
+
+# ---------------------------------------------------------------------------
+# Replay token signing
+# ---------------------------------------------------------------------------
+
+
+def _sign(payload: bytes) -> str:
+    return hmac.new(get_signing_key(), payload, hashlib.sha256).hexdigest()
+
+
+def issue_replay_token(*, form_id: str, ip: str, session_key: str) -> str:
+    """Issue a signed reference to session-stored replay data.
+
+    The token contains form_id, IP, the session key under which the
+    data was stored, an expiry timestamp, and an HMAC signature.
+    Bound to the IP so a stolen token can't be replayed from a
+    different network.
+    """
+    expires_at = int(time.time()) + _REPLAY_TTL_SECONDS
+    payload = f"{form_id}|{ip}|{session_key}|{expires_at}".encode()
+    sig = _sign(payload)
+    raw = payload + b"|" + sig.encode()
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def verify_replay_token(token: str, *, current_ip: str) -> dict[str, str] | None:
+    """Validate a replay token; return its payload or None.
+
+    Returns ``None`` on any failure (malformed, bad signature,
+    expired, IP mismatch). The caller treats None as 'no replay
+    available' and shows the user a fresh form.
+    """
+    if not token:
+        return None
+    padding = "=" * (-len(token) % 4)
+    try:
+        raw = base64.urlsafe_b64decode((token + padding).encode("ascii"))
+    except Exception:
+        return None
+
+    sep_index = raw.rfind(b"|")
+    if sep_index == -1:
+        return None
+    payload, sig = raw[:sep_index], raw[sep_index + 1 :].decode("ascii", errors="replace")
+    expected = _sign(payload)
+    if not hmac.compare_digest(expected, sig):
+        return None
+
+    try:
+        form_id, ip, session_key, expires_at_str = payload.decode("utf-8").split("|")
+        expires_at = int(expires_at_str)
+    except (ValueError, UnicodeDecodeError):
+        return None
+
+    if expires_at < int(time.time()):
+        return None
+    if ip != current_ip:
+        return None
+
+    return {"form_id": form_id, "session_key": session_key}
+
+
+# ---------------------------------------------------------------------------
+# Session-backed storage (default)
+# ---------------------------------------------------------------------------
+
+
+def store_in_session(request, *, form_id: str, post_url: str, data: dict[str, Any]) -> str | None:
+    """Stash filtered POST data in the session; return the session key.
+
+    Returns None when the session framework isn't configured (the
+    consumer either doesn't use sessions or the middleware isn't
+    installed). The caller falls back to 'reject without replay' in
+    that case.
+    """
+    session = getattr(request, "session", None)
+    if session is None:
+        return None
+
+    key = secrets.token_hex(8)
+    stash = session.get(_SESSION_KEY, {})
+    if not isinstance(stash, dict):
+        stash = {}
+    stash[key] = {
+        "form_id": form_id,
+        "post_url": post_url,
+        "data": filter_sensitive_fields(data),
+        "stored_at": int(time.time()),
+    }
+    # Cap session bloat — keep at most 5 outstanding replays per session.
+    if len(stash) > 5:
+        oldest = sorted(stash.items(), key=lambda kv: kv[1].get("stored_at", 0))
+        for old_key, _ in oldest[:-5]:
+            stash.pop(old_key, None)
+    session[_SESSION_KEY] = stash
+    session.modified = True
+    return key
+
+
+def fetch_from_session(request, *, session_key: str) -> dict[str, Any] | None:
+    """Look up a replay record by session key; return None if missing/expired."""
+    session = getattr(request, "session", None)
+    if session is None:
+        return None
+    stash = session.get(_SESSION_KEY, {})
+    if not isinstance(stash, dict):
+        return None
+    record = stash.get(session_key)
+    if record is None:
+        return None
+    # Optional age check — the replay token has its own expiry, but
+    # double-check here in case storage outlived it.
+    if int(time.time()) - record.get("stored_at", 0) > _REPLAY_TTL_SECONDS + 60:
+        return None
+    return record
+
+
+def discard_from_session(request, *, session_key: str) -> None:
+    """Remove a consumed replay record from the session."""
+    session = getattr(request, "session", None)
+    if session is None:
+        return
+    stash = session.get(_SESSION_KEY, {})
+    if isinstance(stash, dict) and session_key in stash:
+        stash.pop(session_key)
+        session[_SESSION_KEY] = stash
+        session.modified = True
+
+
+__all__ = [
+    "discard_from_session",
+    "fetch_from_session",
+    "filter_sensitive_fields",
+    "is_sensitive_field",
+    "issue_replay_token",
+    "store_in_session",
+    "verify_replay_token",
+]

--- a/src/icv_waf/forms/services/tokens.py
+++ b/src/icv_waf/forms/services/tokens.py
@@ -1,0 +1,210 @@
+"""HMAC-signed render tokens for protected forms.
+
+A render token carries everything the verifier needs to authenticate a
+submission as coming from a form this server actually issued:
+
+* ``form_id``       — which form the token is for (per-form scoping)
+* ``ip``            — IP at render time (binds the token to a session-ish thing)
+* ``user_id``       — authenticated user id, or empty string
+* ``render_time``   — ISO 8601 timestamp at render
+* ``nonce``         — 16 random bytes hex; pairs with the Redis marker
+* ``ua_hash``       — SHA-256 of the User-Agent header at render time
+
+The token is the base64url-encoded ``payload + "|" + signature`` where
+``signature = HMAC-SHA256(signing_key, payload)``. Verification is
+constant-time. Expiry, IP-mismatch, and replay are detected by callers;
+this module only owns the signing format and the helpers around it.
+
+Per the PRD §4.1, §4.2, §7.4.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+# ---------------------------------------------------------------------------
+# Signing key resolution
+# ---------------------------------------------------------------------------
+
+
+def get_signing_key() -> bytes:
+    """Return the package's HMAC signing key as raw bytes.
+
+    Resolution order:
+
+    1. ``ICV_WAF_SIGNING_KEY`` if non-empty.
+    2. A value derived from Django's ``SECRET_KEY`` via HKDF-style hash,
+       namespaced so it differs from any other SECRET_KEY-derived
+       secret in the project (e.g. Django's own signers).
+
+    The fallback is documented and surfaced via the ``icv_waf.W003``
+    system check; callers don't need to handle the unset case
+    themselves.
+    """
+    from django.conf import settings
+
+    from icv_waf import conf
+
+    if conf.ICV_WAF_SIGNING_KEY:
+        return conf.ICV_WAF_SIGNING_KEY.encode("utf-8")
+
+    # Fallback: namespace-derive from SECRET_KEY so we never use the raw
+    # secret directly. ``b"icv-waf:signing:v1"`` is the namespace; bumping
+    # the suffix would let us rotate the derivation without changing the
+    # source SECRET_KEY.
+    raw = settings.SECRET_KEY.encode("utf-8") if isinstance(settings.SECRET_KEY, str) else settings.SECRET_KEY
+    return hashlib.sha256(b"icv-waf:signing:v1|" + raw).digest()
+
+
+# ---------------------------------------------------------------------------
+# Token payload
+# ---------------------------------------------------------------------------
+
+
+_DELIM = "|"
+# Payload field count — bumped when the format changes so old tokens
+# fail signature check cleanly rather than parsing into garbage.
+_PAYLOAD_FIELDS = 6
+
+
+@dataclass(frozen=True, slots=True)
+class TokenPayload:
+    """The data carried by a form render token.
+
+    Frozen so accidental mutation can't desync the signature.
+    """
+
+    form_id: str
+    ip: str
+    user_id: str  # "" when anonymous; stored as str so the format is stable
+    render_time: datetime
+    nonce: str
+    ua_hash: str
+
+    def encode(self) -> str:
+        """Render the canonical pipe-separated payload string for signing."""
+        return _DELIM.join(
+            (
+                self.form_id,
+                self.ip,
+                self.user_id,
+                self.render_time.isoformat(),
+                self.nonce,
+                self.ua_hash,
+            )
+        )
+
+    @classmethod
+    def decode(cls, raw: str) -> TokenPayload:
+        """Parse a payload string back into a ``TokenPayload``.
+
+        Raises ``ValueError`` if the field count is wrong or the
+        timestamp doesn't parse — callers should treat any exception as
+        a malformed token and fail verification.
+        """
+        parts = raw.split(_DELIM)
+        if len(parts) != _PAYLOAD_FIELDS:
+            raise ValueError(f"expected {_PAYLOAD_FIELDS} payload fields, got {len(parts)}")
+        form_id, ip, user_id, render_time_iso, nonce, ua_hash = parts
+        # ``fromisoformat`` accepts what ``isoformat`` produced.
+        render_time = datetime.fromisoformat(render_time_iso)
+        return cls(
+            form_id=form_id,
+            ip=ip,
+            user_id=user_id,
+            render_time=render_time,
+            nonce=nonce,
+            ua_hash=ua_hash,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issuance + verification
+# ---------------------------------------------------------------------------
+
+
+def hash_user_agent(user_agent: str) -> str:
+    """Stable SHA-256 hash of a User-Agent header.
+
+    Hashed (not stored raw) so the token doesn't bloat with long UA
+    strings and so a change in any byte produces a fresh hash.
+    """
+    return hashlib.sha256(user_agent.encode("utf-8", errors="replace")).hexdigest()
+
+
+def issue_token(
+    *,
+    form_id: str,
+    ip: str,
+    user_id: str = "",
+    user_agent: str = "",
+    nonce: str | None = None,
+    render_time: datetime | None = None,
+) -> tuple[str, TokenPayload]:
+    """Issue a signed render token for a form.
+
+    Returns ``(token_string, payload)``. ``token_string`` is what goes
+    into the hidden field; ``payload`` is returned so callers can store
+    auxiliary state keyed on the same nonce (the Redis marker).
+
+    All keyword-only because positional argument order doesn't carry
+    meaning here and the call site will be at form-render time where
+    explicit keywords read better.
+    """
+    if nonce is None:
+        nonce = secrets.token_hex(16)
+    if render_time is None:
+        render_time = datetime.now(tz=UTC)
+
+    payload = TokenPayload(
+        form_id=form_id,
+        ip=ip,
+        user_id=user_id,
+        render_time=render_time,
+        nonce=nonce,
+        ua_hash=hash_user_agent(user_agent),
+    )
+
+    payload_str = payload.encode()
+    signature = hmac.new(get_signing_key(), payload_str.encode("utf-8"), hashlib.sha256).hexdigest()
+    raw = payload_str + _DELIM + signature
+    token = base64.urlsafe_b64encode(raw.encode("utf-8")).decode("ascii").rstrip("=")
+    return token, payload
+
+
+def verify_token(token: str) -> TokenPayload:
+    """Validate the signature and return the parsed payload.
+
+    Raises ``ValueError`` on any failure — malformed encoding, wrong
+    field count, bad signature. Callers translate that into the
+    defence's Block outcome (``render_token:invalid``).
+
+    Constant-time signature comparison via ``hmac.compare_digest``.
+    """
+    # Restore base64 padding stripped during issuance.
+    padding = "=" * (-len(token) % 4)
+    try:
+        raw = base64.urlsafe_b64decode((token + padding).encode("ascii")).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ValueError("token is not valid base64url-encoded utf-8") from exc
+
+    # Signature is the final pipe-delimited segment; everything before
+    # it is the signed payload. We can't use ``split('|', ...)`` because
+    # the payload itself contains pipes — rsplit on a single delimiter
+    # is the correct seam.
+    sep_index = raw.rfind(_DELIM)
+    if sep_index == -1:
+        raise ValueError("token has no signature delimiter")
+    payload_str = raw[:sep_index]
+    signature = raw[sep_index + 1 :]
+
+    expected = hmac.new(get_signing_key(), payload_str.encode("utf-8"), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected, signature):
+        raise ValueError("signature mismatch")
+
+    return TokenPayload.decode(payload_str)

--- a/src/icv_waf/forms/signals.py
+++ b/src/icv_waf/forms/signals.py
@@ -1,0 +1,35 @@
+"""Signals emitted by the form-protection orchestrator + entry points.
+
+Receivers must not raise; failures are caught at the emission site
+and logged. Pin: existing signals in ``icv_waf.signals`` follow the
+same contract.
+
+Per PRD §8.
+"""
+
+from __future__ import annotations
+
+from django.dispatch import Signal
+
+# Emitted on PASSED submissions only when
+# ICV_WAF_FORM_EMIT_PASSED_SIGNAL=True (default False). See PRD §8.
+# kwargs: form_id, ip, user_agent, user_id (or None)
+form_submission_passed = Signal()
+
+
+# Emitted when total score crosses ICV_WAF_FORM_FLAG_THRESHOLD.
+# kwargs: form_id, ip, user_agent, user_id, total_score, outcomes
+form_submission_flagged = Signal()
+
+
+# Emitted on BLOCKED verdict (defence block OR score >= block threshold).
+# kwargs: form_id, ip, user_agent, user_id, total_score, outcomes, reason
+form_submission_blocked = Signal()
+
+
+# Emitted by the credential-throttle when a per-account counter
+# crosses its threshold. Consumer projects connect a handler to
+# email the legitimate account holder, notify ops, etc. Critical:
+# does NOT affect the user-visible response (enumeration safety).
+# kwargs: identifier_hash, attempt_count, window_seconds, ip
+credential_attack_observed = Signal()

--- a/src/icv_waf/templatetags/waf_form_tags.py
+++ b/src/icv_waf/templatetags/waf_form_tags.py
@@ -1,0 +1,72 @@
+"""{% waf_protect %} template tag.
+
+Used in templates whose form bypasses Django's Form layer (the
+handwritten-HTML case). Pairs with the ``waf_protect_post`` decorator
+on the view::
+
+    # views.py
+    @waf_protect_post(form_id='contact-handwritten')
+    def contact_view(request):
+        ...
+
+    # contact.html
+    <form method="post">
+      {% csrf_token %}
+      {% load waf_form_tags %}
+      {% waf_protect form_id='contact-handwritten' %}
+      <input type="text" name="email">
+      ...
+    </form>
+
+The tag looks up the FormProtection that the decorator constructed
+(keyed by form_id) and renders its hidden fields. If no matching
+decorator has run, the tag renders nothing — so a template typo
+doesn't crash the page, it just fails silently (and the logged
+``no FormProtection found`` warning surfaces in dev).
+
+Per PRD §2.1 (entry-point C).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django import template
+from django.utils.safestring import SafeString, mark_safe
+
+from icv_waf.forms.decorators import _registry_get
+
+logger = logging.getLogger("icv_waf.forms")
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def waf_protect(context, form_id: str) -> SafeString:
+    """Render the WAF's hidden fields for a handwritten HTML form.
+
+    ``form_id`` must match the value passed to ``waf_protect_post`` on
+    the view that handles this template's submissions.
+    """
+    protection = _registry_get(form_id)
+    if protection is None:
+        # The decorator hasn't been imported yet, or the form_id is
+        # mis-typed. Log + render nothing — surface in dev via the
+        # logger, never crash production.
+        logger.warning(
+            "icv-waf: {%% waf_protect form_id=%r %%} called but no "
+            "FormProtection is registered. Did you forget the "
+            "@waf_protect_post decorator?",
+            form_id,
+        )
+        return mark_safe("")  # noqa: S308 — empty string is XSS-safe
+
+    request = context.get("request")
+    if request is None:
+        logger.warning(
+            "icv-waf: {%% waf_protect %%} requires 'request' in the template context. Ensure RequestContext is in use."
+        )
+        return mark_safe("")  # noqa: S308
+
+    fields = protection.render_fields(request)
+    html = "".join(fields[k] for k in sorted(fields))
+    return mark_safe(html)  # noqa: S308 — each fragment is already SafeString

--- a/src/icv_waf/views.py
+++ b/src/icv_waf/views.py
@@ -114,6 +114,8 @@ class ChallengeView(TemplateView):
     template_name = "icv_waf/challenge.html"
 
     def get(self, request: HttpRequest, *args, **kwargs) -> HttpResponse:
+        from urllib.parse import urlencode
+
         from icv_waf import conf
         from icv_waf.services.challenge_service import issue_challenge
 
@@ -123,6 +125,16 @@ class ChallengeView(TemplateView):
         user_agent = request.META.get("HTTP_USER_AGENT", "")
 
         challenge_token = issue_challenge(ip, redis_client, user_agent=user_agent)
+
+        # Form-replay token: when the form-protection orchestrator
+        # redirected here on a FLAGGED submission, the original POST
+        # data is parked in the session and ``form_replay=<token>`` is
+        # in the URL. Preserve it through to next_url so the
+        # post-challenge landing page can resubmit.
+        form_replay = request.GET.get("form_replay", "")
+        if form_replay:
+            separator = "&" if "?" in next_url else "?"
+            next_url = f"{next_url}{separator}{urlencode({'form_replay': form_replay})}"
 
         # Resolve the verify URL the same way the middleware does
         # (icv_waf.middleware._get_challenge_paths) — honour the operator

--- a/tests/forms/test_challenge_replay_flow.py
+++ b/tests/forms/test_challenge_replay_flow.py
@@ -1,0 +1,314 @@
+"""End-to-end tests for the FLAGGED → challenge → replay flow."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+class _FakeSession(dict):
+    """A dict that also supports the ``.modified`` attribute Django uses."""
+
+    modified = False
+
+
+def _request_with_session(method, path, post=None, get_params=None):
+    rf = RequestFactory()
+    if method == "POST":  # noqa: SIM108 — explicit branch reads clearer here
+        request = rf.post(path, data=post or {})
+    else:
+        # rf.get accepts a data dict for query params.
+        request = rf.get(path, data=get_params or {})
+    request.user = MagicMock(is_authenticated=False)
+    # Stub out a session — RequestFactory doesn't add one by default.
+    request.session = _FakeSession()
+    return request
+
+
+def _flagged_protection_for(form_id):
+    """Build a FormProtection whose evaluate() always returns FLAGGED.
+
+    Simpler than constructing a real flagged submission — the focus
+    is the decorator's redirect-and-replay behaviour, not the
+    orchestrator's verdict logic (which has its own tests).
+    """
+    from icv_waf.forms.protection import (
+        FormEvaluationResult,
+        FormProtection,
+        FormVerdict,
+    )
+
+    protection = FormProtection(
+        form_id=form_id,
+        defences=("honeypot",),
+        redis_client_factory=lambda: _redis(),
+    )
+
+    def always_flagged(request, submitted_data):
+        return FormEvaluationResult(
+            verdict=FormVerdict.FLAGGED,
+            total_score=3.0,
+            outcomes=[],
+            token_payload=None,
+        )
+
+    protection.evaluate = always_flagged
+    return protection
+
+
+# ---------------------------------------------------------------------------
+# FLAGGED → redirect
+# ---------------------------------------------------------------------------
+
+
+class TestFlaggedRedirect:
+    def test_flagged_post_redirects_to_challenge(self, settings):
+        """FLAGGED + session + setting True → 302 to /waf/challenge/?form_replay=..."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import _registry_get, waf_protect_post
+        from icv_waf.forms.protection import FormEvaluationResult, FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            form_id = "contact-flagged-redirect"
+
+            @waf_protect_post(
+                form_id=form_id,
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):  # noqa: ARG001
+                from django.http import HttpResponse
+
+                return HttpResponse("view-ran")
+
+            # Force the protection to always FLAG so we test the
+            # redirect path deterministically.
+            protection = _registry_get(form_id)
+            protection.evaluate = lambda request, submitted_data: FormEvaluationResult(
+                verdict=FormVerdict.FLAGGED, total_score=3.0, outcomes=[], token_payload=None
+            )
+
+            request = _request_with_session("POST", "/contact/", post={"name": "alice"})
+            response = view(request)
+
+        assert response.status_code == 302
+        location = response["Location"]
+        assert "/waf/challenge/" in location
+        assert "form_replay=" in location
+        # Session now has the stashed data. dict(QueryDict) returns
+        # list-valued values, which is what we want for round-trip.
+        stash = request.session.get("waf_form_replay", {})
+        assert len(stash) == 1
+        only_record = next(iter(stash.values()))
+        assert only_record["data"]["name"] == ["alice"]
+        assert only_record["post_url"] == "/contact/"
+
+    def test_flagged_without_session_falls_back_to_view(self, settings):
+        """If the request has no session, the decorator falls back to
+        calling the view (operators see FLAGGED in request.waf_form_result)."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import (
+            _registry_get,
+            waf_protect_post,
+        )
+        from icv_waf.forms.protection import FormEvaluationResult, FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            form_id = "contact-no-session"
+
+            @waf_protect_post(
+                form_id=form_id,
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("view-ran")
+
+            protection = _registry_get(form_id)
+            protection.evaluate = lambda r, submitted_data: FormEvaluationResult(
+                verdict=FormVerdict.FLAGGED, total_score=3.0, outcomes=[], token_payload=None
+            )
+
+            # RequestFactory without a session attribute.
+            rf = RequestFactory()
+            request = rf.post("/contact/", data={"name": "alice"})
+            request.user = MagicMock(is_authenticated=False)
+            # NO request.session set.
+
+            response = view(request)
+
+        # View ran (decorator fell back); the redirect did not happen.
+        assert response.status_code == 200
+        assert response.content.decode() == "view-ran"
+
+    def test_challenge_redirect_disabled_setting(self, settings):
+        """ICV_WAF_FORM_CHALLENGE_ON_FLAG=False → no redirect; view runs."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import (
+            _registry_get,
+            waf_protect_post,
+        )
+        from icv_waf.forms.protection import FormEvaluationResult, FormVerdict
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"),
+            patch.object(conf_mod, "ICV_WAF_FORM_CHALLENGE_ON_FLAG", False),
+        ):
+            form_id = "contact-challenge-disabled"
+
+            @waf_protect_post(
+                form_id=form_id,
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("view-ran")
+
+            protection = _registry_get(form_id)
+            protection.evaluate = lambda r, submitted_data: FormEvaluationResult(
+                verdict=FormVerdict.FLAGGED, total_score=3.0, outcomes=[], token_payload=None
+            )
+
+            request = _request_with_session("POST", "/contact/", post={"name": "alice"})
+            response = view(request)
+
+        assert response.status_code == 200
+        assert response.content.decode() == "view-ran"
+
+
+# ---------------------------------------------------------------------------
+# GET ?form_replay=... triggers replay
+# ---------------------------------------------------------------------------
+
+
+class TestReplayDispatch:
+    def test_valid_replay_invokes_view_as_post(self, settings):
+        """GET ?form_replay=<valid> + matching session → view sees POST."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import (
+            _registry_get,
+            waf_protect_post,
+        )
+        from icv_waf.forms.protection import FormEvaluationResult, FormVerdict
+        from icv_waf.forms.services.replay import (
+            issue_replay_token,
+            store_in_session,
+        )
+
+        captured = {}
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            form_id = "contact-replay-valid"
+
+            @waf_protect_post(
+                form_id=form_id,
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                captured["method"] = request.method
+                captured["name"] = request.POST.get("name")
+                from django.http import HttpResponse
+
+                return HttpResponse("ok")
+
+            # Replace evaluate so the replayed POST passes through.
+            protection = _registry_get(form_id)
+            protection.evaluate = lambda r, submitted_data: FormEvaluationResult(
+                verdict=FormVerdict.PASSED, total_score=0.0, outcomes=[], token_payload=None
+            )
+
+            request = _request_with_session("GET", "/contact/", get_params={"form_replay": ""})
+            # Stash data, then mint a token referring to that session key.
+            session_key = store_in_session(request, form_id=form_id, post_url="/contact/", data={"name": "alice"})
+            token = issue_replay_token(form_id=form_id, ip="127.0.0.1", session_key=session_key)
+            request.GET = request.GET.copy()
+            request.GET["form_replay"] = token
+
+            response = view(request)
+
+        assert response.status_code == 200
+        assert captured["method"] == "POST"
+        assert captured["name"] == "alice"
+
+    def test_invalid_replay_falls_back_to_normal_get(self, settings):
+        """GET ?form_replay=garbage → no replay → view sees GET."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import waf_protect_post
+
+        captured = {}
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-replay-invalid",
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                captured["method"] = request.method
+                from django.http import HttpResponse
+
+                return HttpResponse("ok")
+
+            request = _request_with_session("GET", "/contact/", get_params={"form_replay": "garbage"})
+            response = view(request)
+
+        assert response.status_code == 200
+        assert captured["method"] == "GET"
+
+    def test_replay_consumed_after_use(self, settings):
+        """The session record is removed after a successful replay so
+        the same token can't be re-used."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import _registry_get, waf_protect_post
+        from icv_waf.forms.protection import FormEvaluationResult, FormVerdict
+        from icv_waf.forms.services.replay import (
+            issue_replay_token,
+            store_in_session,
+        )
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            form_id = "contact-replay-consumed"
+
+            @waf_protect_post(
+                form_id=form_id,
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                from django.http import HttpResponse
+
+                return HttpResponse("ok")
+
+            protection = _registry_get(form_id)
+            protection.evaluate = lambda r, submitted_data: FormEvaluationResult(
+                verdict=FormVerdict.PASSED, total_score=0.0, outcomes=[], token_payload=None
+            )
+
+            request = _request_with_session("GET", "/contact/")
+            session_key = store_in_session(request, form_id=form_id, post_url="/contact/", data={"name": "alice"})
+            token = issue_replay_token(form_id=form_id, ip="127.0.0.1", session_key=session_key)
+            request.GET = request.GET.copy()
+            request.GET["form_replay"] = token
+
+            view(request)
+
+        # Session record gone.
+        stash = request.session.get("waf_form_replay", {})
+        assert session_key not in stash

--- a/tests/forms/test_credential_throttle.py
+++ b/tests/forms/test_credential_throttle.py
@@ -1,0 +1,201 @@
+"""Tests for CredentialThrottleDefence and the credential-counter service.
+
+The enumeration-safety constraint (PRD §3.6.1) is the most important
+property to pin. Tests below verify that:
+
+* The defence's verdict is identical whether the typed identifier
+  exists in the system or not — the defence never consults a user
+  table.
+* The challenge fires on the per-IP counter only; the per-account
+  counter is observation-only and never changes the user-facing
+  outcome.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    # Default: pipeline().execute() returns sensible counter values.
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None  # no existing counter by default
+    return r
+
+
+def _ctx(*, ip="1.2.3.4", config=None):
+    from icv_waf.forms.defences.base import EvaluateContext
+
+    request = MagicMock()
+    request.META = {"REMOTE_ADDR": ip}
+    return EvaluateContext(
+        form_id="login",
+        request=request,
+        submitted_data={},
+        config=config or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# counters service
+# ---------------------------------------------------------------------------
+
+
+class TestCounters:
+    def test_record_credential_failure_increments_both_counters(self):
+        from icv_waf.forms.services.counters import record_credential_failure
+
+        redis = _redis()
+        redis.pipeline.return_value.execute.return_value = [3, True, 7, True]
+        acct, ip = record_credential_failure(redis, identifier="user@example.com", ip="1.2.3.4", window_seconds=900)
+
+        assert acct == 3
+        assert ip == 7
+        # Pipeline calls: incr(acct), expire(acct), incr(ip), expire(ip)
+        calls = redis.pipeline.return_value.method_calls
+        method_names = [c[0] for c in calls]
+        assert method_names.count("incr") == 2
+        assert method_names.count("expire") == 2
+
+    def test_record_credential_failure_hashes_identifier(self):
+        """The Redis key for the account counter must contain a HASH,
+        not the plain typed identifier."""
+        from icv_waf.forms.services.counters import record_credential_failure
+
+        redis = _redis()
+        record_credential_failure(redis, identifier="admin@example.com", ip="1.2.3.4", window_seconds=900)
+
+        pipe_calls = redis.pipeline.return_value.method_calls
+        # Find the first incr() call (account key) and inspect its argument.
+        incr_calls = [c for c in pipe_calls if c[0] == "incr"]
+        assert incr_calls, "no incr call recorded"
+        account_key = incr_calls[0][1][0]  # first arg of first incr
+        assert "admin@example.com" not in account_key
+        assert account_key.startswith("waf:form:cred_fail:account:")
+
+    def test_redis_failure_returns_zero_zero(self):
+        """Redis pipeline failure must return (0, 0), not raise."""
+        from icv_waf.forms.services.counters import record_credential_failure
+
+        redis = _redis()
+        redis.pipeline.return_value.execute.side_effect = RuntimeError("redis down")
+        acct, ip = record_credential_failure(redis, identifier="u", ip="1.2.3.4", window_seconds=900)
+
+        assert (acct, ip) == (0, 0)
+
+    def test_empty_identifier_does_not_touch_redis(self):
+        """No identifier → no-op (defensive)."""
+        from icv_waf.forms.services.counters import record_credential_failure
+
+        redis = _redis()
+        record_credential_failure(redis, identifier="", ip="1.2.3.4", window_seconds=900)
+
+        redis.pipeline.assert_not_called()
+
+    def test_credential_ip_count_reads_without_incrementing(self):
+        from icv_waf.forms.services.counters import credential_ip_count
+
+        redis = _redis()
+        redis.get.return_value = b"15"
+        assert credential_ip_count(redis, ip="1.2.3.4") == 15
+
+    def test_credential_ip_count_missing_key_returns_zero(self):
+        from icv_waf.forms.services.counters import credential_ip_count
+
+        redis = _redis()
+        redis.get.return_value = None
+        assert credential_ip_count(redis, ip="1.2.3.4") == 0
+
+
+# ---------------------------------------------------------------------------
+# CredentialThrottleDefence
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialThrottleDefence:
+    def _defence(self, redis_client):
+        from icv_waf.forms.defences.credential_throttle import CredentialThrottleDefence
+
+        return CredentialThrottleDefence(redis_client_factory=lambda: redis_client)
+
+    def test_passes_when_below_threshold(self):
+        from icv_waf.forms.defences.credential_throttle import CredentialThrottleDefence
+
+        redis = _redis()
+        redis.get.return_value = b"5"  # well below default limit of 20
+        defence = CredentialThrottleDefence(redis_client_factory=lambda: redis)
+
+        assert defence.evaluate(_ctx()).verdict == "pass"
+
+    def test_flags_when_ip_threshold_crossed(self):
+        from icv_waf.forms.defences.credential_throttle import CredentialThrottleDefence
+
+        redis = _redis()
+        redis.get.return_value = b"25"  # above default limit of 20
+        defence = CredentialThrottleDefence(redis_client_factory=lambda: redis)
+        outcome = defence.evaluate(_ctx())
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "credential_throttle:ip"
+        assert outcome.score == 5.0
+
+    def test_per_form_ip_limit_override(self):
+        """Per-form config can lower the threshold for tighter forms."""
+        from icv_waf.forms.defences.credential_throttle import CredentialThrottleDefence
+
+        redis = _redis()
+        redis.get.return_value = b"5"
+        defence = CredentialThrottleDefence(redis_client_factory=lambda: redis)
+        outcome = defence.evaluate(_ctx(config={"ip_limit": 3}))
+
+        assert outcome.verdict == "flag"
+
+    def test_redis_failure_passes(self):
+        """Counter unreadable → fail-open (don't block legitimate logins)."""
+        from icv_waf.forms.defences.credential_throttle import CredentialThrottleDefence
+
+        redis = _redis()
+        redis.get.side_effect = RuntimeError("redis down")
+        defence = CredentialThrottleDefence(redis_client_factory=lambda: redis)
+
+        assert defence.evaluate(_ctx()).verdict == "pass"
+
+    def test_missing_ip_passes(self):
+        from icv_waf.forms.defences.credential_throttle import CredentialThrottleDefence
+
+        redis = _redis()
+        defence = CredentialThrottleDefence(redis_client_factory=lambda: redis)
+        outcome = defence.evaluate(_ctx(ip=""))
+
+        assert outcome.verdict == "pass"
+
+    def test_enumeration_safety_identical_verdict_regardless_of_identifier(self):
+        """Critical: the verdict depends on the per-IP counter ONLY.
+
+        The defence must not consult any user-account state. We pin
+        this behaviourally by checking that two evaluations with
+        wildly different identifiers but the same per-IP count
+        produce identical outcomes.
+        """
+        from icv_waf.forms.defences.credential_throttle import CredentialThrottleDefence
+
+        redis = _redis()
+        redis.get.return_value = b"25"
+        defence = CredentialThrottleDefence(redis_client_factory=lambda: redis)
+
+        # The defence doesn't even read the identifier from submitted_data —
+        # it has no API surface that would let it leak account existence.
+        # We verify by constructing two contexts with the same IP and
+        # asserting the outcome is byte-identical.
+        ctx_a = _ctx(ip="1.2.3.4")
+        ctx_b = _ctx(ip="1.2.3.4")
+        ctx_a.submitted_data["username"] = "admin"
+        ctx_b.submitted_data["username"] = "definitely_nonexistent_user"
+
+        outcome_a = defence.evaluate(ctx_a)
+        outcome_b = defence.evaluate(ctx_b)
+
+        assert outcome_a == outcome_b

--- a/tests/forms/test_decorator.py
+++ b/tests/forms/test_decorator.py
@@ -1,0 +1,185 @@
+"""Tests for the waf_protect_post view decorator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import RequestFactory
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _factory_with_user():
+    rf = RequestFactory()
+    return rf
+
+
+def _build_request(method, path, post=None):
+    rf = _factory_with_user()
+    if method == "POST":  # noqa: SIM108 — explicit branch reads clearer than nested ternary
+        request = rf.post(path, data=post or {})
+    else:
+        request = rf.get(path)
+    request.user = MagicMock(is_authenticated=False)
+    return request
+
+
+# ---------------------------------------------------------------------------
+# Decorator behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestDecorator:
+    def test_get_request_passes_through(self):
+        """GET requests don't trigger defence evaluation — render is
+        the template tag's job, not the decorator's."""
+        from icv_waf.forms.decorators import waf_protect_post
+
+        @waf_protect_post(
+            form_id="contact-get-test",
+            defences=("honeypot",),
+            redis_client_factory=lambda: _redis(),
+        )
+        def view(request):
+            return MagicMock(status_code=200)
+
+        request = _build_request("GET", "/contact/")
+        response = view(request)
+
+        assert response.status_code == 200
+
+    def test_clean_post_calls_view(self, settings):
+        """Honeypot empty → PASSED → view runs."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import waf_protect_post
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-clean-post",
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                response = MagicMock()
+                response.status_code = 200
+                response.__setitem__ = lambda self, k, v: None
+                return response
+
+            request = _build_request("POST", "/contact/", post={"name": "alice"})
+            response = view(request)
+
+        assert response.status_code == 200
+
+    def test_blocked_post_returns_403(self, settings):
+        """Filled honeypot → BLOCKED → 403, view not called."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import waf_protect_post
+        from icv_waf.forms.defences.honeypot import _pick_field_names
+
+        view_called = MagicMock()
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            form_id = "contact-blocked-post"
+
+            @waf_protect_post(
+                form_id=form_id,
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                view_called()
+                return MagicMock(status_code=200)
+
+            honeypot = _pick_field_names(form_id, conf_mod.ICV_WAF_FORM_HONEYPOT_FIELD_NAMES, 2)[0]
+            request = _build_request("POST", "/contact/", post={honeypot: "spam"})
+            response = view(request)
+
+        assert response.status_code == 403
+        view_called.assert_not_called()
+        # Generic body, no defence name leaked.
+        body = response.content.decode()
+        assert "honeypot" not in body
+        assert "rejected" in body.lower()
+
+    def test_decorator_registers_form_id_in_registry(self, settings):
+        """The template tag needs to find the FormProtection by form_id."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import _registry_get, waf_protect_post
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-registry-test",
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):  # noqa: ARG001
+                return MagicMock(status_code=200)
+
+        assert _registry_get("contact-registry-test") is not None
+        assert _registry_get("not-registered") is None
+
+
+# ---------------------------------------------------------------------------
+# X-WAF-Form-Verdict debug header
+# ---------------------------------------------------------------------------
+
+
+class TestDebugHeader:
+    def test_header_attached_in_debug(self, settings):
+        from django.http import HttpResponse
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import waf_protect_post
+
+        settings.DEBUG = True
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-debug-header",
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):  # noqa: ARG001
+                return HttpResponse("ok")
+
+            request = _build_request("POST", "/contact/", post={})
+            response = view(request)
+
+        # Header present, format pinned.
+        assert "X-WAF-Form-Verdict" in response
+        assert "passed" in response["X-WAF-Form-Verdict"]
+        assert "form_id=contact-debug-header" in response["X-WAF-Form-Verdict"]
+
+    def test_header_absent_in_production(self, settings):
+        from django.http import HttpResponse
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import waf_protect_post
+
+        settings.DEBUG = False
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-prod-header",
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):  # noqa: ARG001
+                return HttpResponse("ok")
+
+            request = _build_request("POST", "/contact/", post={})
+            response = view(request)
+
+        assert "X-WAF-Form-Verdict" not in response

--- a/tests/forms/test_defence_base.py
+++ b/tests/forms/test_defence_base.py
@@ -1,0 +1,163 @@
+"""Tests for the defence base contract.
+
+The contract itself is small but it underpins eight defences and the
+orchestrator. These tests pin the shapes (frozen, factory helpers,
+context defaults) so a future refactor can't silently change the
+public surface defences depend on.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Outcome dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestOutcome:
+    def test_outcome_is_frozen(self):
+        """Outcomes are frozen so a defence can't mutate after returning."""
+        from icv_waf.forms.defences.base import Outcome
+
+        outcome = Outcome(verdict="pass")
+        with pytest.raises((AttributeError, TypeError)):
+            outcome.verdict = "block"  # type: ignore[misc]
+
+    def test_default_score_is_zero(self):
+        from icv_waf.forms.defences.base import Outcome
+
+        assert Outcome(verdict="pass").score == 0.0
+
+    def test_default_reason_and_message_are_empty(self):
+        from icv_waf.forms.defences.base import Outcome
+
+        outcome = Outcome(verdict="flag")
+        assert outcome.reason == ""
+        assert outcome.public_message == ""
+
+
+class TestOutcomeFactories:
+    def test_passed_returns_pass_verdict(self):
+        from icv_waf.forms.defences.base import passed
+
+        outcome = passed()
+        assert outcome.verdict == "pass"
+        assert outcome.score == 0.0
+        assert outcome.reason == ""
+
+    def test_flagged_carries_score_and_reason(self):
+        from icv_waf.forms.defences.base import flagged
+
+        outcome = flagged(2.0, "time_trap:fast")
+        assert outcome.verdict == "flag"
+        assert outcome.score == 2.0
+        assert outcome.reason == "time_trap:fast"
+
+    def test_flagged_accepts_public_message(self):
+        from icv_waf.forms.defences.base import flagged
+
+        outcome = flagged(2.0, "x:y", public_message="please retry")
+        assert outcome.public_message == "please retry"
+
+    def test_blocked_defaults_score_to_zero(self):
+        """Most blocks short-circuit; recording a score is optional."""
+        from icv_waf.forms.defences.base import blocked
+
+        outcome = blocked("honeypot:url")
+        assert outcome.verdict == "block"
+        assert outcome.score == 0.0
+        assert outcome.reason == "honeypot:url"
+
+    def test_blocked_can_record_score(self):
+        from icv_waf.forms.defences.base import blocked
+
+        outcome = blocked("render_token:invalid", score=5.0)
+        assert outcome.score == 5.0
+
+
+# ---------------------------------------------------------------------------
+# RenderContext / EvaluateContext
+# ---------------------------------------------------------------------------
+
+
+class TestRenderContext:
+    def test_config_defaults_to_empty_dict(self):
+        from icv_waf.forms.defences.base import RenderContext
+
+        ctx = RenderContext(form_id="contact", request=object())
+        assert ctx.config == {}
+
+    def test_distinct_instances_have_distinct_config_dicts(self):
+        """Default factory must give each context its own dict.
+
+        A shared mutable default would leak state between forms — the
+        worst kind of test-flake source. Frozen dataclass + default_factory
+        avoids it but worth pinning behaviourally.
+        """
+        from icv_waf.forms.defences.base import RenderContext
+
+        a = RenderContext(form_id="a", request=object())
+        b = RenderContext(form_id="b", request=object())
+        assert a.config is not b.config
+
+    def test_context_is_frozen(self):
+        from icv_waf.forms.defences.base import RenderContext
+
+        ctx = RenderContext(form_id="contact", request=object())
+        with pytest.raises((AttributeError, TypeError)):
+            ctx.form_id = "other"  # type: ignore[misc]
+
+
+class TestEvaluateContext:
+    def test_token_payload_defaults_to_none(self):
+        """Defences that run before render_token verifies must see None
+        rather than a stale payload from a previous request."""
+        from icv_waf.forms.defences.base import EvaluateContext
+
+        ctx = EvaluateContext(form_id="contact", request=object(), submitted_data={})
+        assert ctx.token_payload is None
+
+    def test_submitted_data_is_required(self):
+        """Submitted data has no default — the orchestrator always
+        passes it. Pin so a future refactor doesn't introduce a
+        misleading empty default."""
+        from icv_waf.forms.defences.base import EvaluateContext
+
+        with pytest.raises(TypeError):
+            EvaluateContext(form_id="contact", request=object())  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# Defence protocol — structural compliance
+# ---------------------------------------------------------------------------
+
+
+class TestDefenceProtocol:
+    def test_minimal_defence_satisfies_protocol(self):
+        """A trivial defence with the right shape passes isinstance check.
+
+        Protocols don't enforce at construction time; the check is at
+        runtime via ``isinstance`` against a ``@runtime_checkable``
+        Protocol. We don't currently mark the base Protocol as
+        runtime-checkable (saves the registry overhead), so this test
+        instead asserts the duck-typing contract: an object with
+        ``name``, ``render_fields``, ``evaluate`` is what the
+        orchestrator will iterate over.
+        """
+        from icv_waf.forms.defences.base import EvaluateContext, RenderContext, passed
+
+        class Stub:
+            name = "stub"
+
+            def render_fields(self, ctx: RenderContext) -> dict:
+                return {}
+
+            def evaluate(self, ctx: EvaluateContext):
+                return passed()
+
+        stub = Stub()
+        assert stub.name == "stub"
+        assert stub.render_fields(RenderContext(form_id="c", request=object())) == {}
+        outcome = stub.evaluate(EvaluateContext(form_id="c", request=object(), submitted_data={}))
+        assert outcome.verdict == "pass"

--- a/tests/forms/test_honeypot_defence.py
+++ b/tests/forms/test_honeypot_defence.py
@@ -1,0 +1,234 @@
+"""Tests for HoneypotDefence.
+
+The simplest defence by mechanism but the one most likely to produce
+false positives if the rendered HTML is wrong (password manager
+autofill, accessibility-tool interaction). These tests pin the
+accessibility attributes alongside the verdict logic.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _ctx_render(form_id="contact", config=None):
+    from icv_waf.forms.defences.base import RenderContext
+
+    return RenderContext(form_id=form_id, request=MagicMock(), config=config or {})
+
+
+def _ctx_eval(submitted_data, form_id="contact", config=None):
+    from icv_waf.forms.defences.base import EvaluateContext
+
+    return EvaluateContext(
+        form_id=form_id,
+        request=MagicMock(),
+        submitted_data=submitted_data,
+        config=config or {},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field-name rotation
+# ---------------------------------------------------------------------------
+
+
+class TestFieldNameRotation:
+    def test_same_form_id_picks_same_names(self):
+        """Idempotent — must be stable across renders so caches don't break."""
+        from icv_waf.forms.defences.honeypot import _pick_field_names
+
+        pool = ["url", "website", "homepage", "email_confirm"]
+        a = _pick_field_names("contact", pool, 2)
+        b = _pick_field_names("contact", pool, 2)
+        assert a == b
+
+    def test_different_form_ids_can_pick_different_names(self):
+        """Some pair of form_ids in the pool must yield different selections.
+
+        We assert 'at least one pair differs' rather than 'every pair
+        differs' because a 4-element pool with 2-name picks has a
+        non-trivial collision rate by design.
+        """
+        from icv_waf.forms.defences.honeypot import _pick_field_names
+
+        pool = ["url", "website", "homepage", "email_confirm"]
+        picks = {fid: _pick_field_names(fid, pool, 2) for fid in ("a", "b", "c", "d", "e", "f")}
+        assert len({tuple(v) for v in picks.values()}) > 1
+
+    def test_empty_pool_returns_no_fields(self):
+        """An operator who configures an empty pool gets no honeypot."""
+        from icv_waf.forms.defences.honeypot import _pick_field_names
+
+        assert _pick_field_names("contact", [], 2) == []
+
+    def test_count_larger_than_pool_caps_at_pool_size(self):
+        """No duplicate names if the operator asks for more than the pool has."""
+        from icv_waf.forms.defences.honeypot import _pick_field_names
+
+        pool = ["a", "b"]
+        names = _pick_field_names("contact", pool, 10)
+        assert len(names) == len(pool)
+        assert len(set(names)) == len(names)
+
+
+# ---------------------------------------------------------------------------
+# render_fields
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFields:
+    def test_returns_hidden_inputs(self):
+        from icv_waf.forms.defences.honeypot import HoneypotDefence
+
+        defence = HoneypotDefence()
+        fields = defence.render_fields(_ctx_render())
+
+        assert "_waf_honeypot" in fields
+        html = fields["_waf_honeypot"]
+        assert html.count("<input") == 2  # default _FIELDS_PER_FORM
+
+    def test_html_includes_accessibility_attributes(self):
+        """Hidden inputs must have autocomplete=off, tabindex=-1, aria-label.
+
+        Pin behaviour — accessibility is non-negotiable and the
+        attributes are what make honeypots safe for screen reader
+        users.
+        """
+        from icv_waf.forms.defences.honeypot import HoneypotDefence
+
+        defence = HoneypotDefence()
+        html = defence.render_fields(_ctx_render())["_waf_honeypot"]
+
+        assert 'autocomplete="off"' in html
+        assert 'tabindex="-1"' in html
+        assert "aria-label=" in html
+
+    def test_uses_offscreen_positioning_not_display_none(self):
+        """`display:none` is what bots check for — must use off-screen instead."""
+        from icv_waf.forms.defences.honeypot import HoneypotDefence
+
+        defence = HoneypotDefence()
+        html = defence.render_fields(_ctx_render())["_waf_honeypot"]
+
+        assert "position:absolute" in html
+        assert "display:none" not in html
+
+    def test_unsafe_pool_names_are_silently_dropped(self):
+        """HTML-special characters in a pool name must NOT survive into the DOM.
+
+        We assert the structural characters are gone (no `<`, `>`,
+        `"`, `'`, `/` that could escape the input attribute or open a
+        new tag). The plain-letter remnants left behind by aggressive
+        stripping are harmless — they'd just produce a weirdly-named
+        input field.
+        """
+        from icv_waf.forms.defences.honeypot import HoneypotDefence
+
+        defence = HoneypotDefence()
+        html = defence.render_fields(_ctx_render(config={"field_names": ['"><script>alert(1)</script>']}))[
+            "_waf_honeypot"
+        ]
+
+        # No tag injection possible — these are the characters that
+        # would let the name field escape its attribute context.
+        for char in ('"', "'", "<", ">", "/", "\\"):
+            assert char not in _name_attribute_value(html), f"unsafe char {char!r} survived into name attribute"
+
+    def test_empty_pool_renders_no_fields(self):
+        from icv_waf.forms.defences.honeypot import HoneypotDefence
+
+        defence = HoneypotDefence()
+        fields = defence.render_fields(_ctx_render(config={"field_names": []}))
+
+        assert fields == {}
+
+
+def _name_attribute_value(html: str) -> str:
+    """Extract the substring inside name=\"...\" — what the browser sees."""
+    import re
+
+    m = re.search(r'name="([^"]*)"', html)
+    return m.group(1) if m else ""
+
+
+# ---------------------------------------------------------------------------
+# evaluate
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    def test_empty_honeypot_fields_pass(self):
+        """Default case — humans don't fill hidden fields."""
+        from icv_waf.forms.defences.honeypot import HoneypotDefence
+
+        defence = HoneypotDefence()
+        outcome = defence.evaluate(_ctx_eval({}))
+
+        assert outcome.verdict == "pass"
+
+    def test_any_filled_honeypot_field_blocks(self):
+        """Bot fills every input → the honeypot fields are non-empty → block."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.honeypot import HoneypotDefence, _pick_field_names
+
+        pool = conf_mod.ICV_WAF_FORM_HONEYPOT_FIELD_NAMES
+        names = _pick_field_names("contact", pool, 2)
+        defence = HoneypotDefence()
+        # Simulate a bot filling the first honeypot.
+        outcome = defence.evaluate(_ctx_eval({names[0]: "spam value"}))
+
+        assert outcome.verdict == "block"
+        assert outcome.reason == f"honeypot:{names[0]}"
+        assert outcome.score == 5.0
+
+    def test_reason_carries_specific_field_name(self):
+        """Operators tune the pool when one name keeps tripping —
+        the reason needs the specific field name."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.honeypot import HoneypotDefence, _pick_field_names
+
+        pool = conf_mod.ICV_WAF_FORM_HONEYPOT_FIELD_NAMES
+        names = _pick_field_names("contact", pool, 2)
+        defence = HoneypotDefence()
+
+        # Fill the second honeypot, not the first.
+        outcome = defence.evaluate(_ctx_eval({names[1]: "spam"}))
+
+        assert outcome.reason == f"honeypot:{names[1]}"
+
+    def test_whitespace_only_value_is_not_a_block(self):
+        """A field whose value is whitespace-only is treated as empty.
+
+        Some browsers / autofill tools insert a single space. Don't
+        block on that; the real signal is meaningful content.
+        """
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.honeypot import HoneypotDefence, _pick_field_names
+
+        pool = conf_mod.ICV_WAF_FORM_HONEYPOT_FIELD_NAMES
+        names = _pick_field_names("contact", pool, 2)
+        defence = HoneypotDefence()
+        outcome = defence.evaluate(_ctx_eval({names[0]: ""}))
+
+        assert outcome.verdict == "pass"
+
+    def test_filled_field_not_in_this_forms_pool_is_ignored(self):
+        """A POST containing a value under a name that ISN'T this form's
+        honeypot must pass — bots that submit a global field set would
+        otherwise always be blocked, which is the desired behaviour for
+        the configured names, but unrelated form fields with the same
+        name shouldn't accidentally trip the defence."""
+        from icv_waf.forms.defences.honeypot import HoneypotDefence
+
+        defence = HoneypotDefence()
+        # Custom pool of one unused name — the defence picks 'unused' as
+        # the honeypot. A POST with 'something_else' should not match.
+        outcome = defence.evaluate(
+            _ctx_eval(
+                {"something_else": "totally unrelated"},
+                config={"field_names": ["unused_field"]},
+            )
+        )
+
+        assert outcome.verdict == "pass"

--- a/tests/forms/test_js_touch_defence.py
+++ b/tests/forms/test_js_touch_defence.py
@@ -1,0 +1,135 @@
+"""Tests for JsTouchDefence."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _ctx_render(form_id="c", config=None):
+    from icv_waf.forms.defences.base import RenderContext
+
+    return RenderContext(form_id=form_id, request=MagicMock(), config=config or {})
+
+
+def _ctx_eval(submitted_data, *, payload_nonce=None, config=None):
+    """Build EvaluateContext. payload_nonce sets ctx.token_payload.nonce."""
+    from icv_waf.forms.defences.base import EvaluateContext
+
+    payload = None
+    if payload_nonce is not None:
+        payload = MagicMock()
+        payload.nonce = payload_nonce
+
+    return EvaluateContext(
+        form_id="c",
+        request=MagicMock(),
+        submitted_data=submitted_data,
+        config=config or {},
+        token_payload=payload,
+    )
+
+
+class TestRenderFields:
+    def test_renders_hidden_field_with_sentinel(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.js_touch import FIELD_NAME, JsTouchDefence
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = JsTouchDefence()
+            html = defence.render_fields(_ctx_render())[FIELD_NAME]
+
+        assert f'name="{FIELD_NAME}"' in html
+        assert 'value="unset"' in html
+        assert "aria-hidden=" in html
+        assert "tabindex=" in html
+
+    def test_includes_inline_script_that_clears_sentinel(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.js_touch import FIELD_NAME, JsTouchDefence
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = JsTouchDefence()
+            html = defence.render_fields(_ctx_render())[FIELD_NAME]
+
+        # The script must reference the input and reassign its value.
+        assert "<script" in html
+        assert "_waf_js_touch_input" in html
+        assert ".value=" in html
+
+    def test_uses_offscreen_positioning_not_display_none(self, settings):
+        """Same accessibility-friendly hiding pattern as honeypot."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.js_touch import FIELD_NAME, JsTouchDefence
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = JsTouchDefence()
+            html = defence.render_fields(_ctx_render())[FIELD_NAME]
+
+        assert "position:absolute" in html
+        assert "display:none" not in html
+
+
+class TestEvaluate:
+    def test_sentinel_unchanged_flags(self, settings):
+        """JS didn't run → field is still 'unset' → flag."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.js_touch import FIELD_NAME, JsTouchDefence
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = JsTouchDefence()
+            outcome = defence.evaluate(_ctx_eval({FIELD_NAME: "unset"}, payload_nonce="n"))
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "js_touch:not_set"
+        assert outcome.score == 1.5
+
+    def test_correct_value_passes(self, settings):
+        """Browser executed the script → field contains the expected MAC → pass."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.js_touch import FIELD_NAME, JsTouchDefence, _expected_value
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = JsTouchDefence()
+            expected = _expected_value("nonce-xyz")
+            outcome = defence.evaluate(_ctx_eval({FIELD_NAME: expected}, payload_nonce="nonce-xyz"))
+
+        assert outcome.verdict == "pass"
+
+    def test_missing_field_flags(self, settings):
+        """Field entirely absent → suspicious (hand-crafted POST)."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.js_touch import JsTouchDefence
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = JsTouchDefence()
+            outcome = defence.evaluate(_ctx_eval({}, payload_nonce="n"))
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "js_touch:missing"
+
+    def test_arbitrary_value_flags(self, settings):
+        """A non-empty value that isn't the correct MAC → bot wrote junk."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.js_touch import FIELD_NAME, JsTouchDefence
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = JsTouchDefence()
+            outcome = defence.evaluate(_ctx_eval({FIELD_NAME: "definitely-not-the-right-value"}, payload_nonce="n"))
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "js_touch:invalid"
+
+    def test_expected_value_is_signing_key_dependent(self, settings):
+        """Same nonce + different signing keys → different expected values.
+
+        Otherwise a bot could compute the expected value once and reuse.
+        """
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.js_touch import _expected_value
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "key-a"):
+            value_a = _expected_value("same-nonce")
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "key-b"):
+            value_b = _expected_value("same-nonce")
+
+        assert value_a != value_b

--- a/tests/forms/test_logging.py
+++ b/tests/forms/test_logging.py
@@ -1,0 +1,205 @@
+"""Tests for the structured-logging + signal-dispatch layer."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _request():
+    req = MagicMock()
+    req.META = {"REMOTE_ADDR": "1.2.3.4", "HTTP_USER_AGENT": "Mozilla/5.0"}
+    req.user = MagicMock(is_authenticated=False)
+    return req
+
+
+def _result(verdict, outcomes=None, total_score=0.0):
+    from icv_waf.forms.protection import FormEvaluationResult, FormVerdict
+
+    return FormEvaluationResult(
+        verdict=FormVerdict(verdict),
+        total_score=total_score,
+        outcomes=outcomes or [],
+        token_payload=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Structured logging
+# ---------------------------------------------------------------------------
+
+
+class TestLogging:
+    def test_blocked_emits_warning_with_payload(self, settings, caplog):
+        import logging as stdlib_logging
+
+        from icv_waf.forms.defences.base import Outcome
+        from icv_waf.forms.logging import log_form_submission
+
+        outcomes = [Outcome(verdict="block", score=5.0, reason="honeypot:url")]
+        with caplog.at_level(stdlib_logging.WARNING, logger="icv_waf.forms"):
+            log_form_submission(form_id="c", request=_request(), result=_result("blocked", outcomes, 5.0))
+
+        # One record, level WARNING, structured payload attached.
+        records = [r for r in caplog.records if r.message == "waf.form_submission"]
+        assert len(records) == 1
+        record = records[0]
+        assert record.levelno == stdlib_logging.WARNING
+        assert record.verdict == "blocked"
+        assert record.form_id == "c"
+        assert record.ip == "1.2.3.4"
+        assert record.defences[0]["reason"] == "honeypot:url"
+
+    def test_flagged_emits_info(self, settings, caplog):
+        import logging as stdlib_logging
+
+        from icv_waf.forms.defences.base import Outcome
+        from icv_waf.forms.logging import log_form_submission
+
+        outcomes = [Outcome(verdict="flag", score=2.0, reason="time_trap:fast")]
+        with caplog.at_level(stdlib_logging.INFO, logger="icv_waf.forms"):
+            log_form_submission(form_id="c", request=_request(), result=_result("flagged", outcomes, 2.0))
+
+        records = [r for r in caplog.records if r.message == "waf.form_submission"]
+        assert any(r.levelno == stdlib_logging.INFO for r in records)
+
+    def test_passed_sampled_by_log_sample_rate(self, settings, caplog):
+        """ICV_WAF_LOG_SAMPLE_RATE controls how often PASSED logs.
+
+        With rate=0.0, no PASSED log entries are emitted.
+        """
+        import logging as stdlib_logging
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.logging import log_form_submission
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_LOG_SAMPLE_RATE", 0.0),
+            caplog.at_level(stdlib_logging.INFO, logger="icv_waf.forms"),
+        ):
+            for _ in range(10):
+                log_form_submission(form_id="c", request=_request(), result=_result("passed"))
+
+        # No log entries — sampling suppressed all of them.
+        records = [r for r in caplog.records if r.message == "waf.form_submission"]
+        assert records == []
+
+
+# ---------------------------------------------------------------------------
+# Signal dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSignals:
+    def test_blocked_signal_fires_with_reason(self):
+        from icv_waf.forms.defences.base import Outcome
+        from icv_waf.forms.logging import log_form_submission
+        from icv_waf.forms.signals import form_submission_blocked
+
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        form_submission_blocked.connect(handler, dispatch_uid="test_blocked")
+        try:
+            outcomes = [Outcome(verdict="block", score=5.0, reason="honeypot:url")]
+            log_form_submission(form_id="c", request=_request(), result=_result("blocked", outcomes, 5.0))
+        finally:
+            form_submission_blocked.disconnect(dispatch_uid="test_blocked")
+
+        assert len(received) == 1
+        assert received[0]["form_id"] == "c"
+        assert received[0]["reason"] == "honeypot:url"
+
+    def test_flagged_signal_fires(self):
+        from icv_waf.forms.defences.base import Outcome
+        from icv_waf.forms.logging import log_form_submission
+        from icv_waf.forms.signals import form_submission_flagged
+
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        form_submission_flagged.connect(handler, dispatch_uid="test_flagged")
+        try:
+            outcomes = [Outcome(verdict="flag", score=2.0, reason="time_trap:fast")]
+            log_form_submission(form_id="c", request=_request(), result=_result("flagged", outcomes, 2.0))
+        finally:
+            form_submission_flagged.disconnect(dispatch_uid="test_flagged")
+
+        assert len(received) == 1
+        assert received[0]["total_score"] == 2.0
+
+    def test_passed_signal_off_by_default(self, settings):
+        """ICV_WAF_FORM_EMIT_PASSED_SIGNAL=False → no signal for PASSED."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.logging import log_form_submission
+        from icv_waf.forms.signals import form_submission_passed
+
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        form_submission_passed.connect(handler, dispatch_uid="test_passed_off")
+        try:
+            with (
+                patch.object(conf_mod, "ICV_WAF_FORM_EMIT_PASSED_SIGNAL", False),
+                patch.object(conf_mod, "ICV_WAF_LOG_SAMPLE_RATE", 1.0),
+            ):
+                log_form_submission(form_id="c", request=_request(), result=_result("passed"))
+        finally:
+            form_submission_passed.disconnect(dispatch_uid="test_passed_off")
+
+        assert received == []
+
+    def test_passed_signal_opt_in(self, settings):
+        """ICV_WAF_FORM_EMIT_PASSED_SIGNAL=True → signal fires."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.logging import log_form_submission
+        from icv_waf.forms.signals import form_submission_passed
+
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        form_submission_passed.connect(handler, dispatch_uid="test_passed_on")
+        try:
+            with (
+                patch.object(conf_mod, "ICV_WAF_FORM_EMIT_PASSED_SIGNAL", True),
+                patch.object(conf_mod, "ICV_WAF_LOG_SAMPLE_RATE", 1.0),
+            ):
+                log_form_submission(form_id="c", request=_request(), result=_result("passed"))
+        finally:
+            form_submission_passed.disconnect(dispatch_uid="test_passed_on")
+
+        assert len(received) == 1
+
+    def test_signal_receiver_exception_does_not_propagate(self):
+        """A misbehaving receiver must NOT break the request lifecycle."""
+        from icv_waf.forms.defences.base import Outcome
+        from icv_waf.forms.logging import log_form_submission
+        from icv_waf.forms.signals import form_submission_blocked
+
+        def broken_handler(sender, **kwargs):
+            raise RuntimeError("receiver bug")
+
+        form_submission_blocked.connect(broken_handler, dispatch_uid="test_broken")
+        try:
+            outcomes = [Outcome(verdict="block", score=5.0, reason="honeypot:url")]
+            # Must NOT raise.
+            log_form_submission(form_id="c", request=_request(), result=_result("blocked", outcomes, 5.0))
+        finally:
+            form_submission_blocked.disconnect(dispatch_uid="test_broken")

--- a/tests/forms/test_markers.py
+++ b/tests/forms/test_markers.py
@@ -1,0 +1,86 @@
+"""Tests for the form-token Redis marker service.
+
+Markers are the load-bearing primitive for replay protection. The
+"delete only on PASS" rule (see PRD §4.3) is what makes HTMX
+re-renders work — these tests pin that rule so a future change to the
+orchestrator can't quietly regress the semantics.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _redis():
+    """Return a Redis MagicMock with the methods the marker service uses."""
+    r = MagicMock(name="redis")
+    r.exists.return_value = 0
+    return r
+
+
+class TestIssueMarker:
+    def test_setex_called_with_namespaced_key_and_ttl(self):
+        from icv_waf.forms.services.markers import issue_marker
+
+        r = _redis()
+        issue_marker(r, nonce="abc", ttl_seconds=3600)
+
+        r.setex.assert_called_once_with("waf:form:token:abc", 3600, "1")
+
+    def test_distinct_nonces_use_distinct_keys(self):
+        from icv_waf.forms.services.markers import issue_marker
+
+        r = _redis()
+        issue_marker(r, nonce="aaa", ttl_seconds=60)
+        issue_marker(r, nonce="bbb", ttl_seconds=60)
+
+        keys = [c.args[0] for c in r.setex.call_args_list]
+        assert keys == ["waf:form:token:aaa", "waf:form:token:bbb"]
+
+
+class TestMarkerExists:
+    def test_returns_true_when_redis_exists_returns_one(self):
+        from icv_waf.forms.services.markers import marker_exists
+
+        r = _redis()
+        r.exists.return_value = 1
+
+        assert marker_exists(r, "abc") is True
+        r.exists.assert_called_once_with("waf:form:token:abc")
+
+    def test_returns_false_when_redis_exists_returns_zero(self):
+        from icv_waf.forms.services.markers import marker_exists
+
+        r = _redis()
+        r.exists.return_value = 0
+
+        assert marker_exists(r, "abc") is False
+
+    def test_returns_false_for_none_response(self):
+        """Defensive — some Redis clients return None instead of 0."""
+        from icv_waf.forms.services.markers import marker_exists
+
+        r = _redis()
+        r.exists.return_value = None
+
+        assert marker_exists(r, "abc") is False
+
+
+class TestConsumeMarker:
+    def test_delete_called_with_namespaced_key(self):
+        from icv_waf.forms.services.markers import consume_marker
+
+        r = _redis()
+        consume_marker(r, "abc")
+
+        r.delete.assert_called_once_with("waf:form:token:abc")
+
+    def test_consume_does_not_touch_other_redis_state(self):
+        """Marker consumption must NOT trigger setex or exists calls."""
+        from icv_waf.forms.services.markers import consume_marker
+
+        r = _redis()
+        consume_marker(r, "abc")
+
+        r.setex.assert_not_called()
+        r.exists.assert_not_called()

--- a/tests/forms/test_mixin.py
+++ b/tests/forms/test_mixin.py
@@ -1,0 +1,253 @@
+"""Tests for ProtectedForm mixin.
+
+The mixin's job is small: wire the orchestrator to Django Form's
+lifecycle. These tests pin the contract (request kwarg required,
+clean raises on BLOCKED, waf_result available on FLAGGED, waf_fields
+renders).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django import forms
+from django.core.exceptions import ImproperlyConfigured
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _request():
+    req = MagicMock()
+    req.META = {"REMOTE_ADDR": "1.2.3.4", "HTTP_USER_AGENT": "Mozilla/5.0"}
+    req.user = MagicMock(is_authenticated=False)
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Subclass-time enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestSubclassEnforcement:
+    def test_missing_waf_attribute_raises(self):
+        """A subclass without `waf` must raise at class-definition time."""
+        from icv_waf.forms.mixin import ProtectedForm
+
+        with pytest.raises(ImproperlyConfigured, match="`waf` attribute"):
+
+            class Bad(ProtectedForm, forms.Form):
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Construction contract
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def _build_form_class(self):
+        """Build a ContactForm with a real FormProtection wired up."""
+        from icv_waf.forms.mixin import ProtectedForm
+        from icv_waf.forms.protection import FormProtection
+
+        redis = _redis()
+
+        class ContactForm(ProtectedForm, forms.Form):
+            name = forms.CharField()
+            waf = FormProtection(
+                form_id="contact",
+                defences=("honeypot",),
+                redis_client_factory=lambda: redis,
+            )
+
+        return ContactForm, redis
+
+    def test_missing_request_kwarg_raises(self):
+        ContactForm, _ = self._build_form_class()
+
+        with pytest.raises(ImproperlyConfigured, match="request"):
+            ContactForm(data={"name": "alice"})
+
+    def test_request_kwarg_stored(self):
+        ContactForm, _ = self._build_form_class()
+        req = _request()
+
+        form = ContactForm(data={"name": "alice"}, request=req)
+        assert form._waf_request is req
+
+
+# ---------------------------------------------------------------------------
+# waf_fields rendering
+# ---------------------------------------------------------------------------
+
+
+class TestWafFields:
+    def test_renders_honeypot_html(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.mixin import ProtectedForm
+        from icv_waf.forms.protection import FormProtection
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            redis = _redis()
+
+            class ContactForm(ProtectedForm, forms.Form):
+                name = forms.CharField(required=False)
+                waf = FormProtection(
+                    form_id="c",
+                    defences=("honeypot",),
+                    redis_client_factory=lambda: redis,
+                )
+
+            form = ContactForm(request=_request())
+            html = form.waf_fields
+
+        assert "<input" in html
+        assert "position:absolute" in html
+
+    def test_renders_empty_when_master_switch_off(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.mixin import ProtectedForm
+        from icv_waf.forms.protection import FormProtection
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"),
+            patch.object(conf_mod, "ICV_WAF_FORM_PROTECTION_ENABLED", False),
+        ):
+            redis = _redis()
+
+            class ContactForm(ProtectedForm, forms.Form):
+                waf = FormProtection(
+                    form_id="c",
+                    defences=("honeypot",),
+                    redis_client_factory=lambda: redis,
+                )
+
+            form = ContactForm(request=_request())
+            assert form.waf_fields == ""
+
+
+# ---------------------------------------------------------------------------
+# clean() verdict dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestClean:
+    def _form_class(self, defences=("honeypot",)):
+        from icv_waf.forms.mixin import ProtectedForm
+        from icv_waf.forms.protection import FormProtection
+
+        # Patch is applied by callers; the form needs a signing key
+        # to render or evaluate render_token.
+        redis = _redis()
+
+        class TestForm(ProtectedForm, forms.Form):
+            name = forms.CharField()
+            waf = FormProtection(
+                form_id="c",
+                defences=defences,
+                redis_client_factory=lambda: redis,
+            )
+
+        return TestForm, redis
+
+    def test_blocked_verdict_raises_validation_error(self, settings):
+        """Honeypot field filled → BLOCKED → ValidationError on clean."""
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            ContactForm, _ = self._form_class()
+            # Find the honeypot field name and fill it.
+            from icv_waf.forms.defences.honeypot import _pick_field_names
+
+            honeypot_name = _pick_field_names("c", conf_mod.ICV_WAF_FORM_HONEYPOT_FIELD_NAMES, 2)[0]
+
+            form = ContactForm(
+                data={"name": "alice", honeypot_name: "spam"},
+                request=_request(),
+            )
+            assert form.is_valid() is False
+            # The non-field errors should mention the generic message.
+            non_field = form.non_field_errors()
+            assert any("rejected" in str(e).lower() for e in non_field)
+
+    def test_passed_verdict_validates_normally(self, settings):
+        """Clean honeypot → no validation error from the mixin."""
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            ContactForm, _ = self._form_class()
+
+            form = ContactForm(data={"name": "alice"}, request=_request())
+            assert form.is_valid()
+
+    def test_waf_result_populated_after_clean(self, settings):
+        """The view code reads form.waf_result to decide on FLAGGED handling."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            ContactForm, _ = self._form_class()
+            form = ContactForm(data={"name": "alice"}, request=_request())
+            form.is_valid()  # triggers clean
+
+        assert form.waf_result is not None
+        assert form.waf_result.verdict == FormVerdict.PASSED
+
+    def test_blocked_message_does_not_leak_defence_name(self, settings):
+        """Pin enumeration-safety: the user-visible message must not
+        say WHICH defence fired. Operators see the detail in the log."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.honeypot import _pick_field_names
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            ContactForm, _ = self._form_class()
+            honeypot = _pick_field_names("c", conf_mod.ICV_WAF_FORM_HONEYPOT_FIELD_NAMES, 2)[0]
+            form = ContactForm(data={"name": "alice", honeypot: "spam"}, request=_request())
+            form.is_valid()
+
+            for err in form.non_field_errors():
+                # No defence name should appear in the user-facing message.
+                for name in (
+                    "honeypot",
+                    "render_token",
+                    "time_trap",
+                    "ua_consistency",
+                    "js_touch",
+                    "credential_throttle",
+                    "signup_velocity",
+                    "pow_gate",
+                ):
+                    assert name not in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Public exports
+# ---------------------------------------------------------------------------
+
+
+class TestPublicExports:
+    def test_public_api_surface(self):
+        """The top-level package exposes the documented entry points."""
+        import icv_waf.forms as forms_pkg
+
+        # Names match PRD §2.3 and the public API table.
+        for name in (
+            "FormProtection",
+            "FormVerdict",
+            "FormEvaluationResult",
+            "ProtectedForm",
+            "form_submission_passed",
+            "form_submission_flagged",
+            "form_submission_blocked",
+            "credential_attack_observed",
+        ):
+            assert hasattr(forms_pkg, name), f"icv_waf.forms missing public name {name!r}"

--- a/tests/forms/test_orchestrator.py
+++ b/tests/forms/test_orchestrator.py
@@ -1,0 +1,391 @@
+"""Tests for the FormProtection orchestrator.
+
+Covers:
+* defence chain construction + canonical ordering
+* render_fields collects from every defence + threads token_nonce
+* evaluate runs chain in order + threads token_payload onto contexts
+* block short-circuits the chain
+* score aggregation crosses FLAG / BLOCK thresholds at the right
+  points
+* skip_for_authenticated short-circuits to render_token only
+* consume_token_marker is the PASS-only consume path
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _request(*, ip="1.2.3.4", ua="Mozilla/5.0", user=None):
+    req = MagicMock()
+    req.META = {"REMOTE_ADDR": ip, "HTTP_USER_AGENT": ua}
+    req.user = user or MagicMock(is_authenticated=False)
+    return req
+
+
+# ---------------------------------------------------------------------------
+# Construction + ordering
+# ---------------------------------------------------------------------------
+
+
+class TestConstruction:
+    def test_defences_ordered_canonically(self, settings):
+        """Operators may pass defences in any order; the chain runs
+        in canonical order so render_token always goes first."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            protection = FormProtection(
+                form_id="c",
+                defences=("pow_gate", "honeypot", "render_token"),
+                redis_client_factory=lambda: _redis(),
+            )
+
+        assert protection.defence_names == ("render_token", "honeypot", "pow_gate")
+
+    def test_unknown_defence_raises_at_construction(self):
+        import pytest
+
+        from icv_waf.forms.protection import FormProtection
+
+        with pytest.raises(ValueError, match="unknown defence"):
+            FormProtection(form_id="c", defences=("doesnt_exist",))
+
+    def test_redis_defence_without_factory_raises(self):
+        """A defence that needs Redis (render_token, credential_throttle,
+        signup_velocity) without a factory must surface at construction
+        — not silently fail at first render."""
+
+        from icv_waf.forms.protection import FormProtection
+
+        # We can't currently construct without a factory because
+        # _default_redis_factory always returns something (or None).
+        # Pin the explicit-None behaviour by passing a factory that
+        # returns None.
+        protection = FormProtection(
+            form_id="c",
+            defences=("honeypot",),  # no Redis defence — should work
+            redis_client_factory=lambda: None,
+        )
+        # Sanity: honeypot constructs fine even with None factory.
+        assert "honeypot" in protection.defence_names
+
+
+# ---------------------------------------------------------------------------
+# render_fields
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFields:
+    def test_collects_fields_from_every_defence(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            redis = _redis()
+            protection = FormProtection(
+                form_id="contact",
+                defences=("render_token", "honeypot", "js_touch", "pow_gate"),
+                redis_client_factory=lambda: redis,
+            )
+            fields = protection.render_fields(_request())
+
+        # Token, honeypot, js_touch, pow_gate all contribute keys.
+        assert "waf_token" in fields
+        assert "_waf_honeypot" in fields
+        assert "waf_js_touch" in fields
+        assert "waf_pow_nonce" in fields
+
+    def test_master_switch_short_circuits_to_empty(self, settings):
+        """ICV_WAF_FORM_PROTECTION_ENABLED=False → no fields rendered."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"),
+            patch.object(conf_mod, "ICV_WAF_FORM_PROTECTION_ENABLED", False),
+        ):
+            protection = FormProtection(
+                form_id="c",
+                defences=("render_token", "honeypot"),
+                redis_client_factory=lambda: _redis(),
+            )
+            fields = protection.render_fields(_request())
+
+        assert fields == {}
+
+    def test_skip_for_authenticated_renders_only_render_token(self, settings):
+        """In-product forms (skip_for_authenticated=True) drop spam
+        defences when the user is logged in but keep render_token for
+        integrity."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection
+
+        authed = MagicMock(is_authenticated=True, pk=42)
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            protection = FormProtection(
+                form_id="c",
+                defences=("render_token", "honeypot", "js_touch"),
+                skip_for_authenticated=True,
+                redis_client_factory=lambda: _redis(),
+            )
+            fields = protection.render_fields(_request(user=authed))
+
+        # render_token present, honeypot + js_touch absent.
+        assert "waf_token" in fields
+        assert "_waf_honeypot" not in fields
+        assert "waf_js_touch" not in fields
+
+    def test_skip_for_authenticated_runs_full_chain_for_anonymous(self, settings):
+        """Anonymous users always get the full chain regardless of the flag."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection
+
+        anon = MagicMock(is_authenticated=False)
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            protection = FormProtection(
+                form_id="c",
+                defences=("render_token", "honeypot"),
+                skip_for_authenticated=True,
+                redis_client_factory=lambda: _redis(),
+            )
+            fields = protection.render_fields(_request(user=anon))
+
+        assert "_waf_honeypot" in fields
+
+
+# ---------------------------------------------------------------------------
+# evaluate — chain wiring
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    def test_all_pass_returns_passed_verdict(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection, FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            redis = _redis()
+            protection = FormProtection(
+                form_id="c",
+                defences=("render_token", "honeypot"),
+                redis_client_factory=lambda: redis,
+            )
+            # Render to get a valid token.
+            fields = protection.render_fields(_request())
+            token = fields["waf_token"]
+
+            result = protection.evaluate(
+                _request(),
+                submitted_data={"waf_token": token},
+            )
+
+        assert result.verdict == FormVerdict.PASSED
+        assert result.total_score == 0.0
+
+    def test_block_short_circuits_chain(self, settings):
+        """A defence returning block must stop later defences from running."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection, FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            redis = _redis()
+            protection = FormProtection(
+                form_id="c",
+                # Bad token → render_token blocks → honeypot never runs.
+                defences=("render_token", "honeypot"),
+                redis_client_factory=lambda: redis,
+            )
+
+            result = protection.evaluate(
+                _request(),
+                submitted_data={"waf_token": "garbage"},
+            )
+
+        assert result.verdict == FormVerdict.BLOCKED
+        # Only render_token ran; chain short-circuited before honeypot.
+        assert len(result.outcomes) == 1
+        assert result.outcomes[0].reason == "render_token:invalid"
+
+    def test_token_payload_threaded_to_later_defences(self, settings):
+        """After render_token verifies, time_trap should see the payload."""
+        from datetime import UTC, datetime, timedelta
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection, FormVerdict
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            redis = _redis()
+            # Forge a token rendered 0.1s ago → time_trap should block on too_fast.
+            old = datetime.now(tz=UTC) - timedelta(seconds=0.1)
+            token, _ = issue_token(form_id="c", ip="1.2.3.4", render_time=old, user_agent="Mozilla/5.0")
+            protection = FormProtection(
+                form_id="c",
+                defences=("render_token", "time_trap"),
+                redis_client_factory=lambda: redis,
+            )
+            result = protection.evaluate(
+                _request(),
+                submitted_data={"waf_token": token},
+            )
+
+        # time_trap fired with too_fast because it saw the payload's render_time.
+        assert result.verdict == FormVerdict.BLOCKED
+        assert any(o.reason == "time_trap:too_fast" for o in result.outcomes)
+
+    def test_master_switch_short_circuits_to_passed(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection, FormVerdict
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"),
+            patch.object(conf_mod, "ICV_WAF_FORM_PROTECTION_ENABLED", False),
+        ):
+            protection = FormProtection(
+                form_id="c",
+                defences=("render_token", "honeypot"),
+                redis_client_factory=lambda: _redis(),
+            )
+            result = protection.evaluate(_request(), submitted_data={})
+
+        assert result.verdict == FormVerdict.PASSED
+
+    def test_defence_exception_treated_as_pass(self, settings):
+        """A buggy defence must NOT lock users out. The orchestrator
+        catches and logs, then treats the outcome as a silent pass."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection, FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            protection = FormProtection(
+                form_id="c",
+                defences=("honeypot",),  # only honeypot, no Redis dep
+                redis_client_factory=lambda: _redis(),
+            )
+            # Inject a defence that raises.
+            broken = MagicMock()
+            broken.name = "honeypot"
+            broken.evaluate.side_effect = RuntimeError("bug in defence")
+            protection._defences["honeypot"] = broken
+
+            result = protection.evaluate(_request(), submitted_data={})
+
+        assert result.verdict == FormVerdict.PASSED
+
+
+# ---------------------------------------------------------------------------
+# Score aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestScoreAggregation:
+    def _protection(self):
+        from icv_waf.forms.protection import FormProtection
+
+        return FormProtection(
+            form_id="c",
+            defences=("honeypot",),
+            redis_client_factory=lambda: _redis(),
+        )
+
+    def test_sub_flag_threshold_passes(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_FORM_FLAG_THRESHOLD", 2.0):
+            assert self._protection()._resolve_verdict(1.5) == FormVerdict.PASSED
+
+    def test_crossing_flag_threshold_returns_flagged(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormVerdict
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_FORM_FLAG_THRESHOLD", 2.0),
+            patch.object(conf_mod, "ICV_WAF_FORM_BLOCK_THRESHOLD", 5.0),
+        ):
+            assert self._protection()._resolve_verdict(3.0) == FormVerdict.FLAGGED
+
+    def test_crossing_block_threshold_returns_blocked(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_FORM_BLOCK_THRESHOLD", 5.0):
+            assert self._protection()._resolve_verdict(6.0) == FormVerdict.BLOCKED
+
+    def test_exact_threshold_value_crosses_inclusive(self, settings):
+        """Pin >= semantics — operators tune thresholds expecting
+        inclusive behaviour."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_FORM_FLAG_THRESHOLD", 2.0):
+            assert self._protection()._resolve_verdict(2.0) == FormVerdict.FLAGGED
+
+
+# ---------------------------------------------------------------------------
+# Marker consumption
+# ---------------------------------------------------------------------------
+
+
+class TestMarkerConsumption:
+    def test_consume_calls_delete_on_redis(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            redis = _redis()
+            protection = FormProtection(
+                form_id="c",
+                defences=("honeypot",),
+                redis_client_factory=lambda: redis,
+            )
+
+            payload = MagicMock()
+            payload.nonce = "abc123"
+            protection.consume_token_marker(payload)
+
+        redis.delete.assert_called_once_with("waf:form:token:abc123")
+
+    def test_consume_with_none_payload_is_noop(self):
+        from icv_waf.forms.protection import FormProtection
+
+        redis = _redis()
+        protection = FormProtection(
+            form_id="c",
+            defences=("honeypot",),
+            redis_client_factory=lambda: redis,
+        )
+        protection.consume_token_marker(None)
+
+        redis.delete.assert_not_called()
+
+    def test_consume_swallows_redis_errors(self):
+        """Marker consume failures must not propagate — the form has
+        already been processed; failing here would surface to the
+        user as a 500."""
+        from icv_waf.forms.protection import FormProtection
+
+        redis = _redis()
+        redis.delete.side_effect = RuntimeError("redis down")
+        protection = FormProtection(
+            form_id="c",
+            defences=("honeypot",),
+            redis_client_factory=lambda: redis,
+        )
+
+        payload = MagicMock()
+        payload.nonce = "abc"
+        # Must not raise.
+        protection.consume_token_marker(payload)

--- a/tests/forms/test_pow_gate_defence.py
+++ b/tests/forms/test_pow_gate_defence.py
@@ -1,0 +1,184 @@
+"""Tests for PowGateDefence."""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import MagicMock
+
+
+def _ctx_render(form_id="contact", config=None):
+    from icv_waf.forms.defences.base import RenderContext
+
+    return RenderContext(form_id=form_id, request=MagicMock(), config=config or {})
+
+
+def _ctx_eval(submitted_data, *, payload_nonce=None, config=None):
+    from icv_waf.forms.defences.base import EvaluateContext
+
+    payload = None
+    if payload_nonce is not None:
+        payload = MagicMock()
+        payload.nonce = payload_nonce
+
+    return EvaluateContext(
+        form_id="contact",
+        request=MagicMock(),
+        submitted_data=submitted_data,
+        config=config or {},
+        token_payload=payload,
+    )
+
+
+def _solve(token_nonce: str, difficulty: int) -> str:
+    """Brute-force a candidate nonce that satisfies the PoW.
+
+    Used in tests to construct valid submissions. Matches the
+    defence's hash construction exactly.
+    """
+    from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+    for n in range(1_000_000):
+        msg = f"{token_nonce}:{n}".encode()
+        if _digest_has_leading_zero_bits(hashlib.sha256(msg).digest(), difficulty):
+            return str(n)
+    raise RuntimeError("could not solve PoW in 1M iterations — test set difficulty too high")
+
+
+# ---------------------------------------------------------------------------
+# render_fields
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFields:
+    def test_renders_nonce_field_and_script(self):
+        from icv_waf.forms.defences.pow_gate import NONCE_FIELD, PowGateDefence
+
+        defence = PowGateDefence()
+        html = defence.render_fields(_ctx_render())[NONCE_FIELD]
+
+        assert f'name="{NONCE_FIELD}"' in html
+        assert "<script" in html
+        assert "crypto.subtle.digest" in html
+
+    def test_solver_script_includes_difficulty(self):
+        """The JS solver uses the difficulty value — pin so a future
+        bug doesn't silently set it to a different constant."""
+        from icv_waf.forms.defences.pow_gate import NONCE_FIELD, PowGateDefence
+
+        defence = PowGateDefence()
+        html = defence.render_fields(_ctx_render(config={"difficulty": 8}))[NONCE_FIELD]
+
+        assert "difficulty=8" in html
+
+    def test_per_form_difficulty_override(self):
+        from icv_waf.forms.defences.pow_gate import NONCE_FIELD, PowGateDefence
+
+        defence = PowGateDefence()
+        html = defence.render_fields(_ctx_render(config={"difficulty": 4}))[NONCE_FIELD]
+
+        # Difficulty 4 is in the script literal — sanity check that
+        # the per-form value, not the default, made it through.
+        assert "difficulty=4" in html
+
+
+# ---------------------------------------------------------------------------
+# evaluate
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluate:
+    def test_missing_nonce_blocks(self):
+        from icv_waf.forms.defences.pow_gate import PowGateDefence
+
+        defence = PowGateDefence()
+        outcome = defence.evaluate(_ctx_eval({}))
+
+        assert outcome.verdict == "block"
+        assert outcome.reason == "pow_gate:missing"
+        assert outcome.score == 5.0
+
+    def test_invalid_nonce_blocks(self):
+        from icv_waf.forms.defences.pow_gate import NONCE_FIELD, PowGateDefence
+
+        defence = PowGateDefence()
+        outcome = defence.evaluate(
+            _ctx_eval(
+                {NONCE_FIELD: "999999999", "waf_pow_token": "some_nonce"},
+                config={"difficulty": 12},
+            )
+        )
+
+        assert outcome.verdict == "block"
+        assert outcome.reason == "pow_gate:invalid"
+
+    def test_valid_nonce_passes(self):
+        """Solve a low-difficulty PoW in test, submit it, defence passes."""
+        from icv_waf.forms.defences.pow_gate import NONCE_FIELD, PowGateDefence
+
+        token_nonce = "test_token_nonce"
+        # Use difficulty 8 — solves in ~256 attempts, instant.
+        candidate = _solve(token_nonce, 8)
+
+        defence = PowGateDefence()
+        outcome = defence.evaluate(
+            _ctx_eval(
+                {NONCE_FIELD: candidate, "waf_pow_token": token_nonce},
+                config={"difficulty": 8},
+            )
+        )
+
+        assert outcome.verdict == "pass"
+
+    def test_uses_token_payload_nonce_when_available(self):
+        """When the orchestrator has populated token_payload, prefer
+        its nonce over the bind field — the verified token is the
+        source of truth."""
+        from icv_waf.forms.defences.pow_gate import NONCE_FIELD, PowGateDefence
+
+        token_nonce = "verified_nonce"
+        candidate = _solve(token_nonce, 8)
+
+        defence = PowGateDefence()
+        outcome = defence.evaluate(
+            _ctx_eval(
+                {NONCE_FIELD: candidate, "waf_pow_token": "tampered_nonce"},
+                payload_nonce=token_nonce,  # the trusted source
+                config={"difficulty": 8},
+            )
+        )
+
+        assert outcome.verdict == "pass"
+
+    def test_tampered_bind_field_fails_when_no_payload(self):
+        """If a bot bumps the bind field, the PoW won't verify against
+        the original token_nonce → block."""
+        from icv_waf.forms.defences.pow_gate import NONCE_FIELD, PowGateDefence
+
+        original_nonce = "original"
+        candidate = _solve(original_nonce, 8)
+
+        defence = PowGateDefence()
+        outcome = defence.evaluate(
+            _ctx_eval(
+                {NONCE_FIELD: candidate, "waf_pow_token": "tampered"},
+                config={"difficulty": 8},
+            )
+        )
+
+        assert outcome.verdict == "block"
+        assert outcome.reason == "pow_gate:invalid"
+
+    def test_verifier_matches_page_level_pow(self):
+        """The form-level PoW uses the same _digest_has_leading_zero_bits
+        helper as the page challenge — pin so a future refactor doesn't
+        introduce a parallel implementation that could drift."""
+        from icv_waf.forms.defences.pow_gate import _verify_nonce
+        from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+        # _verify_nonce constructs a digest and calls the shared helper.
+        # Compute both ways and check the parity.
+        nonce = "abc"
+        candidate = _solve(nonce, 6)
+        msg = f"{nonce}:{candidate}".encode()
+        assert _verify_nonce(nonce, candidate, 6) is True
+        assert _digest_has_leading_zero_bits(hashlib.sha256(msg).digest(), 6) is True

--- a/tests/forms/test_render_token_defence.py
+++ b/tests/forms/test_render_token_defence.py
@@ -1,0 +1,329 @@
+"""Tests for RenderTokenDefence.
+
+The foundation defence — three other defences depend on its parsed
+payload. These tests pin every transition in the truth table from PRD
+§3.3 (missing, invalid, expired, replayed, ip_changed, pass).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_request(*, ip="1.2.3.4", ua="Mozilla/5.0", user=None):
+    """Build a request-like object with the META fields the defence reads."""
+    req = MagicMock()
+    req.META = {"REMOTE_ADDR": ip, "HTTP_USER_AGENT": ua}
+    req.user = user or MagicMock(is_authenticated=False)
+    return req
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1  # marker present by default
+    return r
+
+
+def _defence(redis_client):
+    from icv_waf.forms.defences.render_token import RenderTokenDefence
+
+    return RenderTokenDefence(redis_client_factory=lambda: redis_client)
+
+
+def _render_ctx(req, form_id="contact", config=None):
+    from icv_waf.forms.defences.base import RenderContext
+
+    return RenderContext(form_id=form_id, request=req, config=config or {})
+
+
+def _eval_ctx(req, submitted_data, form_id="contact", config=None):
+    from icv_waf.forms.defences.base import EvaluateContext
+
+    return EvaluateContext(form_id=form_id, request=req, submitted_data=submitted_data, config=config or {})
+
+
+# ---------------------------------------------------------------------------
+# render_fields
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFields:
+    def test_returns_token_hidden_field(self, settings):
+        """The hidden field name is waf_token (stable for grep)."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.render_token import TOKEN_FIELD_NAME
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = _defence(_redis())
+            fields = defence.render_fields(_render_ctx(_fake_request()))
+
+        assert TOKEN_FIELD_NAME == "waf_token"
+        assert TOKEN_FIELD_NAME in fields
+        assert isinstance(fields[TOKEN_FIELD_NAME], str)
+        assert len(fields[TOKEN_FIELD_NAME]) > 20  # base64-encoded payload+sig
+
+    def test_issues_redis_marker_for_token(self, settings):
+        """A fresh render must SETEX the one-shot marker."""
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            redis = _redis()
+            defence = _defence(redis)
+            defence.render_fields(_render_ctx(_fake_request()))
+
+        assert redis.setex.called
+        key = redis.setex.call_args.args[0]
+        assert key.startswith("waf:form:token:")
+
+    def test_marker_failure_does_not_break_render(self, settings):
+        """Redis down at render time must not block form rendering.
+
+        Fail-open is the project-wide policy. Worst case: replay
+        protection weakens to the token's TTL.
+        """
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            redis = _redis()
+            redis.setex.side_effect = RuntimeError("redis down")
+            defence = _defence(redis)
+            fields = defence.render_fields(_render_ctx(_fake_request()))
+
+        # Token still rendered.
+        from icv_waf.forms.defences.render_token import TOKEN_FIELD_NAME
+
+        assert TOKEN_FIELD_NAME in fields
+
+
+# ---------------------------------------------------------------------------
+# evaluate — truth table
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateMissingOrInvalid:
+    def test_missing_token_blocks(self, settings):
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = _defence(_redis())
+            outcome = defence.evaluate(_eval_ctx(_fake_request(), submitted_data={}))
+
+        assert outcome.verdict == "block"
+        assert outcome.reason == "render_token:missing"
+
+    def test_empty_string_token_blocks(self, settings):
+        """A present-but-empty token is just as bad as missing."""
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = _defence(_redis())
+            outcome = defence.evaluate(_eval_ctx(_fake_request(), submitted_data={"waf_token": ""}))
+        assert outcome.reason == "render_token:missing"
+
+    def test_malformed_token_blocks(self, settings):
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            defence = _defence(_redis())
+            outcome = defence.evaluate(_eval_ctx(_fake_request(), submitted_data={"waf_token": "not-a-valid-token"}))
+        assert outcome.verdict == "block"
+        assert outcome.reason == "render_token:invalid"
+
+    def test_wrong_signature_blocks(self, settings):
+        """A token signed under key A doesn't validate when verified under key B."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "key-a"):
+            token, _ = issue_token(form_id="contact", ip="1.2.3.4")
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "key-b"):
+            defence = _defence(_redis())
+            outcome = defence.evaluate(_eval_ctx(_fake_request(), submitted_data={"waf_token": token}))
+        assert outcome.reason == "render_token:invalid"
+
+
+class TestEvaluateExpiry:
+    def test_expired_token_blocks(self, settings):
+        """render_time + TTL < now → expired."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        # Token issued an hour ago, with TTL 60s — clearly expired.
+        old_time = datetime.now(tz=UTC) - timedelta(hours=1)
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="contact", ip="1.2.3.4", render_time=old_time)
+            defence = _defence(_redis())
+            outcome = defence.evaluate(
+                _eval_ctx(
+                    _fake_request(),
+                    submitted_data={"waf_token": token},
+                    config={"token_ttl": 60},
+                )
+            )
+
+        assert outcome.reason == "render_token:expired"
+
+    def test_within_ttl_does_not_expire(self, settings):
+        """A token render_time + TTL > now → not expired (other checks apply)."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="contact", ip="1.2.3.4")
+            defence = _defence(_redis())
+            outcome = defence.evaluate(
+                _eval_ctx(
+                    _fake_request(),
+                    submitted_data={"waf_token": token},
+                    config={"token_ttl": 3600},
+                )
+            )
+
+        # Marker present (default), IP matches → pass.
+        assert outcome.verdict == "pass"
+
+
+class TestEvaluateReplay:
+    def test_missing_marker_outside_grace_window_blocks(self, settings):
+        """Marker gone + render_time older than 5s → replay."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        # Render 10 seconds ago (outside the 5s grace window).
+        old_time = datetime.now(tz=UTC) - timedelta(seconds=10)
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="c", ip="1.2.3.4", render_time=old_time)
+            redis = _redis()
+            redis.exists.return_value = 0  # marker consumed
+            defence = _defence(redis)
+            outcome = defence.evaluate(
+                _eval_ctx(
+                    _fake_request(),
+                    submitted_data={"waf_token": token},
+                    config={"token_ttl": 3600},
+                )
+            )
+
+        assert outcome.reason == "render_token:replayed"
+
+    def test_missing_marker_inside_grace_window_passes(self, settings):
+        """5s grace handles the marker-delete race between near-simultaneous submits."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        # Render 1 second ago — within the 5s grace.
+        recent = datetime.now(tz=UTC) - timedelta(seconds=1)
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="c", ip="1.2.3.4", render_time=recent)
+            redis = _redis()
+            redis.exists.return_value = 0  # marker absent
+            defence = _defence(redis)
+            outcome = defence.evaluate(
+                _eval_ctx(
+                    _fake_request(),
+                    submitted_data={"waf_token": token},
+                    config={"token_ttl": 3600},
+                )
+            )
+
+        assert outcome.verdict == "pass"
+
+    def test_redis_unavailable_fails_open_on_replay_check(self, settings):
+        """If Redis raises on exists(), treat the marker as present (fail-open).
+
+        Project-wide policy: infrastructure outages must not lock
+        legitimate users out.
+        """
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="c", ip="1.2.3.4")
+            redis = _redis()
+            redis.exists.side_effect = RuntimeError("redis down")
+            defence = _defence(redis)
+            outcome = defence.evaluate(
+                _eval_ctx(
+                    _fake_request(),
+                    submitted_data={"waf_token": token},
+                    config={"token_ttl": 3600},
+                )
+            )
+
+        assert outcome.verdict == "pass"
+
+
+class TestEvaluateIpBinding:
+    def test_changed_ip_flags(self, settings):
+        """Token issued from 1.2.3.4 then submitted from 9.9.9.9 → flag."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="c", ip="1.2.3.4")
+            defence = _defence(_redis())
+            outcome = defence.evaluate(
+                _eval_ctx(
+                    _fake_request(ip="9.9.9.9"),
+                    submitted_data={"waf_token": token},
+                    config={"token_ttl": 3600},
+                )
+            )
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "render_token:ip_changed"
+        assert outcome.score > 0  # actual weight pinned in PRD §3.3 — 3.0
+
+    def test_same_ip_passes(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="c", ip="1.2.3.4")
+            defence = _defence(_redis())
+            outcome = defence.evaluate(
+                _eval_ctx(
+                    _fake_request(ip="1.2.3.4"),
+                    submitted_data={"waf_token": token},
+                    config={"token_ttl": 3600},
+                )
+            )
+
+        assert outcome.verdict == "pass"
+
+
+# ---------------------------------------------------------------------------
+# parse_submitted_payload — helper used by the orchestrator
+# ---------------------------------------------------------------------------
+
+
+class TestParseSubmittedPayload:
+    def test_valid_token_returns_payload(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.defences.render_token import parse_submitted_payload
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="contact", ip="1.2.3.4")
+            payload = parse_submitted_payload({"waf_token": token})
+
+        assert payload is not None
+        assert payload.form_id == "contact"
+
+    def test_missing_token_returns_none(self):
+        from icv_waf.forms.defences.render_token import parse_submitted_payload
+
+        assert parse_submitted_payload({}) is None
+
+    def test_invalid_token_returns_none(self):
+        """parse_submitted_payload swallows ValueError — orchestrator
+        treats None as 'no verifiable token; don't compound penalties'."""
+        from icv_waf.forms.defences.render_token import parse_submitted_payload
+
+        assert parse_submitted_payload({"waf_token": "garbage"}) is None

--- a/tests/forms/test_replay.py
+++ b/tests/forms/test_replay.py
@@ -1,0 +1,206 @@
+"""Tests for the challenge-replay services."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Sensitive-field detection
+# ---------------------------------------------------------------------------
+
+
+class TestSensitiveFieldDetection:
+    def test_password_fields_are_sensitive(self):
+        from icv_waf.forms.services.replay import is_sensitive_field
+
+        assert is_sensitive_field("password")
+        assert is_sensitive_field("user_password")
+        assert is_sensitive_field("password1")  # Django default
+        # Patterns are anchored on word boundaries, but the regex
+        # we ship intentionally matches '_password', 'password_',
+        # or bare. Pin the cases that matter.
+        assert is_sensitive_field("Password")  # case-insensitive
+
+    def test_secret_token_csrf_are_sensitive(self):
+        from icv_waf.forms.services.replay import is_sensitive_field
+
+        assert is_sensitive_field("secret_key")
+        assert is_sensitive_field("api_key")
+        assert is_sensitive_field("csrfmiddlewaretoken")
+
+    def test_normal_fields_pass(self):
+        from icv_waf.forms.services.replay import is_sensitive_field
+
+        for name in ("email", "name", "message", "subject", "title", "body"):
+            assert not is_sensitive_field(name), name
+
+
+class TestFilterSensitiveFields:
+    def test_strips_passwords_keeps_others(self):
+        from icv_waf.forms.services.replay import filter_sensitive_fields
+
+        data = {"username": "alice", "password": "hunter2", "subject": "hi"}
+        filtered = filter_sensitive_fields(data)
+
+        assert "password" not in filtered
+        assert filtered["username"] == "alice"
+        assert filtered["subject"] == "hi"
+
+
+# ---------------------------------------------------------------------------
+# Replay-token signing
+# ---------------------------------------------------------------------------
+
+
+class TestReplayToken:
+    def test_round_trip(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.replay import (
+            issue_replay_token,
+            verify_replay_token,
+        )
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token = issue_replay_token(form_id="contact", ip="1.2.3.4", session_key="abc")
+            payload = verify_replay_token(token, current_ip="1.2.3.4")
+
+        assert payload is not None
+        assert payload["form_id"] == "contact"
+        assert payload["session_key"] == "abc"
+
+    def test_ip_mismatch_fails(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.replay import issue_replay_token, verify_replay_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token = issue_replay_token(form_id="c", ip="1.2.3.4", session_key="abc")
+            payload = verify_replay_token(token, current_ip="9.9.9.9")
+
+        assert payload is None
+
+    def test_tampered_token_fails(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.replay import issue_replay_token, verify_replay_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token = issue_replay_token(form_id="c", ip="1.2.3.4", session_key="abc")
+            # Flip a character mid-token.
+            tampered = token[:-3] + ("A" if token[-3] != "A" else "B") + token[-2:]
+            payload = verify_replay_token(tampered, current_ip="1.2.3.4")
+
+        assert payload is None
+
+    def test_wrong_key_fails(self, settings):
+        """Token issued under key A doesn't verify under key B."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.replay import issue_replay_token, verify_replay_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "key-a"):
+            token = issue_replay_token(form_id="c", ip="1.2.3.4", session_key="abc")
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "key-b"):
+            payload = verify_replay_token(token, current_ip="1.2.3.4")
+
+        assert payload is None
+
+    def test_expired_token_fails(self, settings):
+        """Tokens past their 60s TTL must not verify."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.replay import issue_replay_token, verify_replay_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token = issue_replay_token(form_id="c", ip="1.2.3.4", session_key="abc")
+            # Patch time.time so the verifier sees the token as expired.
+            with patch("icv_waf.forms.services.replay.time.time", return_value=time.time() + 120):
+                payload = verify_replay_token(token, current_ip="1.2.3.4")
+
+        assert payload is None
+
+    def test_empty_or_garbage_returns_none(self):
+        from icv_waf.forms.services.replay import verify_replay_token
+
+        assert verify_replay_token("", current_ip="1.2.3.4") is None
+        assert verify_replay_token("not!!base64!!", current_ip="1.2.3.4") is None
+
+
+# ---------------------------------------------------------------------------
+# Session storage
+# ---------------------------------------------------------------------------
+
+
+class _FakeSession(dict):
+    """A dict that also supports the ``.modified`` attribute Django uses."""
+
+    modified = False
+
+
+class TestSessionStorage:
+    def _request_with_session(self):
+        req = MagicMock()
+        req.session = _FakeSession()
+        return req
+
+    def test_store_and_fetch_round_trip(self):
+        from icv_waf.forms.services.replay import fetch_from_session, store_in_session
+
+        req = self._request_with_session()
+        key = store_in_session(
+            req,
+            form_id="contact",
+            post_url="/contact/",
+            data={"name": "alice", "email": "a@b.com"},
+        )
+        record = fetch_from_session(req, session_key=key)
+
+        assert record["form_id"] == "contact"
+        assert record["data"]["name"] == "alice"
+
+    def test_passwords_stripped_before_storage(self):
+        from icv_waf.forms.services.replay import fetch_from_session, store_in_session
+
+        req = self._request_with_session()
+        key = store_in_session(
+            req,
+            form_id="login",
+            post_url="/login/",
+            data={"username": "alice", "password": "hunter2"},
+        )
+        record = fetch_from_session(req, session_key=key)
+
+        assert "password" not in record["data"]
+        assert record["data"]["username"] == "alice"
+
+    def test_session_missing_returns_none(self):
+        from icv_waf.forms.services.replay import store_in_session
+
+        req = MagicMock(spec=[])  # no .session attr
+        assert store_in_session(req, form_id="c", post_url="/c/", data={}) is None
+
+    def test_discard_removes_record(self):
+        from icv_waf.forms.services.replay import (
+            discard_from_session,
+            fetch_from_session,
+            store_in_session,
+        )
+
+        req = self._request_with_session()
+        key = store_in_session(req, form_id="c", post_url="/c/", data={"a": "1"})
+        assert fetch_from_session(req, session_key=key) is not None
+        discard_from_session(req, session_key=key)
+        assert fetch_from_session(req, session_key=key) is None
+
+    def test_cap_keeps_at_most_five_records(self):
+        """Session bloat protection — don't let stale flagged forms
+        accumulate indefinitely under one session."""
+        from icv_waf.forms.services.replay import store_in_session
+
+        req = self._request_with_session()
+        keys = []
+        for i in range(7):
+            k = store_in_session(req, form_id=f"f{i}", post_url="/", data={"i": str(i)})
+            keys.append(k)
+            # Walk the timer so the cap's age-sort is meaningful.
+            time.sleep(0.001)
+
+        stash = req.session["waf_form_replay"]
+        assert len(stash) == 5

--- a/tests/forms/test_signup_velocity.py
+++ b/tests/forms/test_signup_velocity.py
@@ -1,0 +1,109 @@
+"""Tests for SignupVelocityDefence + the signup counter."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _ctx(*, ip="1.2.3.4", config=None):
+    from icv_waf.forms.defences.base import EvaluateContext
+
+    request = MagicMock()
+    request.META = {"REMOTE_ADDR": ip}
+    return EvaluateContext(
+        form_id="signup",
+        request=request,
+        submitted_data={},
+        config=config or {},
+    )
+
+
+class TestSignupCounter:
+    def test_record_signup_returns_new_count(self):
+        from icv_waf.forms.services.counters import record_signup
+
+        redis = _redis()
+        redis.pipeline.return_value.execute.return_value = [4, True]
+        assert record_signup(redis, ip="1.2.3.4", window_seconds=86400) == 4
+
+    def test_record_signup_redis_failure_returns_zero(self):
+        from icv_waf.forms.services.counters import record_signup
+
+        redis = _redis()
+        redis.pipeline.return_value.execute.side_effect = RuntimeError("redis down")
+        assert record_signup(redis, ip="1.2.3.4", window_seconds=86400) == 0
+
+    def test_signup_count_reads_without_incrementing(self):
+        from icv_waf.forms.services.counters import signup_count
+
+        redis = _redis()
+        redis.get.return_value = b"7"
+        assert signup_count(redis, ip="1.2.3.4") == 7
+        # pipeline / incr should not have been touched.
+        redis.pipeline.assert_not_called()
+
+    def test_empty_ip_returns_zero(self):
+        from icv_waf.forms.services.counters import record_signup, signup_count
+
+        redis = _redis()
+        assert record_signup(redis, ip="", window_seconds=86400) == 0
+        assert signup_count(redis, ip="") == 0
+
+
+class TestSignupVelocityDefence:
+    def test_passes_when_below_threshold(self):
+        from icv_waf.forms.defences.signup_velocity import SignupVelocityDefence
+
+        redis = _redis()
+        redis.get.return_value = b"3"
+        defence = SignupVelocityDefence(redis_client_factory=lambda: redis)
+
+        assert defence.evaluate(_ctx()).verdict == "pass"
+
+    def test_flags_when_threshold_crossed(self):
+        from icv_waf.forms.defences.signup_velocity import SignupVelocityDefence
+
+        redis = _redis()
+        redis.get.return_value = b"10"  # well over default limit of 5
+        defence = SignupVelocityDefence(redis_client_factory=lambda: redis)
+        outcome = defence.evaluate(_ctx())
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "signup_velocity:ip"
+        assert outcome.score == 5.0
+
+    def test_per_form_limit_override(self):
+        from icv_waf.forms.defences.signup_velocity import SignupVelocityDefence
+
+        redis = _redis()
+        redis.get.return_value = b"5"
+        defence = SignupVelocityDefence(redis_client_factory=lambda: redis)
+        # Tighter limit (2) — 5 trips it.
+        assert defence.evaluate(_ctx(config={"limit": 2})).verdict == "flag"
+        # Looser limit (10) — 5 doesn't trip.
+        assert defence.evaluate(_ctx(config={"limit": 10})).verdict == "pass"
+
+    def test_redis_failure_passes(self):
+        from icv_waf.forms.defences.signup_velocity import SignupVelocityDefence
+
+        redis = _redis()
+        redis.get.side_effect = RuntimeError("redis down")
+        defence = SignupVelocityDefence(redis_client_factory=lambda: redis)
+
+        assert defence.evaluate(_ctx()).verdict == "pass"
+
+    def test_missing_ip_passes(self):
+        from icv_waf.forms.defences.signup_velocity import SignupVelocityDefence
+
+        redis = _redis()
+        defence = SignupVelocityDefence(redis_client_factory=lambda: redis)
+        assert defence.evaluate(_ctx(ip="")).verdict == "pass"

--- a/tests/forms/test_template_tag.py
+++ b/tests/forms/test_template_tag.py
@@ -1,0 +1,74 @@
+"""Tests for the {% waf_protect %} template tag."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.template import Context, Template
+from django.test import RequestFactory
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _request():
+    rf = RequestFactory()
+    request = rf.get("/")
+    request.user = MagicMock(is_authenticated=False)
+    return request
+
+
+class TestWafProtectTag:
+    def test_renders_protection_fields_when_form_id_registered(self, settings):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import waf_protect_post
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-tag-renders",
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):  # noqa: ARG001
+                pass
+
+            tpl = Template("{% load waf_form_tags %}{% waf_protect form_id='contact-tag-renders' %}")
+            html = tpl.render(Context({"request": _request()}))
+
+        assert "<input" in html
+        assert "position:absolute" in html
+
+    def test_renders_empty_when_form_id_unknown(self):
+        """Missing decorator → empty string + log warning, never a crash."""
+        tpl = Template("{% load waf_form_tags %}{% waf_protect form_id='never-registered' %}")
+        html = tpl.render(Context({"request": _request()}))
+
+        assert html == ""
+
+    def test_renders_empty_when_request_missing_from_context(self, settings):
+        """Tag needs request in context — if absent, fail safe (empty)."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import waf_protect_post
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-tag-no-request",
+                defences=("honeypot",),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):  # noqa: ARG001
+                pass
+
+            tpl = Template("{% load waf_form_tags %}{% waf_protect form_id='contact-tag-no-request' %}")
+            html = tpl.render(Context({}))  # No 'request' key
+
+        assert html == ""

--- a/tests/forms/test_time_trap_defence.py
+++ b/tests/forms/test_time_trap_defence.py
@@ -1,0 +1,186 @@
+"""Tests for TimeTrapDefence.
+
+Pins every transition in PRD §3.2's truth table. The 0.5s hard floor
+is the only threshold not configurable per-form, so it gets a
+dedicated test.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock
+
+
+def _payload(render_time):
+    """Build a TokenPayload-like object with just the field the defence reads."""
+    p = MagicMock()
+    p.render_time = render_time
+    return p
+
+
+def _ctx(payload, config=None):
+    from icv_waf.forms.defences.base import EvaluateContext
+
+    return EvaluateContext(
+        form_id="c",
+        request=MagicMock(),
+        submitted_data={},
+        config=config or {},
+        token_payload=payload,
+    )
+
+
+def _ago(seconds):
+    return datetime.now(tz=UTC) - timedelta(seconds=seconds)
+
+
+# ---------------------------------------------------------------------------
+# render_fields
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFields:
+    def test_returns_empty_dict(self):
+        """TimeTrap relies on the render-token timestamp; no fields of its own."""
+        from icv_waf.forms.defences.base import RenderContext
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        defence = TimeTrapDefence()
+        fields = defence.render_fields(RenderContext(form_id="c", request=MagicMock()))
+
+        assert fields == {}
+
+
+# ---------------------------------------------------------------------------
+# evaluate — truth table
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluateTruthTable:
+    def test_too_fast_blocks(self):
+        """delta < 0.5s → hard block."""
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(_ago(0.1))))
+
+        assert outcome.verdict == "block"
+        assert outcome.reason == "time_trap:too_fast"
+        assert outcome.score == 5.0
+
+    def test_fast_band_flags(self):
+        """0.5s ≤ delta < min → flag."""
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        # Default min is 1.5s; 1.0s is in the fast band.
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(_ago(1.0))))
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "time_trap:fast"
+        assert outcome.score == 2.0
+
+    def test_within_min_max_passes(self):
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(_ago(10.0))))
+
+        assert outcome.verdict == "pass"
+
+    def test_expired_flags(self):
+        """delta > max → flag with expired reason."""
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        # Default max is 3600s; 7200 (2h) is well past.
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(_ago(7200))))
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "time_trap:expired"
+
+    def test_negative_delta_treated_as_too_fast(self):
+        """Clock skew producing future render_time → block as too_fast.
+
+        Better to flag a false positive than ignore a genuine replay.
+        """
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        future = datetime.now(tz=UTC) + timedelta(seconds=30)
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(future)))
+
+        assert outcome.verdict == "block"
+        assert outcome.reason == "time_trap:too_fast"
+
+
+# ---------------------------------------------------------------------------
+# Configurability
+# ---------------------------------------------------------------------------
+
+
+class TestConfigurable:
+    def test_per_form_min_overrides_default(self):
+        """Newsletter-style short forms set min_fill_seconds lower."""
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(_ago(0.7)), config={"min_fill_seconds": 0.6}))
+
+        # 0.7s > 0.5 (too_fast floor) AND > configured min 0.6 → pass
+        assert outcome.verdict == "pass"
+
+    def test_per_form_max_overrides_default(self):
+        """A form with a tight max flags submissions sooner."""
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(_ago(120)), config={"max_fill_seconds": 60}))
+
+        assert outcome.reason == "time_trap:expired"
+
+    def test_hard_floor_is_not_configurable_via_min(self):
+        """Setting min_fill_seconds to 0 cannot weaken the 0.5s hard floor.
+
+        The floor is a security invariant — a configuration mistake
+        shouldn't lower it.
+        """
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(_ago(0.1)), config={"min_fill_seconds": 0.0}))
+
+        # 0.1s is below the hard 0.5s floor regardless of min config.
+        assert outcome.verdict == "block"
+        assert outcome.reason == "time_trap:too_fast"
+
+
+# ---------------------------------------------------------------------------
+# Defensive defaults
+# ---------------------------------------------------------------------------
+
+
+class TestDefensive:
+    def test_missing_token_payload_passes_silently(self):
+        """No token_payload means RenderTokenDefence already blocked.
+        Don't compound the penalty — just pass."""
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(payload=None))
+
+        assert outcome.verdict == "pass"
+
+    def test_naive_render_time_treated_as_utc(self):
+        """Defensive: if a future bug produces a naive datetime, the
+        defence must not crash. Treat as UTC."""
+        from icv_waf.forms.defences.time_trap import TimeTrapDefence
+
+        # Strip tzinfo from a known-aware datetime so we get a naive value
+        # without using the deprecated datetime.utcnow().
+        naive_now = (datetime.now(tz=UTC) - timedelta(seconds=5)).replace(tzinfo=None)
+        defence = TimeTrapDefence()
+        outcome = defence.evaluate(_ctx(_payload(naive_now)))
+
+        # Within fill window → pass
+        assert outcome.verdict == "pass"

--- a/tests/forms/test_tokens.py
+++ b/tests/forms/test_tokens.py
@@ -1,0 +1,243 @@
+"""Tests for the form-protection token service.
+
+Covers the signing key resolution, token issuance/verification round
+trips, signature tampering, and payload-format strictness. Marker
+behaviour is tested separately in ``test_markers.py`` so each module's
+tests pin a single concern.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# get_signing_key
+# ---------------------------------------------------------------------------
+
+
+class TestGetSigningKey:
+    def test_uses_icv_waf_signing_key_when_set(self):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import get_signing_key
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "explicit-key-value"):
+            assert get_signing_key() == b"explicit-key-value"
+
+    def test_falls_back_to_secret_key_derivative_when_unset(self, settings):
+        """An empty ICV_WAF_SIGNING_KEY derives from Django's SECRET_KEY.
+
+        Critical: the derived key must NOT equal SECRET_KEY directly —
+        if a future bug exposed it, leaking it would not also leak the
+        Django session secret. The namespace byte string in the
+        derivation is the load-bearing detail here.
+        """
+        import hashlib
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import get_signing_key
+
+        fake_secret = "django-secret-do-not-leak"
+        settings.SECRET_KEY = fake_secret
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", ""):
+            derived = get_signing_key()
+
+        assert derived != fake_secret.encode()
+        expected = hashlib.sha256(b"icv-waf:signing:v1|" + fake_secret.encode()).digest()
+        assert derived == expected
+
+    def test_derived_key_is_stable_across_calls(self, settings):
+        """Same SECRET_KEY input must produce the same derived key.
+
+        Otherwise tokens issued under one process couldn't be verified
+        by another, breaking horizontally-scaled deployments.
+        """
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import get_signing_key
+
+        settings.SECRET_KEY = "stable-secret"
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", ""):
+            assert get_signing_key() == get_signing_key()
+
+
+# ---------------------------------------------------------------------------
+# issue_token / verify_token round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestTokenRoundTrip:
+    def test_issue_then_verify_returns_same_payload(self):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token, verify_token
+
+        render_time = datetime(2026, 5, 27, 10, 0, 0, tzinfo=UTC)
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "test-key"):
+            token, original = issue_token(
+                form_id="contact",
+                ip="1.2.3.4",
+                user_id="42",
+                user_agent="Mozilla/5.0",
+                render_time=render_time,
+                nonce="deadbeef",
+            )
+            recovered = verify_token(token)
+
+        assert recovered.form_id == "contact"
+        assert recovered.ip == "1.2.3.4"
+        assert recovered.user_id == "42"
+        assert recovered.render_time == render_time
+        assert recovered.nonce == "deadbeef"
+        assert recovered.ua_hash == original.ua_hash
+
+    def test_issued_token_is_url_safe(self):
+        """Token must survive being placed into an HTML attribute and a URL.
+
+        We base64url-encode and strip padding, which is exactly that
+        — but the test pins the contract so future changes don't
+        silently introduce `+` or `/` characters that would break
+        attribute serialisation.
+        """
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="c", ip="1.1.1.1")
+
+        # Only base64url alphabet plus optional `=` padding (we strip it,
+        # but tolerate if a future change adds it back).
+        assert all(c.isalnum() or c in "-_=" for c in token)
+
+    def test_anonymous_user_round_trips_as_empty_string(self):
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token, verify_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = issue_token(form_id="c", ip="1.1.1.1")
+            payload = verify_token(token)
+
+        assert payload.user_id == ""
+
+    def test_nonce_is_random_when_not_supplied(self):
+        """Two tokens issued in quick succession must have distinct nonces."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            _, p1 = issue_token(form_id="c", ip="1.1.1.1")
+            _, p2 = issue_token(form_id="c", ip="1.1.1.1")
+
+        assert p1.nonce != p2.nonce
+        # 16 bytes hex = 32 chars; pin so a future change to length is deliberate.
+        assert len(p1.nonce) == 32
+
+
+# ---------------------------------------------------------------------------
+# verify_token failure modes
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyTokenFailures:
+    def _issue(self, **kwargs):
+        from icv_waf.forms.services.tokens import issue_token
+
+        defaults = {"form_id": "c", "ip": "1.1.1.1"}
+        defaults.update(kwargs)
+        return issue_token(**defaults)
+
+    def test_tampered_payload_fails_signature_check(self):
+        """Flipping a single byte of the payload must invalidate the token."""
+        import base64
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import verify_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            token, _ = self._issue(form_id="contact")
+            # Decode, mutate the payload (the IP field), re-encode.
+            padding = "=" * (-len(token) % 4)
+            raw = base64.urlsafe_b64decode((token + padding).encode("ascii")).decode("utf-8")
+            tampered_raw = raw.replace("1.1.1.1", "9.9.9.9", 1)
+            tampered = base64.urlsafe_b64encode(tampered_raw.encode("utf-8")).decode("ascii").rstrip("=")
+
+            with pytest.raises(ValueError, match="signature mismatch"):
+                verify_token(tampered)
+
+    def test_wrong_signing_key_fails_signature_check(self):
+        """Token issued under key A must not verify under key B."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import issue_token, verify_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "key-a"):
+            token, _ = issue_token(form_id="c", ip="1.1.1.1")
+
+        with (
+            patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "key-b"),
+            pytest.raises(ValueError, match="signature mismatch"),
+        ):
+            verify_token(token)
+
+    def test_malformed_base64_raises_value_error(self):
+        from icv_waf.forms.services.tokens import verify_token
+
+        with pytest.raises(ValueError):
+            verify_token("not!!base64!!at!!all")
+
+    def test_missing_signature_delimiter_raises_value_error(self):
+        """A base64-clean string with no '|' inside is invalid."""
+        import base64
+
+        from icv_waf.forms.services.tokens import verify_token
+
+        bad = base64.urlsafe_b64encode(b"no-pipes-here").decode("ascii").rstrip("=")
+        with pytest.raises(ValueError, match="no signature delimiter"):
+            verify_token(bad)
+
+    def test_wrong_field_count_in_payload_raises_value_error(self):
+        """A signature-valid token with the wrong payload shape still fails.
+
+        Pin: if we ever extend the payload, old short-format tokens
+        signed with the same key must NOT silently parse into
+        defaulted fields. They must blow up loudly.
+        """
+        import base64
+        import hashlib
+        import hmac
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.services.tokens import verify_token
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            payload_str = "only|three|fields"  # 3 fields, not the required 6
+            sig = hmac.new(b"k", payload_str.encode(), hashlib.sha256).hexdigest()
+            raw = payload_str + "|" + sig
+            token = base64.urlsafe_b64encode(raw.encode()).decode("ascii").rstrip("=")
+
+            with pytest.raises(ValueError, match="expected .* payload fields"):
+                verify_token(token)
+
+
+# ---------------------------------------------------------------------------
+# hash_user_agent
+# ---------------------------------------------------------------------------
+
+
+class TestHashUserAgent:
+    def test_same_ua_hashes_to_same_value(self):
+        from icv_waf.forms.services.tokens import hash_user_agent
+
+        assert hash_user_agent("Mozilla/5.0") == hash_user_agent("Mozilla/5.0")
+
+    def test_different_ua_hashes_to_different_value(self):
+        from icv_waf.forms.services.tokens import hash_user_agent
+
+        assert hash_user_agent("Mozilla/5.0") != hash_user_agent("curl/7.0")
+
+    def test_empty_ua_hashes_to_stable_value(self):
+        """Anonymous-UA submissions are common; the hash must be stable."""
+        from icv_waf.forms.services.tokens import hash_user_agent
+
+        assert hash_user_agent("") == hash_user_agent("")
+        # Sanity: SHA-256 hex length.
+        assert len(hash_user_agent("")) == 64

--- a/tests/forms/test_ua_consistency_defence.py
+++ b/tests/forms/test_ua_consistency_defence.py
@@ -1,0 +1,89 @@
+"""Tests for UaConsistencyDefence — short defence, short tests."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _ctx(*, payload_ua_hash, current_ua):
+    """Build an EvaluateContext with a payload whose ua_hash is given."""
+    from icv_waf.forms.defences.base import EvaluateContext
+
+    payload = MagicMock()
+    payload.ua_hash = payload_ua_hash
+
+    request = MagicMock()
+    request.META = {"HTTP_USER_AGENT": current_ua}
+
+    return EvaluateContext(
+        form_id="c",
+        request=request,
+        submitted_data={},
+        token_payload=payload,
+    )
+
+
+class TestRenderFields:
+    def test_returns_empty_dict(self):
+        """UA hash rides on the render token; no fields of its own."""
+        from icv_waf.forms.defences.base import RenderContext
+        from icv_waf.forms.defences.ua_consistency import UaConsistencyDefence
+
+        defence = UaConsistencyDefence()
+        fields = defence.render_fields(RenderContext(form_id="c", request=MagicMock()))
+
+        assert fields == {}
+
+
+class TestEvaluate:
+    def test_matching_ua_passes(self):
+        from icv_waf.forms.defences.ua_consistency import UaConsistencyDefence
+        from icv_waf.forms.services.tokens import hash_user_agent
+
+        ua = "Mozilla/5.0 ..."
+        defence = UaConsistencyDefence()
+        outcome = defence.evaluate(_ctx(payload_ua_hash=hash_user_agent(ua), current_ua=ua))
+
+        assert outcome.verdict == "pass"
+
+    def test_changed_ua_flags(self):
+        from icv_waf.forms.defences.ua_consistency import UaConsistencyDefence
+        from icv_waf.forms.services.tokens import hash_user_agent
+
+        defence = UaConsistencyDefence()
+        outcome = defence.evaluate(
+            _ctx(
+                payload_ua_hash=hash_user_agent("Mozilla/5.0 (browser at render)"),
+                current_ua="curl/7.79.1",  # different client at submit
+            )
+        )
+
+        assert outcome.verdict == "flag"
+        assert outcome.reason == "ua_consistency:changed"
+        assert outcome.score == 2.0
+
+    def test_missing_token_payload_passes_silently(self):
+        """RenderTokenDefence already blocked → don't compound."""
+        from icv_waf.forms.defences.base import EvaluateContext
+        from icv_waf.forms.defences.ua_consistency import UaConsistencyDefence
+
+        ctx = EvaluateContext(form_id="c", request=MagicMock(), submitted_data={})
+        defence = UaConsistencyDefence()
+        outcome = defence.evaluate(ctx)
+
+        assert outcome.verdict == "pass"
+
+    def test_empty_current_ua_compares_to_empty_hash(self):
+        """A request with no UA header must still compare consistently.
+
+        Anonymous-UA submissions are common (some proxies strip the
+        header). The hash function handles empty input identically at
+        render and submit time, so identical-empty UAs pass.
+        """
+        from icv_waf.forms.defences.ua_consistency import UaConsistencyDefence
+        from icv_waf.forms.services.tokens import hash_user_agent
+
+        defence = UaConsistencyDefence()
+        outcome = defence.evaluate(_ctx(payload_ua_hash=hash_user_agent(""), current_ua=""))
+
+        assert outcome.verdict == "pass"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -17,6 +17,12 @@ def _run_checks():
     return check_challenge_difficulty(app_configs=None)
 
 
+def _run_signing_key_check():
+    from icv_waf.checks import check_signing_key
+
+    return check_signing_key(app_configs=None)
+
+
 class TestChallengeDifficultyCheck:
     def test_recommended_defaults_produce_no_messages(self):
         import icv_waf.conf as conf_mod
@@ -87,3 +93,32 @@ class TestChallengeDifficultyCheck:
             messages = _run_checks()
 
         assert any(m.id == "icv_waf.E001" for m in messages)
+
+
+class TestSigningKeyCheck:
+    """W003 — warns when ICV_WAF_SIGNING_KEY is unset.
+
+    Falling back to a SECRET_KEY-derived value is supported (and is
+    what makes v0.10.x → v0.11.0 upgrades seamless) but it ties WAF
+    signature rotation to Django's session secret. The check nudges
+    operators toward an explicit dedicated key.
+    """
+
+    def test_explicit_key_produces_no_messages(self):
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "an-explicit-key-value"):
+            assert _run_signing_key_check() == []
+
+    def test_empty_key_emits_w003_warning(self):
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", ""):
+            messages = _run_signing_key_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "icv_waf.W003"
+        # The hint must tell operators how to fix it — pin the actionable
+        # part of the message so future edits don't lose the remediation.
+        assert "secrets.token_urlsafe" in messages[0].hint
+        assert "ICV_WAF_SIGNING_KEY" in messages[0].hint


### PR DESCRIPTION
## v0.11.0 form-protection — PRD only (draft)

This is **spec only — no implementation**. Opening as a draft PR so the
design has a stable URL to review and revisit before any code lands.

The PRD lives at `docs/specs/forms/PRD.md`. ~900 lines, structured as:

- **Context + threat model** — four threats in scope (spam, credential
  stuffing, mass signup, scraping), explicit non-goals.
- **Architecture** — three entry points (Form mixin, view decorator,
  template tag) feeding one `FormProtection` orchestrator.
- **Eight defences** — Honeypot, TimeTrap, RenderToken, UaConsistency,
  JsTouch, CredentialThrottle, SignupVelocity, PowGate. Each with
  contract, default weight, settings, accessibility notes, and
  false-positive considerations.
- **Token lifecycle** — HMAC signing, Redis one-shot markers, the
  HTMX-aware "delete on pass only" rule that's critical for
  Vendably-style multi-render flows.
- **Challenge-replay flow** — full sequence including the
  sensitive-field omission rules for login forms and file uploads.
- **Settings reference** — 19 new settings, including the new
  package-wide `ICV_WAF_SIGNING_KEY` (separate from `SECRET_KEY` for
  rotation independence).
- **Signals + logging** — structured event format, sampling rules,
  `X-WAF-Form-Verdict` debug header.
- **Operator runbook** — three common debug scenarios.
- **Test plan** — per-defence test modules + integration tests including
  HTMX replay and enumeration-timing.
- **Resolved design decisions** — six questions debated during PRD
  review, with the decisions taken and the reasoning.

### What to react to before implementation starts

The six "resolved decisions" in §14 are the load-bearing ones; if any
of those feel wrong, now is the cheap time to push back.

The PoW reuses the existing `_digest_has_leading_zero_bits` /
`hasLeadingZeroBits` helpers from v0.10.5 rather than building a
parallel implementation — that's worth confirming as the right call.

### Why open as a draft PR rather than merge the PRD straight to main

Spec-as-PR keeps the design discoverable (one URL, one review
surface), and once implementation starts the work commits land on the
same branch so the PR grows incrementally rather than dropping a
~2.5k LOC bomb at the end.

### Implementation order (planned)

1. Token + marker services + tests (~0.5 day)
2. Defences one-by-one, each as its own commit (~3 days for all eight)
3. Orchestrator + mixin (~1 day)
4. Decorator + template tag (~0.5 day)
5. Challenge-replay flow (last; behind `ICV_WAF_FORM_CHALLENGE_ON_FLAG`
   so it can be disabled if it lands buggy) (~1 day)
6. Docs + CHANGELOG + version bump (~0.5 day)

~7 working days end-to-end. No DB migrations.
