### PR TITLE
fix: v0.11.1 — RenderTokenDefence renders an <input>, not the raw token (critical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,49 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] - 2026-05-27
+
+### Fixed
+
+- **`RenderTokenDefence.render_fields` shipped the raw token string
+  instead of a hidden `<input>` tag** — a critical bug in v0.11.0 that
+  made every protected form unusable for real users. The orchestrator
+  concatenated the raw token into the DOM as visible page text; no
+  `<input name="waf_token">` ever rendered, so browsers never
+  submitted a `waf_token` field, and every real-user POST was rejected
+  with `render_token:missing`.
+
+  The unit tests in v0.11.0 missed this because they constructed POST
+  payloads directly — none ever parsed the rendered HTML and submitted
+  what a browser would actually submit. The strengthened tests in this
+  release (see "Added" below) close that gap.
+
+  **Fix**: `RenderTokenDefence.render_fields` now returns
+  `format_html('<input type="hidden" name="{}" value="{}">', ...)`.
+  The orchestrator extracts the nonce back out of the rendered `<input>`
+  via a `value="..."` regex when threading it to subsequent defences
+  (honeypot, js_touch, pow_gate). No public-API change.
+
+### Added
+
+- **DOM round-trip test suite** (`tests/forms/test_dom_round_trip.py`).
+  Renders a protected form, parses the HTML the way a browser would
+  (via `html.parser`), builds a POST from the discovered `<input>`
+  values, and verifies `PASSED`. This is the test class that would
+  have caught the v0.11.0 bug before release; future render-side
+  regressions across any defence are now covered.
+
+### Upgrade
+
+Anyone who shipped v0.11.0 with form protection enabled has broken
+forms — upgrade immediately:
+
+```bash
+pip install -U django-waf
+```
+
+No settings or migration changes.
+
 ## [0.11.0] - 2026-05-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "0.11.0"
+version = "0.11.1"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/icv_waf/forms/defences/render_token.py
+++ b/src/icv_waf/forms/defences/render_token.py
@@ -25,7 +25,8 @@ import contextlib
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from django.utils.safestring import SafeString, mark_safe
+from django.utils.html import format_html
+from django.utils.safestring import SafeString
 
 from icv_waf.forms.defences.base import (
     EvaluateContext,
@@ -125,9 +126,22 @@ class RenderTokenDefence:
         with contextlib.suppress(Exception):
             issue_marker(self._redis(), nonce=payload.nonce, ttl_seconds=ttl)
 
-        # The token is base64url-encoded — no HTML-special characters
-        # can appear in it, so mark_safe is XSS-safe by construction.
-        return {TOKEN_FIELD_NAME: mark_safe(token)}  # noqa: S308
+        # Return a full <input> tag, not just the token. v0.11.0
+        # shipped this returning the raw token string, which the
+        # orchestrator's ''.join() concatenated into the page as bare
+        # text — so the browser never submitted a waf_token field and
+        # every real user POST was rejected with render_token:missing.
+        # ``format_html`` HTML-escapes the value defensively; tokens
+        # are base64url so the escape is a no-op today, but the
+        # explicit safety documents the intent and survives a future
+        # change in token format.
+        return {
+            TOKEN_FIELD_NAME: format_html(
+                '<input type="hidden" name="{}" value="{}">',
+                TOKEN_FIELD_NAME,
+                token,
+            ),
+        }
 
     def evaluate(self, ctx: EvaluateContext) -> Outcome:
         """Verify the submitted token + check expiry, marker, IP."""

--- a/src/icv_waf/forms/protection.py
+++ b/src/icv_waf/forms/protection.py
@@ -148,6 +148,27 @@ _CANONICAL_ORDER = (
 )
 
 
+_TOKEN_VALUE_RE = None  # lazy-compiled on first call
+
+
+def _extract_token_value(fragment: str) -> str:
+    """Return the contents of ``value="..."`` from a rendered <input> fragment.
+
+    The orchestrator uses this to read back the token nonce after
+    ``RenderTokenDefence.render_fields`` returns its hidden-input
+    HTML. Returns the empty string if no value attribute is found
+    (treated as 'no token available', and the orchestrator falls
+    through without threading a nonce to later defences).
+    """
+    import re
+
+    global _TOKEN_VALUE_RE  # noqa: PLW0603 — single-shot lazy compile is fine
+    if _TOKEN_VALUE_RE is None:
+        _TOKEN_VALUE_RE = re.compile(r'value="([^"]*)"')
+    match = _TOKEN_VALUE_RE.search(fragment)
+    return match.group(1) if match else ""
+
+
 def _order_defences(names: tuple[str, ...]) -> tuple[str, ...]:
     """Return the configured names in canonical order.
 
@@ -337,19 +358,30 @@ class FormProtection:
             try:
                 fragments = defence.render_fields(ctx)
                 all_fields.update(fragments)
-                # The token is in fragments[TOKEN_FIELD_NAME] — but
-                # the nonce is internal to it. Extract via the
-                # parse_submitted_payload helper (works because we
-                # just issued the token).
+                # The token rides inside the rendered <input>'s
+                # ``value`` attribute. Extract it back out so the
+                # nonce can be threaded onto subsequent defences'
+                # ctx.config — they need it to bind their hidden
+                # fields to this render (PowGateDefence + JsTouchDefence).
+                #
+                # We could ask the defence to expose the payload via
+                # a side channel, but parsing what we just rendered
+                # keeps the contract uniform: every defence's
+                # ``render_fields`` returns a name → HTML mapping,
+                # and the orchestrator's only structural assumption
+                # is that the token sits in a ``value="..."`` attr —
+                # which is also the assumption browsers will make.
                 from icv_waf.forms.defences.render_token import (
                     TOKEN_FIELD_NAME,
                     parse_submitted_payload,
                 )
 
-                token_str = fragments.get(TOKEN_FIELD_NAME, "")
-                payload = parse_submitted_payload({TOKEN_FIELD_NAME: token_str})
-                if payload is not None:
-                    token_nonce = payload.nonce
+                fragment = fragments.get(TOKEN_FIELD_NAME, "")
+                token_str = _extract_token_value(fragment)
+                if token_str:
+                    payload = parse_submitted_payload({TOKEN_FIELD_NAME: token_str})
+                    if payload is not None:
+                        token_nonce = payload.nonce
             except Exception:
                 # Per fail-open policy: render_token failure must not
                 # break form rendering. The form just renders without

--- a/tests/forms/test_dom_round_trip.py
+++ b/tests/forms/test_dom_round_trip.py
@@ -1,0 +1,194 @@
+"""Browser-shaped integration test for the form-protection render path.
+
+Regression suite for the v0.11.0 → v0.11.1 bug where
+RenderTokenDefence returned the raw token string instead of an
+``<input>`` tag. The unit tests in test_render_token_defence,
+test_orchestrator, test_mixin all passed against the buggy code
+because they constructed POST payloads directly — none of them ever
+parsed the rendered HTML and submitted what a browser would
+actually submit.
+
+This module fills that gap: render the form, parse the HTML for
+hidden inputs, build a POST from those, verify PASS. Any defence
+that owns a hidden field is covered by this round trip.
+"""
+
+from __future__ import annotations
+
+from html.parser import HTMLParser
+from unittest.mock import MagicMock, patch
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _request(*, ip="1.2.3.4", ua="Mozilla/5.0"):
+    req = MagicMock()
+    req.META = {"REMOTE_ADDR": ip, "HTTP_USER_AGENT": ua}
+    req.user = MagicMock(is_authenticated=False)
+    return req
+
+
+class _HiddenInputCollector(HTMLParser):
+    """Extract name=value pairs from every <input> in a fragment.
+
+    Mirrors what a browser does at form submission: read every
+    ``<input>`` (regardless of type) and include its name/value pair
+    in the POST. Honeypot ``type="text"`` inputs are included too
+    — humans don't fill them, but a browser submits them empty.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.inputs: list[tuple[str, str]] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() != "input":
+            return
+        attr_dict = dict(attrs)
+        name = attr_dict.get("name")
+        if not name:
+            return
+        # Browsers submit "" when the value attribute is missing or empty.
+        self.inputs.append((name, attr_dict.get("value", "") or ""))
+
+
+def _parse_inputs(html: str) -> dict[str, str]:
+    """Return {name: value} for every <input> in the fragment.
+
+    Only the first value for each name wins, matching browser
+    behaviour for forms with no duplicate names.
+    """
+    parser = _HiddenInputCollector()
+    parser.feed(html)
+    result: dict[str, str] = {}
+    for name, value in parser.inputs:
+        result.setdefault(name, value)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# DOM round-trip: render → parse → submit → PASS
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTokenDomRoundTrip:
+    """Pin: the token defence renders an <input> the browser will submit."""
+
+    def test_render_then_parse_finds_waf_token_input(self, settings):
+        """The rendered HTML contains exactly one waf_token hidden input
+        carrying a non-empty value."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            protection = FormProtection(
+                form_id="contact",
+                defences=("render_token",),
+                redis_client_factory=lambda: _redis(),
+            )
+            fields = protection.render_fields(_request())
+            html = "".join(fields[k] for k in sorted(fields))
+
+        inputs = _parse_inputs(html)
+        assert "waf_token" in inputs, f"waf_token input missing from rendered DOM. Got inputs: {sorted(inputs)}"
+        assert len(inputs["waf_token"]) > 20  # base64url-ish payload
+
+    def test_token_does_not_leak_as_visible_text(self, settings):
+        """Acceptance criterion 2 from the bug report: no base64url
+        string appears in the DOM outside an input value attribute.
+
+        We approximate 'base64url string' by 'a contiguous run of
+        ≥32 chars from the base64url alphabet that isn't inside a
+        value="..." attribute'.
+        """
+        import re
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            protection = FormProtection(
+                form_id="contact",
+                defences=("render_token",),
+                redis_client_factory=lambda: _redis(),
+            )
+            fields = protection.render_fields(_request())
+            html = "".join(fields[k] for k in sorted(fields))
+
+        # Strip every value="..." span — what's left should not
+        # contain a long base64url-looking run.
+        stripped = re.sub(r'value="[^"]*"', 'value=""', html)
+        # Find runs of base64url characters of length ≥ 32 in the
+        # stripped HTML.
+        leaks = re.findall(r"[A-Za-z0-9_\-]{32,}", stripped)
+        # Filter out the obvious DOM noise (IDs, style classes).
+        # ``_waf_js_touch_input`` is the only legitimate >20-char id.
+        non_dom = [s for s in leaks if not s.startswith("_waf_") and "waf_" not in s]
+        assert non_dom == [], f"Token-shaped strings leaking outside value attributes: {non_dom!r}"
+
+    def test_end_to_end_pass_with_full_defence_chain(self, settings):
+        """Full chain: render → parse → submit → PASS.
+
+        Renders a form with every defence that contributes a hidden
+        input, parses the DOM, builds a POST from those exact inputs
+        (simulating a browser that ran the JS solvers), and asserts
+        the orchestrator returns PASSED.
+
+        This is the test that would have caught the v0.11.0 bug
+        before release.
+        """
+        import hashlib
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormProtection, FormVerdict
+        from icv_waf.services.challenge_service import (
+            _digest_has_leading_zero_bits,
+        )
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            # Drop js_touch from the chain — the simulated 'browser'
+            # below can't actually execute the inline <script>, so we
+            # focus this end-to-end test on the defences that have a
+            # deterministic server-verifiable contract. js_touch is
+            # covered by its own unit tests.
+            protection = FormProtection(
+                form_id="contact",
+                defences=("render_token", "honeypot", "pow_gate"),
+                redis_client_factory=lambda: _redis(),
+            )
+            fields = protection.render_fields(_request())
+            html = "".join(fields[k] for k in sorted(fields))
+
+            # Parse the DOM exactly as a browser would.
+            submitted = _parse_inputs(html)
+
+            # The browser-equivalent runs the PoW solver. Compute a
+            # valid nonce server-side at test time so the simulated
+            # POST is what a real browser would have produced.
+            from icv_waf.forms.defences.pow_gate import NONCE_FIELD
+
+            token_nonce = submitted["waf_pow_token"]
+            difficulty = conf_mod.ICV_WAF_FORM_POW_DIFFICULTY
+            for n in range(1_000_000):
+                msg = f"{token_nonce}:{n}".encode()
+                if _digest_has_leading_zero_bits(hashlib.sha256(msg).digest(), difficulty):
+                    submitted[NONCE_FIELD] = str(n)
+                    break
+            else:  # pragma: no cover
+                raise AssertionError("could not solve PoW in 1M iterations")
+
+            # Submit.
+            result = protection.evaluate(_request(), submitted_data=submitted)
+
+        assert result.verdict == FormVerdict.PASSED, (
+            f"expected PASSED, got {result.verdict.value} "
+            f"with outcomes: {[(o.verdict, o.reason) for o in result.outcomes]}"
+        )

--- a/tests/forms/test_orchestrator.py
+++ b/tests/forms/test_orchestrator.py
@@ -182,9 +182,18 @@ class TestEvaluate:
                 defences=("render_token", "honeypot"),
                 redis_client_factory=lambda: redis,
             )
-            # Render to get a valid token.
+            # Render the form, then build the submission the way a
+            # browser would — by reading the rendered <input>'s
+            # value attribute. Submitting the raw HTML fragment as
+            # the field value (what this test originally did) is what
+            # masked the v0.11.0 bug — pre-bug it accidentally worked
+            # because fields[...] was the raw token, post-bug it stops
+            # working. Use the orchestrator's own _extract_token_value
+            # helper so this test always reflects what browsers do.
+            from icv_waf.forms.protection import _extract_token_value
+
             fields = protection.render_fields(_request())
-            token = fields["waf_token"]
+            token = _extract_token_value(fields["waf_token"])
 
             result = protection.evaluate(
                 _request(),

--- a/tests/forms/test_render_token_defence.py
+++ b/tests/forms/test_render_token_defence.py
@@ -53,8 +53,17 @@ def _eval_ctx(req, submitted_data, form_id="contact", config=None):
 
 
 class TestRenderFields:
-    def test_returns_token_hidden_field(self, settings):
-        """The hidden field name is waf_token (stable for grep)."""
+    def test_returns_token_hidden_input_tag(self, settings):
+        """The fragment must be a hidden <input>, not the raw token.
+
+        Regression: v0.11.0 returned ``mark_safe(token)`` — the bare
+        base64url string. The orchestrator concatenated it into the
+        DOM as visible text, no <input> ever rendered, and every real
+        user POST was rejected with render_token:missing. The
+        original test only checked the fragment was 'a string longer
+        than 20 chars', which the raw token satisfies. Tightened to
+        assert the actual DOM contract.
+        """
         import icv_waf.conf as conf_mod
         from icv_waf.forms.defences.render_token import TOKEN_FIELD_NAME
 
@@ -64,8 +73,27 @@ class TestRenderFields:
 
         assert TOKEN_FIELD_NAME == "waf_token"
         assert TOKEN_FIELD_NAME in fields
-        assert isinstance(fields[TOKEN_FIELD_NAME], str)
-        assert len(fields[TOKEN_FIELD_NAME]) > 20  # base64-encoded payload+sig
+        fragment = fields[TOKEN_FIELD_NAME]
+
+        # Must be a complete hidden <input>, named correctly, with a
+        # non-empty value attribute.
+        assert fragment.startswith(f'<input type="hidden" name="{TOKEN_FIELD_NAME}"'), (
+            f"expected hidden input tag, got: {fragment!r}"
+        )
+        assert 'value="' in fragment
+        assert fragment.rstrip().endswith(">")
+
+        # The token must be inside value="...", not bare in the
+        # fragment text — defends against a future regression that
+        # leaves the token sitting next to (rather than inside) the
+        # input tag.
+        import re
+
+        match = re.search(r'value="([^"]+)"', fragment)
+        assert match, "no value attribute found"
+        token = match.group(1)
+        # base64url-ish (some implementations include padding `=`).
+        assert len(token) > 20
 
     def test_issues_redis_marker_for_token(self, settings):
         """A fresh render must SETEX the one-shot marker."""


### PR DESCRIPTION

### Fixed

- **`RenderTokenDefence.render_fields` shipped the raw token string
  instead of a hidden `<input>` tag** — a critical bug in v0.11.0 that
  made every protected form unusable for real users. The orchestrator
  concatenated the raw token into the DOM as visible page text; no
  `<input name="waf_token">` ever rendered, so browsers never
  submitted a `waf_token` field, and every real-user POST was rejected
  with `render_token:missing`.

  The unit tests in v0.11.0 missed this because they constructed POST
  payloads directly — none ever parsed the rendered HTML and submitted
  what a browser would actually submit. The strengthened tests in this
  release (see "Added" below) close that gap.

  **Fix**: `RenderTokenDefence.render_fields` now returns
  `format_html('<input type="hidden" name="{}" value="{}">', ...)`.
  The orchestrator extracts the nonce back out of the rendered `<input>`
  via a `value="..."` regex when threading it to subsequent defences
  (honeypot, js_touch, pow_gate). No public-API change.

### Added

- **DOM round-trip test suite** (`tests/forms/test_dom_round_trip.py`).
  Renders a protected form, parses the HTML the way a browser would
  (via `html.parser`), builds a POST from the discovered `<input>`
  values, and verifies `PASSED`. This is the test class that would
  have caught the v0.11.0 bug before release; future render-side
  regressions across any defence are now covered.

### Upgrade

Anyone who shipped v0.11.0 with form protection enabled has broken
forms — upgrade immediately:

```bash
pip install -U django-waf
```

No settings or migration changes.


---

### Why this PR is urgent

v0.11.0 shipped a critical bug in `RenderTokenDefence.render_fields` —
it returned the raw token string instead of an `<input>` tag, so
**every protected form was unusable for real users**. Reported by
Vendably during their first production deploy with form protection
enabled.

### Verification

- `pytest`: **687 passed** (was 684 on v0.11.0; +3 DOM round-trip
  tests + strengthened render-token test).
- `ruff check` + `ruff format --check`: clean.
- New `tests/forms/test_dom_round_trip.py` would have caught this
  before release. Renders the form, parses HTML via `html.parser`,
  submits exactly what a browser would. Future render-side
  regressions across any defence are now covered.

### What to eyeball in review

- `src/icv_waf/forms/defences/render_token.py:128–141` — the actual
  fix. `format_html` wrapping; explicit `# noqa` removed since
  there's nothing unsafe to suppress.
- `src/icv_waf/forms/protection.py:170` — new `_extract_token_value`
  helper. Single-purpose regex to read the value back out of the
  rendered `<input>` so the orchestrator can thread the nonce to
  later defences. The site at line 354 that previously did
  `parse_submitted_payload({TOKEN_FIELD_NAME: token_str})` now goes
  through `_extract_token_value` first.
- `tests/forms/test_dom_round_trip.py` — the regression test class.
  Worth reading the docstring at the top for the rationale.

### Backwards compatibility

- No public-API change.
- No settings changes.
- No migrations.

### Recommended urgency

Anyone running v0.11.0 in production with form protection enabled
should `pip install -U django-waf` immediately — all their forms
are currently broken for real users.
