### PR TITLE
fix: v0.11.2 — scalarise QueryDict before passing to defence chain (critical)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,73 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] - 2026-05-27
+
+### Fixed
+
+- **`dict(QueryDict)` produced list-valued entries that crashed the
+  defence chain on every real submission.** Critical bug in v0.11.0
+  and v0.11.1. The mixin's `clean()` (`mixin.py:157`) and the
+  decorator's POST handler (`decorators.py:114`) both called
+  `dict(self.data)` / `dict(request.POST)` — but Django's `QueryDict`
+  stores values as lists internally, and `dict(querydict)` iterates
+  the underlying storage producing entries like `{"waf_token":
+  ["Y29udGFjdHx..."]}`. The defences then crashed (`TypeError: can
+  only concatenate list (not "str") to list` at
+  `base64.urlsafe_b64decode`) or silently mis-evaluated (honeypot
+  saw `[""]`, treating empty fields as filled).
+
+  Production effect: every real-browser POST through a protected
+  form returned a 500 with the TypeError above. Production-affecting
+  for anyone running v0.11.0 or v0.11.1 with form protection
+  enabled.
+
+  Reported by Vendably during the v0.11.1 production rollout —
+  same form, second-consecutive-day breakage. The previous release
+  (v0.11.1) had fixed the render-side bug; this one fixes the
+  submit-side bug. Both bugs passed every unit test in their
+  respective releases because the tests built POST payloads as
+  plain Python dicts, never as actual `QueryDict` instances.
+
+  **Fix**: added `icv_waf.forms.protection.scalarise_submitted_data()`
+  — a single seam between the entry points (mixin, decorator,
+  replay-store) and the orchestrator that calls
+  `QueryDict.dict()` for last-value-per-key string semantics, or
+  falls through to `dict(...)` for plain mappings. Wired into all
+  three call sites. No public-API change.
+
+### Added
+
+- **`tests/forms/test_querydict_round_trip.py`** — regression suite
+  that exercises the mixin and decorator with **real Django
+  `QueryDict` instances**, going through `RequestFactory.post()` and
+  `Client.post()`. Verified to fail loudly without the fix and pass
+  with it. Covers:
+
+    1. `scalarise_submitted_data` contract — `QueryDict` →
+       last-value-per-key strings, plain dicts pass through, `None`
+       → `{}`.
+    2. Mixin path — `Form(request.POST, request=request)` where
+       `request.POST` is a real `QueryDict`.
+    3. Decorator path — `RequestFactory.post()` + Django test
+       `Client.post()`.
+
+  The test suite that would have caught both the v0.11.0 and v0.11.1
+  bugs before either release.
+
+### Upgrade
+
+Anyone running v0.11.0 or v0.11.1 with form protection enabled has
+500s on every real form submission:
+
+```bash
+pip install -U django-waf
+```
+
+No settings or migration changes. The operator-side workaround if
+upgrade is blocked is `ICV_WAF_FORM_PROTECTION_ENABLED=False`, but
+that disables protection entirely — the proper fix is to upgrade.
+
 ## [0.11.1] - 2026-05-27
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "0.11.1"
+version = "0.11.2"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/icv_waf/forms/decorators.py
+++ b/src/icv_waf/forms/decorators.py
@@ -111,7 +111,15 @@ def _handle_post(request, view_func, args, kwargs, form_id, protection):
     Extracted from the wrapper so the GET-replay path can reuse it
     without duplicating the verdict logic.
     """
-    result = protection.evaluate(request, submitted_data=dict(request.POST))
+    # Scalarise via ``scalarise_submitted_data`` — see protection.py
+    # for the rationale. ``dict(request.POST)`` would produce list
+    # values that crash the defence chain.
+    from icv_waf.forms.protection import scalarise_submitted_data
+
+    result = protection.evaluate(
+        request,
+        submitted_data=scalarise_submitted_data(request.POST),
+    )
 
     # Structured log — happens regardless of verdict so logs
     # always reflect the chain's verdict.
@@ -216,7 +224,19 @@ def _maybe_redirect_to_challenge(*, request, form_id: str, result):
     post_url = request.path
     ip = request.META.get("REMOTE_ADDR", "")
 
-    session_key = store_in_session(request, form_id=form_id, post_url=post_url, data=dict(request.POST))
+    # Scalarise so the stored session record contains plain strings,
+    # not QueryDict-style list values. The QueryDict reconstruction
+    # in _try_replay tolerates either shape, but storing scalars
+    # keeps the on-disk record minimal and prevents the
+    # ``dict(QueryDict)`` shape bug from being recreated on replay.
+    from icv_waf.forms.protection import scalarise_submitted_data
+
+    session_key = store_in_session(
+        request,
+        form_id=form_id,
+        post_url=post_url,
+        data=scalarise_submitted_data(request.POST),
+    )
     if session_key is None:
         # Session storage unavailable. Fall back to letting the view
         # handle FLAGGED — operators see the verdict in the log.

--- a/src/icv_waf/forms/mixin.py
+++ b/src/icv_waf/forms/mixin.py
@@ -151,10 +151,15 @@ class ProtectedForm:
 
         # Run the orchestrator against the raw POST data — defences
         # read their own hidden fields by name, not the cleaned form
-        # fields.
+        # fields. Scalarise via ``scalarise_submitted_data`` because
+        # ``self.data`` is a ``QueryDict`` for real bound forms and
+        # ``dict(QueryDict)`` produces list-valued entries that crash
+        # the defence chain (v0.11.0 + v0.11.1 production bug).
+        from icv_waf.forms.protection import scalarise_submitted_data
+
         result = self.waf.evaluate(
             self._waf_request,
-            submitted_data=dict(self.data),
+            submitted_data=scalarise_submitted_data(self.data),
         )
         self.waf_result = result
 

--- a/src/icv_waf/forms/protection.py
+++ b/src/icv_waf/forms/protection.py
@@ -148,6 +148,34 @@ _CANONICAL_ORDER = (
 )
 
 
+def scalarise_submitted_data(data) -> dict[str, str]:
+    """Return a single-value-per-key dict from form-submission data.
+
+    Defences read their hidden fields as scalar strings —
+    ``ctx.submitted_data.get("waf_token")`` is expected to return the
+    token, not ``[token]``. Django's ``QueryDict`` stores values as
+    lists internally; ``dict(querydict)`` iterates the underlying
+    storage and produces list-valued entries, which silently passes
+    the truthy ``or ""`` check in defences and then crashes when the
+    defence tries to ``base64.urlsafe_b64decode`` a list (v0.11.0 +
+    v0.11.1 bug found in production).
+
+    The fix: call ``.dict()`` on a ``QueryDict`` (last-value-per-key
+    string semantics), else just ``dict(data)`` for plain mappings
+    that tests sometimes pass.
+
+    This function is the single seam between the entry points
+    (mixin, decorator, replay) and the orchestrator. Adding it once
+    here closes the class of bug: every defence-facing path goes
+    through this.
+    """
+    # ``QueryDict.dict()`` is the scalarising accessor; we duck-type
+    # against any other MultiValueDict-shaped input that exposes it.
+    if hasattr(data, "dict") and callable(data.dict):
+        return data.dict()
+    return dict(data) if data else {}
+
+
 _TOKEN_VALUE_RE = None  # lazy-compiled on first call
 
 

--- a/tests/forms/test_challenge_replay_flow.py
+++ b/tests/forms/test_challenge_replay_flow.py
@@ -106,12 +106,14 @@ class TestFlaggedRedirect:
         location = response["Location"]
         assert "/waf/challenge/" in location
         assert "form_replay=" in location
-        # Session now has the stashed data. dict(QueryDict) returns
-        # list-valued values, which is what we want for round-trip.
+        # Session now has the stashed data. scalarise_submitted_data
+        # gives last-value-per-key strings — pre-v0.11.2 this was
+        # ``dict(QueryDict)`` producing list-valued entries, which
+        # was the upstream of the bug that broke every real submission.
         stash = request.session.get("waf_form_replay", {})
         assert len(stash) == 1
         only_record = next(iter(stash.values()))
-        assert only_record["data"]["name"] == ["alice"]
+        assert only_record["data"]["name"] == "alice"
         assert only_record["post_url"] == "/contact/"
 
     def test_flagged_without_session_falls_back_to_view(self, settings):

--- a/tests/forms/test_querydict_round_trip.py
+++ b/tests/forms/test_querydict_round_trip.py
@@ -1,0 +1,342 @@
+"""Real-browser-shaped tests: defences see a Django QueryDict, not a dict.
+
+The v0.11.0 + v0.11.1 production bugs both passed every unit test
+because the tests constructed POST data as plain Python dicts. Real
+Django form submissions arrive with ``request.POST`` as a
+``QueryDict`` — and ``dict(QueryDict)`` produces list-valued entries
+that crash the defence chain.
+
+These tests exercise the mixin and decorator with **real
+QueryDicts**, going through ``RequestFactory.post(...)`` for the
+decorator path and binding the form to a real ``request.POST`` for
+the mixin path. They reproduce the production failure mode and pin
+it shut.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from html.parser import HTMLParser
+from unittest.mock import MagicMock, patch
+
+from django import forms
+from django.http import QueryDict
+from django.test import RequestFactory
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _InputCollector(HTMLParser):
+    """Browser-equivalent input extractor — name → value for every <input>."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.inputs: list[tuple[str, str]] = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() != "input":
+            return
+        d = dict(attrs)
+        name = d.get("name")
+        if not name:
+            return
+        self.inputs.append((name, d.get("value", "") or ""))
+
+
+def _parse_inputs(html: str) -> dict[str, str]:
+    parser = _InputCollector()
+    parser.feed(html)
+    out: dict[str, str] = {}
+    for name, value in parser.inputs:
+        out.setdefault(name, value)
+    return out
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    r.exists.return_value = 1
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _solve_pow(token_nonce: str, difficulty: int) -> str:
+    """Match the JS solver's hash construction; return a valid nonce."""
+    from icv_waf.services.challenge_service import _digest_has_leading_zero_bits
+
+    for n in range(1_000_000):
+        msg = f"{token_nonce}:{n}".encode()
+        if _digest_has_leading_zero_bits(hashlib.sha256(msg).digest(), difficulty):
+            return str(n)
+    raise AssertionError("could not solve PoW")
+
+
+# ---------------------------------------------------------------------------
+# scalarise_submitted_data — the helper itself
+# ---------------------------------------------------------------------------
+
+
+class TestScalariseSubmittedData:
+    def test_querydict_returns_last_value_per_key(self):
+        """The bug-fix contract: QueryDict → last-value-per-key strings."""
+        from icv_waf.forms.protection import scalarise_submitted_data
+
+        qd = QueryDict("waf_token=abc&name=jane&color=red&color=blue")
+        out = scalarise_submitted_data(qd)
+
+        assert out["waf_token"] == "abc"
+        assert out["name"] == "jane"
+        # QueryDict.dict() returns the LAST value per key.
+        assert out["color"] == "blue"
+        # No list values anywhere.
+        assert all(isinstance(v, str) for v in out.values())
+
+    def test_plain_dict_passes_through(self):
+        """Tests pass plain dicts; the helper must round-trip them
+        without imposing QueryDict semantics."""
+        from icv_waf.forms.protection import scalarise_submitted_data
+
+        plain = {"waf_token": "abc", "name": "jane"}
+        out = scalarise_submitted_data(plain)
+
+        assert out == plain
+        # Not the same object — the helper returns a copy so callers
+        # can mutate freely.
+        assert out is not plain
+
+    def test_none_returns_empty(self):
+        """Defensive: an unbound form (data=None) returns {}."""
+        from icv_waf.forms.protection import scalarise_submitted_data
+
+        assert scalarise_submitted_data(None) == {}
+
+    def test_does_not_lose_waf_token_value(self):
+        """Pin the actual production failure mode: a QueryDict
+        containing a base64url waf_token must scalarise to that exact
+        string, not [string], so the defence's b64decode succeeds."""
+        from icv_waf.forms.protection import scalarise_submitted_data
+
+        token = "Y29udGFjdHwxLjIuMy40fHwyMDI2LTA1LTI3VDE1OjMyOjA0LjE5ODY0Ny"
+        qd = QueryDict(f"waf_token={token}&name=jane")
+        out = scalarise_submitted_data(qd)
+
+        assert out["waf_token"] == token
+        # Not a list — this is what crashed in production.
+        assert not isinstance(out["waf_token"], list)
+
+
+# ---------------------------------------------------------------------------
+# ProtectedForm mixin — bound to a real QueryDict
+# ---------------------------------------------------------------------------
+
+
+def _build_form_class(form_id, defences):
+    """Build a ContactForm with the given defence chain."""
+    from icv_waf.forms.mixin import ProtectedForm
+    from icv_waf.forms.protection import FormProtection
+
+    redis = _redis()
+
+    class ContactForm(ProtectedForm, forms.Form):
+        name = forms.CharField(required=False)
+        waf = FormProtection(
+            form_id=form_id,
+            defences=defences,
+            redis_client_factory=lambda: redis,
+        )
+
+    return ContactForm
+
+
+class TestMixinWithQueryDict:
+    """The mixin path: Form(request.POST, request=request)."""
+
+    def _bound_request(self, post_data):
+        rf = RequestFactory()
+        request = rf.post("/contact/", data=post_data)
+        request.user = MagicMock(is_authenticated=False)
+        return request
+
+    def test_clean_does_not_raise_on_querydict_post(self, settings):
+        """Pin the production traceback: Form bound to a real QueryDict
+        runs through clean() without TypeError.
+
+        Pre-v0.11.2 this crashed at verify_token with
+        ``TypeError: can only concatenate list (not "str") to list``
+        because dict(QueryDict) put the token in a list.
+        """
+        import icv_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            ContactForm = _build_form_class("contact-querydict-noraise", ("render_token", "honeypot"))
+
+            # Render to get a real token.
+            req = self._bound_request({})  # empty POST just to get a request shape
+            form_for_render = ContactForm(request=req)
+            inputs = _parse_inputs(form_for_render.waf_fields)
+
+            # Build the submission via a real Django QueryDict (what
+            # request.POST is in production).
+            request = self._bound_request({"name": "alice", "waf_token": inputs["waf_token"]})
+            form = ContactForm(request.POST, request=request)
+
+            # Pre-fix: TypeError. Post-fix: form validates.
+            assert form.is_valid(), f"form failed to validate: {form.errors!r}"
+
+    def test_clean_returns_passed_verdict(self, settings):
+        """Same as above but assert the verdict explicitly."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            ContactForm = _build_form_class("contact-querydict-passed", ("render_token", "honeypot"))
+            req = self._bound_request({})
+            inputs = _parse_inputs(ContactForm(request=req).waf_fields)
+
+            request = self._bound_request({"name": "alice", "waf_token": inputs["waf_token"]})
+            form = ContactForm(request.POST, request=request)
+            form.is_valid()
+
+        assert form.waf_result is not None
+        assert form.waf_result.verdict == FormVerdict.PASSED
+        # And the token payload is verified — proof the defences saw
+        # the scalar token, not [token].
+        assert form.waf_result.token_payload is not None
+
+    def test_clean_with_full_chain_including_pow(self, settings):
+        """End-to-end with PoW: render → solve → submit via QueryDict → PASS."""
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.protection import FormVerdict
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+            ContactForm = _build_form_class("contact-qd-full", ("render_token", "honeypot", "pow_gate"))
+            req = self._bound_request({})
+            inputs = _parse_inputs(ContactForm(request=req).waf_fields)
+
+            # Browser-equivalent: solve the PoW.
+            nonce = _solve_pow(inputs["waf_pow_token"], conf_mod.ICV_WAF_FORM_POW_DIFFICULTY)
+
+            # Build the QueryDict the browser would send.
+            request = self._bound_request(
+                {
+                    "name": "alice",
+                    "waf_token": inputs["waf_token"],
+                    "waf_pow_token": inputs["waf_pow_token"],
+                    "waf_pow_nonce": nonce,
+                }
+            )
+            form = ContactForm(request.POST, request=request)
+            assert form.is_valid(), f"errors: {form.errors!r}"
+
+        assert form.waf_result.verdict == FormVerdict.PASSED
+
+
+# ---------------------------------------------------------------------------
+# Decorator — request.POST is a real QueryDict
+# ---------------------------------------------------------------------------
+
+
+class TestDecoratorWithQueryDict:
+    """The decorator path: @waf_protect_post handles the QueryDict."""
+
+    def test_post_via_request_factory_does_not_raise(self, settings):
+        """RequestFactory.post() puts a real QueryDict on request.POST.
+
+        Pre-v0.11.2 the decorator's dict(request.POST) produced list
+        values that crashed in render_token.evaluate. Post-fix the
+        decorator scalarises before passing to the orchestrator.
+        """
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import _registry_get, waf_protect_post
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-decorator-qd",
+                defences=("render_token", "honeypot"),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                from django.http import HttpResponse
+
+                # If we reach here, the chain didn't crash.
+                return HttpResponse(f"verdict={request.waf_form_result.verdict.value}")
+
+            # Render first to get a valid token (via direct render_fields).
+            protection = _registry_get("contact-decorator-qd")
+            rf = RequestFactory()
+            render_req = rf.get("/contact/")
+            render_req.user = MagicMock(is_authenticated=False)
+            fields = protection.render_fields(render_req)
+            inputs = _parse_inputs("".join(fields[k] for k in sorted(fields)))
+
+            # POST as a browser would.
+            request = rf.post(
+                "/contact/",
+                data={"name": "alice", "waf_token": inputs["waf_token"]},
+            )
+            request.user = MagicMock(is_authenticated=False)
+            response = view(request)
+
+        # No crash; view ran; verdict was PASSED (not BLOCKED).
+        assert response.status_code == 200
+        assert b"verdict=passed" in response.content
+
+    def test_post_via_django_test_client_does_not_raise(self, settings, client):
+        """The most realistic shape: Django ``Client.post()`` through the
+        full middleware stack, with sessions, CSRF, etc.
+
+        Needs an actual URL wired in. We register one inline via the
+        decorator + ``override_settings(ROOT_URLCONF=...)`` so this
+        test stands alone without polluting tests/urls.py.
+        """
+        from django.test import override_settings
+        from django.urls import path
+
+        import icv_waf.conf as conf_mod
+        from icv_waf.forms.decorators import _registry_get, waf_protect_post
+
+        with patch.object(conf_mod, "ICV_WAF_SIGNING_KEY", "k"):
+
+            @waf_protect_post(
+                form_id="contact-djclient",
+                defences=("render_token", "honeypot"),
+                redis_client_factory=lambda: _redis(),
+            )
+            def view(request):
+                from django.http import HttpResponse
+
+                if request.method == "POST":
+                    return HttpResponse(f"verdict={request.waf_form_result.verdict.value}")
+                return HttpResponse("get-ok")
+
+            url_patterns = [path("contact/", view, name="contact-djclient")]
+
+            with override_settings(ROOT_URLCONF=type("M", (), {"urlpatterns": url_patterns})):
+                # Get the form to render and grab a valid token.
+                protection = _registry_get("contact-djclient")
+                rf = RequestFactory()
+                render_req = rf.get("/contact/")
+                render_req.user = MagicMock(is_authenticated=False)
+                inputs = _parse_inputs(
+                    "".join(
+                        protection.render_fields(render_req)[k] for k in sorted(protection.render_fields(render_req))
+                    )
+                )
+
+                # POST through the real test client — this is exactly
+                # what a browser does. request.POST will be a real
+                # QueryDict here.
+                response = client.post(
+                    "/contact/",
+                    data={"name": "alice", "waf_token": inputs["waf_token"]},
+                )
+
+        # Critical: no 500. Pre-v0.11.2 this would 500 with a TypeError.
+        assert response.status_code != 500, f"500 from QueryDict crash: {response.content.decode()[:200]}"
+        assert response.status_code == 200
+        assert b"verdict=passed" in response.content


### PR DESCRIPTION

### Fixed

- **`dict(QueryDict)` produced list-valued entries that crashed the
  defence chain on every real submission.** Critical bug in v0.11.0
  and v0.11.1. The mixin's `clean()` (`mixin.py:157`) and the
  decorator's POST handler (`decorators.py:114`) both called
  `dict(self.data)` / `dict(request.POST)` — but Django's `QueryDict`
  stores values as lists internally, and `dict(querydict)` iterates
  the underlying storage producing entries like `{"waf_token":
  ["Y29udGFjdHx..."]}`. The defences then crashed (`TypeError: can
  only concatenate list (not "str") to list` at
  `base64.urlsafe_b64decode`) or silently mis-evaluated (honeypot
  saw `[""]`, treating empty fields as filled).

  Production effect: every real-browser POST through a protected
  form returned a 500 with the TypeError above. Production-affecting
  for anyone running v0.11.0 or v0.11.1 with form protection
  enabled.

  Reported by Vendably during the v0.11.1 production rollout —
  same form, second-consecutive-day breakage. The previous release
  (v0.11.1) had fixed the render-side bug; this one fixes the
  submit-side bug. Both bugs passed every unit test in their
  respective releases because the tests built POST payloads as
  plain Python dicts, never as actual `QueryDict` instances.

  **Fix**: added `icv_waf.forms.protection.scalarise_submitted_data()`
  — a single seam between the entry points (mixin, decorator,
  replay-store) and the orchestrator that calls
  `QueryDict.dict()` for last-value-per-key string semantics, or
  falls through to `dict(...)` for plain mappings. Wired into all
  three call sites. No public-API change.

### Added

- **`tests/forms/test_querydict_round_trip.py`** — regression suite
  that exercises the mixin and decorator with **real Django
  `QueryDict` instances**, going through `RequestFactory.post()` and
  `Client.post()`. Verified to fail loudly without the fix and pass
  with it. Covers:

    1. `scalarise_submitted_data` contract — `QueryDict` →
       last-value-per-key strings, plain dicts pass through, `None`
       → `{}`.
    2. Mixin path — `Form(request.POST, request=request)` where
       `request.POST` is a real `QueryDict`.
    3. Decorator path — `RequestFactory.post()` + Django test
       `Client.post()`.

  The test suite that would have caught both the v0.11.0 and v0.11.1
  bugs before either release.

### Upgrade

Anyone running v0.11.0 or v0.11.1 with form protection enabled has
500s on every real form submission:

```bash
pip install -U django-waf
```

No settings or migration changes. The operator-side workaround if
upgrade is blocked is `ICV_WAF_FORM_PROTECTION_ENABLED=False`, but
that disables protection entirely — the proper fix is to upgrade.


---

### Why this PR is urgent

Same forms broken two days running. v0.11.0 silently rejected every
real user. v0.11.1 fixed that but introduced this 500-on-submit bug.
v0.11.2 fixes this. Reported by Vendably; production-affecting for
anyone on v0.11.0 or v0.11.1 with form protection enabled.

### What the test-suite review found

The reporter correctly diagnosed the root reason both bugs slipped
through: every prior unit test built POST data as a plain Python
dict. Real Django form submissions arrive as `QueryDict`. The
two-line difference is what crashed production.

`tests/forms/test_querydict_round_trip.py` (new in this PR) closes
the gap with 9 tests that go through `RequestFactory.post()` and
Django's test `Client.post()` — verified by reverting the fix and
watching them fail with the exact production TypeError, then
re-applying and watching them pass.

### What to eyeball in review

- `src/icv_waf/forms/protection.py` — new `scalarise_submitted_data()`
  module-level helper. Single seam between entry points and
  defences.
- `src/icv_waf/forms/mixin.py:157` + `src/icv_waf/forms/decorators.py:114, 219`
  — three call sites all routed through the new helper. Going forward,
  any new entry point should use the same helper.
- `tests/forms/test_querydict_round_trip.py` — the regression suite
  that would have caught both bugs.

### Backwards compatibility

- No public-API change.
- No settings changes.
- No migrations.
