### PR TITLE
release: 1.1.0, hardening fixes (IPv6 /48 aggregation, stampede lock, panel degradation, window_minutes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `detect_subnet_burst`, `detect_cloud_spray`, and `build_telemetry_payload`
+  now aggregate IPv6 addresses to their /48 network instead of naively
+  applying an IPv4-style /24, which for IPv6 produced an absurdly wide (and
+  meaningless) network and, for telemetry, was one step away from leaking
+  full IPv6 addresses. All three call sites now share a
+  `_get_subnet_prefix()` helper in `anomaly_detector.py` (IPv4 stays /24,
+  IPv6 is /48).
+- `load_rule_cache` now guards its database rebuild with a short-lived Redis
+  lock (`waf:rule_cache:lock`, 5s TTL) so that concurrent worker processes
+  racing on a cache miss (typically right after the rule version bumps) no
+  longer all hit the database simultaneously. Retries acquiring the lock up
+  to 3 times with a 100ms delay, then proceeds without it (fail-open) rather
+  than blocking the request.
+- `DashboardTopBlockedPanel` and `DashboardAnomalyPanel` now catch database
+  errors in `get_context_data` and degrade to an empty panel (`ips=[]` /
+  `rules=[]`), matching the fallback already in place on
+  `DashboardStatsPanel`. Previously a DB or Redis error on either panel
+  raised and broke the whole dashboard fragment.
+- `django_waf_detect_anomalies --window-minutes` was broken since the flag
+  was added: the command forwarded `window_minutes` to
+  `anomaly_detector.run_all_detectors()`, but that function accepted no
+  parameters, so passing the flag always raised `TypeError` (surfaced as a
+  `CommandError`). `run_all_detectors` now takes `window_minutes: int | None
+  = None` and forwards it to all five detectors (converted to hours for
+  `detect_challenge_farms`, which takes its window in hours); omitting the
+  flag is unchanged and leaves each detector on its own default window.
+
 ### Changed
 
 - Publishing is now triggered by pushing a `v<semver>` tag instead of creating

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.0] - 2026-07-10
+
+Minor rather than patch because two changes are consumer-visible behaviour:
+IPv6 sources now produce /48 rule patterns and telemetry keys (previously
+an IPv4-style /24 of IPv6 space), so anything consuming auto-created rule
+patterns or telemetry payloads will see new shapes; and
+`run_all_detectors()` gained an optional `window_minutes` parameter (new
+public API).
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "1.0.1"
+version = "1.1.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/django_waf/management/commands/django_waf_detect_anomalies.py
+++ b/src/django_waf/management/commands/django_waf_detect_anomalies.py
@@ -36,10 +36,7 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("[dry-run] Analysing anomalies — no rules will be created."))
 
         try:
-            kwargs: dict = {}
-            if window_minutes is not None:
-                kwargs["window_minutes"] = window_minutes
-            results = run_all_detectors(**kwargs)
+            results = run_all_detectors(window_minutes=window_minutes)
         except Exception as exc:
             raise CommandError(f"Anomaly detection failed: {exc}") from exc
 

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -78,7 +78,7 @@ def detect_ua_rotation(
 
 
 def detect_subnet_burst(window_minutes: int = 15) -> list:
-    """Detect /24 subnets with anomalously high request volume.
+    """Detect /24 (IPv4) or /48 (IPv6) subnets with anomalously high request volume.
 
     Per BR-ANOM-002: flags subnets where request count exceeds 3× the mean
     per-subnet rate in the last window_minutes.
@@ -96,11 +96,11 @@ def detect_subnet_burst(window_minutes: int = 15) -> list:
     cutoff = timezone.now() - timedelta(minutes=window_minutes)
     logs = RequestLog.objects.filter(timestamp__gte=cutoff).values_list("ip_address", flat=True)
 
-    # Count requests per /24 subnet
+    # Count requests per subnet (/24 for IPv4, /48 for IPv6)
     subnet_counts: dict[str, int] = {}
     for ip in logs:
         try:
-            subnet = str(ipaddress.ip_network(f"{ip}/24", strict=False))
+            subnet = _get_subnet_prefix(ip)
         except ValueError:
             continue
         subnet_counts[subnet] = subnet_counts.get(subnet, 0) + 1
@@ -330,8 +330,10 @@ def detect_cloud_spray(window_minutes: int = 30) -> list:
     where each IP makes only 1-3 requests with no referer. This pattern is
     characteristic of cloud-hosted bot farms that evade per-IP rate limits.
 
-    Flags /24 subnets rather than individual IPs — cloud providers allocate
-    contiguous blocks, so a single /24 CIDR catches the cluster efficiently.
+    Flags subnets rather than individual IPs — cloud providers allocate
+    contiguous blocks, so a single CIDR catches the cluster efficiently.
+    Aggregation uses ``_get_subnet_prefix`` (the /24 network for IPv4, the
+    /48 network for IPv6), shared with ``detect_subnet_burst``.
 
     Args:
         window_minutes: Time window to analyse (default 30).
@@ -384,11 +386,11 @@ def detect_cloud_spray(window_minutes: int = 30) -> list:
         if len(suspicious_ips) < min_ips:
             continue
 
-        # Step 3: Aggregate into /24 subnets and create rules
+        # Step 3: Aggregate into subnets (/24 IPv4, /48 IPv6) and create rules
         subnet_counts: dict[str, int] = {}
         for ip in suspicious_ips:
             try:
-                subnet = str(ipaddress.ip_network(f"{ip}/24", strict=False))
+                subnet = _get_subnet_prefix(ip)
             except ValueError:
                 continue
             subnet_counts[subnet] = subnet_counts.get(subnet, 0) + 1
@@ -427,18 +429,33 @@ def detect_cloud_spray(window_minutes: int = 30) -> list:
     return created_rules
 
 
-def run_all_detectors() -> dict:
+def run_all_detectors(window_minutes: int | None = None) -> dict:
     """Run all anomaly detectors and return a summary of findings.
+
+    Args:
+        window_minutes: Override the analysis window, in minutes, for every
+            detector. ``None`` (the default) leaves each detector on its own
+            configured default window. ``detect_challenge_farms`` takes its
+            window in hours, so the value is converted (rounded up to the
+            nearest hour, minimum 1) before being forwarded to it.
 
     Returns:
         Dict with keys: ua_rotation_rules, subnet_burst_rules,
         challenge_farm_rules, total_rules_created.
     """
-    ua_rules = detect_ua_rotation()
-    subnet_rules = detect_subnet_burst()
-    farm_rules = detect_challenge_farms()
-    unsolved_rules = detect_unsolved_challenges()
-    spray_rules = detect_cloud_spray()
+    if window_minutes is None:
+        ua_rules = detect_ua_rotation()
+        subnet_rules = detect_subnet_burst()
+        farm_rules = detect_challenge_farms()
+        unsolved_rules = detect_unsolved_challenges()
+        spray_rules = detect_cloud_spray()
+    else:
+        window_hours = max(1, -(-window_minutes // 60))  # ceiling division
+        ua_rules = detect_ua_rotation(window_minutes=window_minutes)
+        subnet_rules = detect_subnet_burst(window_minutes=window_minutes)
+        farm_rules = detect_challenge_farms(window_hours=window_hours)
+        unsolved_rules = detect_unsolved_challenges(window_minutes=window_minutes)
+        spray_rules = detect_cloud_spray(window_minutes=window_minutes)
 
     total = len(ua_rules) + len(subnet_rules) + len(farm_rules) + len(unsolved_rules) + len(spray_rules)
     logger.info(
@@ -465,6 +482,31 @@ def run_all_detectors() -> dict:
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _get_subnet_prefix(ip: str) -> str:
+    """Return the subnet prefix used for aggregating an IP address.
+
+    IPv4 addresses are truncated to their /24 network. IPv6 addresses are
+    truncated to their /48 network — a /24-equivalent aggregation for IPv6
+    would silently span an enormous address range (a /24 IPv6 network still
+    contains 2**104 addresses), corrupting burst detection, cloud-spray
+    aggregation, and telemetry aggregation alike. Shared by
+    ``detect_subnet_burst`` and ``detect_cloud_spray`` (this module) and
+    ``threat_feed.build_telemetry_payload``.
+
+    Args:
+        ip: An IPv4 or IPv6 address string.
+
+    Returns:
+        The subnet in CIDR notation, e.g. "192.0.2.0/24" or "2001:db8::/48".
+
+    Raises:
+        ValueError: If ``ip`` is not a valid IP address.
+    """
+    parsed = ipaddress.ip_address(ip)
+    prefix_length = 24 if parsed.version == 4 else 48
+    return str(ipaddress.ip_network(f"{ip}/{prefix_length}", strict=False))
 
 
 def _get_or_create_auto_rule(

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -53,6 +53,11 @@ _BOT_RDNS_KEY = "waf:bot_rdns:{ip}"
 _STATS_KEY = "waf:stats:today"
 _CACHE_TTL = 600  # 10 minutes
 
+_REBUILD_LOCK_KEY = "waf:rule_cache:lock"
+_REBUILD_LOCK_TTL = 5  # seconds
+_REBUILD_LOCK_RETRIES = 3
+_REBUILD_LOCK_RETRY_DELAY = 0.1  # seconds
+
 # In-process rule cache — avoids Redis GET + JSON parse + regex compilation
 # on every request when the rule version hasn't changed.
 _process_cache: RuleCache | None = None
@@ -117,7 +122,63 @@ def load_rule_cache(redis_client) -> RuleCache:
 
 
 def _rebuild_rule_cache(redis_client, version: int, cache_key: str) -> RuleCache:
-    """Rebuild the rule cache from the database and store in Redis."""
+    """Rebuild the rule cache from the database and store in Redis.
+
+    Acquires a short-lived Redis lock before rebuilding so that concurrent
+    worker processes racing on a cache miss (e.g. immediately after the rule
+    version bumps) don't all hit the database at once. Retries a few times
+    on lock contention, then proceeds without the lock (fail-open) rather
+    than blocking indefinitely — a duplicate rebuild is wasted work, not a
+    correctness problem.
+    """
+    lock_acquired = _acquire_rebuild_lock(redis_client)
+    try:
+        return _rebuild_rule_cache_from_db(redis_client, version, cache_key)
+    finally:
+        if lock_acquired:
+            _release_rebuild_lock(redis_client)
+
+
+def _acquire_rebuild_lock(redis_client) -> bool:
+    """Try to acquire the rule-cache rebuild lock, retrying briefly on contention.
+
+    Returns:
+        True if the lock was acquired (caller must release it). False if the
+        lock could not be acquired after retrying — the caller proceeds
+        without it (fail-open).
+    """
+    import time
+
+    for attempt in range(_REBUILD_LOCK_RETRIES + 1):
+        try:
+            acquired = redis_client.set(_REBUILD_LOCK_KEY, "1", nx=True, ex=_REBUILD_LOCK_TTL)
+        except Exception:
+            logger.warning("django-waf: rule cache lock acquisition failed; proceeding without lock")
+            return False
+
+        if acquired:
+            return True
+
+        if attempt < _REBUILD_LOCK_RETRIES:
+            time.sleep(_REBUILD_LOCK_RETRY_DELAY)
+
+    logger.warning(
+        "django-waf: rule cache lock unavailable after %d retries; proceeding fail-open",
+        _REBUILD_LOCK_RETRIES,
+    )
+    return False
+
+
+def _release_rebuild_lock(redis_client) -> None:
+    """Delete the rule-cache rebuild lock."""
+    try:
+        redis_client.delete(_REBUILD_LOCK_KEY)
+    except Exception:
+        logger.warning("django-waf: failed to release rule cache lock")
+
+
+def _rebuild_rule_cache_from_db(redis_client, version: int, cache_key: str) -> RuleCache:
+    """Read active rules from the database and store the JSON cache in Redis."""
     from django_waf.models import AllowRule, BlockRule
 
     block_qs = BlockRule.objects.active().values(

--- a/src/django_waf/services/threat_feed.py
+++ b/src/django_waf/services/threat_feed.py
@@ -8,7 +8,6 @@ telemetry reporting. Per BR-FEED-001 through BR-TEL-004.
 from __future__ import annotations
 
 import hashlib
-import ipaddress
 import logging
 import uuid
 from datetime import timedelta
@@ -160,7 +159,8 @@ def build_telemetry_payload(period_start, period_end) -> dict:
     """Build the anonymised telemetry payload for the reporting period.
 
     Per BR-TEL-002: no full IPs, no paths, no user identifiers. UA strings are
-    SHA-256 hashed. IPs are truncated to /24 subnets.
+    SHA-256 hashed. IPs are truncated to /24 subnets (IPv4) or /48 subnets
+    (IPv6) — a full IPv6 address must never appear in the payload.
 
     Args:
         period_start: datetime of the reporting period start.
@@ -173,6 +173,7 @@ def build_telemetry_payload(period_start, period_end) -> dict:
 
     from django_waf.enums import RuleSource
     from django_waf.models import BlockRule, RequestLog
+    from django_waf.services.anomaly_detector import _get_subnet_prefix
 
     install_id = get_or_create_install_id()
 
@@ -202,7 +203,7 @@ def build_telemetry_payload(period_start, period_end) -> dict:
     subnet_counts: dict[str, dict] = {}
     for log in logs_in_period.values("ip_address", "verdict"):
         try:
-            subnet = str(ipaddress.ip_network(f"{log['ip_address']}/24", strict=False))
+            subnet = _get_subnet_prefix(log["ip_address"])
         except ValueError:
             continue
         if subnet not in subnet_counts:

--- a/src/django_waf/views.py
+++ b/src/django_waf/views.py
@@ -376,10 +376,14 @@ class DashboardTopBlockedPanel(StaffRequiredMixin, TemplateView):
     template_name = "django_waf/partials/top_blocked_panel.html"
 
     def get_context_data(self, **kwargs) -> dict:
-        from django_waf.models import IPReputation
-
         ctx = super().get_context_data(**kwargs)
-        ctx["ips"] = IPReputation.objects.order_by("-blocked_requests")[:10]
+        try:
+            from django_waf.models import IPReputation
+
+            ctx["ips"] = IPReputation.objects.order_by("-blocked_requests")[:10]
+        except Exception:
+            logger.warning("django-waf: could not fetch top-blocked IPs; degrading to empty panel")
+            ctx["ips"] = []
         return ctx
 
 
@@ -397,19 +401,23 @@ class DashboardAnomalyPanel(StaffRequiredMixin, TemplateView):
     template_name = "django_waf/partials/anomalies_panel.html"
 
     def get_context_data(self, **kwargs) -> dict:
-        from datetime import timedelta
-
-        from django.utils import timezone
-
-        from django_waf.enums import RuleSource
-        from django_waf.models import BlockRule
-
         ctx = super().get_context_data(**kwargs)
-        cutoff = timezone.now() - timedelta(hours=48)
-        ctx["rules"] = BlockRule.objects.filter(
-            source=RuleSource.AUTO,
-            created_at__gte=cutoff,
-        ).order_by("-created_at")
+        try:
+            from datetime import timedelta
+
+            from django.utils import timezone
+
+            from django_waf.enums import RuleSource
+            from django_waf.models import BlockRule
+
+            cutoff = timezone.now() - timedelta(hours=48)
+            ctx["rules"] = BlockRule.objects.filter(
+                source=RuleSource.AUTO,
+                created_at__gte=cutoff,
+            ).order_by("-created_at")
+        except Exception:
+            logger.warning("django-waf: could not fetch anomaly rules; degrading to empty panel")
+            ctx["rules"] = []
         return ctx
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -10,13 +10,14 @@ Each command is tested for:
 from __future__ import annotations
 
 from io import StringIO
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, create_autospec, patch
 
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from django.utils import timezone
 
+from django_waf.services.anomaly_detector import run_all_detectors
 from django_waf.testing.factories import BlockRuleFactory, RequestLogFactory
 
 # ---------------------------------------------------------------------------
@@ -128,19 +129,34 @@ class TestGenerateBlocklistCommand:
 class TestDetectAnomaliesCommand:
     """Tests for the ``django_waf_detect_anomalies`` management command."""
 
+    @staticmethod
+    def _autospec_detector(return_value=None, side_effect=None):
+        """Build an autospec'd mock of run_all_detectors.
+
+        Using ``create_autospec`` (rather than a loose ``patch(...)``) means a
+        call with a signature the real function doesn't accept raises
+        ``TypeError`` from the mock itself, catching regressions like the one
+        that let ``--window-minutes`` silently pass an unsupported keyword
+        argument through to the service for an entire release.
+        """
+        mock_detect = create_autospec(run_all_detectors, spec_set=True)
+        if side_effect is not None:
+            mock_detect.side_effect = side_effect
+        else:
+            mock_detect.return_value = return_value
+        return mock_detect
+
     @pytest.mark.django_db
     def test_dry_run_reports_without_creating_rules(self):
         """Dry-run emits the dry-run notice and displays detector results."""
         results = {"burst_detector": [MagicMock(), MagicMock()], "ua_rotation": []}
+        mock_detect = self._autospec_detector(return_value=results)
 
-        with patch(
-            "django_waf.services.anomaly_detector.run_all_detectors",
-            return_value=results,
-        ) as mock_detect:
+        with patch("django_waf.services.anomaly_detector.run_all_detectors", mock_detect):
             out = StringIO()
             call_command("django_waf_detect_anomalies", "--dry-run", stdout=out)
 
-        mock_detect.assert_called_once_with()
+        mock_detect.assert_called_once_with(window_minutes=None)
         output = out.getvalue()
         assert "dry-run" in output
         assert "would create" in output
@@ -150,15 +166,13 @@ class TestDetectAnomaliesCommand:
     def test_normal_run_calls_service(self):
         """Normal run calls run_all_detectors and reports created rule counts."""
         results = {"burst_detector": [MagicMock()], "ua_rotation": [MagicMock(), MagicMock()]}
+        mock_detect = self._autospec_detector(return_value=results)
 
-        with patch(
-            "django_waf.services.anomaly_detector.run_all_detectors",
-            return_value=results,
-        ) as mock_detect:
+        with patch("django_waf.services.anomaly_detector.run_all_detectors", mock_detect):
             out = StringIO()
             call_command("django_waf_detect_anomalies", stdout=out)
 
-        mock_detect.assert_called_once_with()
+        mock_detect.assert_called_once_with(window_minutes=None)
         output = out.getvalue()
         assert "created" in output
         assert "3 anomaly rule(s)" in output
@@ -166,10 +180,9 @@ class TestDetectAnomaliesCommand:
     @pytest.mark.django_db
     def test_window_minutes_forwarded_to_service(self):
         """--window-minutes is passed through to run_all_detectors."""
-        with patch(
-            "django_waf.services.anomaly_detector.run_all_detectors",
-            return_value={},
-        ) as mock_detect:
+        mock_detect = self._autospec_detector(return_value={})
+
+        with patch("django_waf.services.anomaly_detector.run_all_detectors", mock_detect):
             call_command("django_waf_detect_anomalies", "--window-minutes=10")
 
         mock_detect.assert_called_once_with(window_minutes=10)
@@ -177,10 +190,9 @@ class TestDetectAnomaliesCommand:
     @pytest.mark.django_db
     def test_no_anomalies_detected_message(self):
         """When no anomalies are detected the success message is shown."""
-        with patch(
-            "django_waf.services.anomaly_detector.run_all_detectors",
-            return_value={"burst_detector": [], "ua_rotation": []},
-        ):
+        mock_detect = self._autospec_detector(return_value={"burst_detector": [], "ua_rotation": []})
+
+        with patch("django_waf.services.anomaly_detector.run_all_detectors", mock_detect):
             out = StringIO()
             call_command("django_waf_detect_anomalies", stdout=out)
 
@@ -189,11 +201,10 @@ class TestDetectAnomaliesCommand:
     @pytest.mark.django_db
     def test_service_exception_raises_command_error(self):
         """A service exception is converted to CommandError."""
+        mock_detect = self._autospec_detector(side_effect=ValueError("bad window"))
+
         with (
-            patch(
-                "django_waf.services.anomaly_detector.run_all_detectors",
-                side_effect=ValueError("bad window"),
-            ),
+            patch("django_waf.services.anomaly_detector.run_all_detectors", mock_detect),
             pytest.raises(CommandError, match="Anomaly detection failed"),
         ):
             call_command("django_waf_detect_anomalies")
@@ -201,15 +212,30 @@ class TestDetectAnomaliesCommand:
     @pytest.mark.django_db
     def test_dry_run_with_window_minutes(self):
         """Dry-run correctly forwards --window-minutes."""
-        with patch(
-            "django_waf.services.anomaly_detector.run_all_detectors",
-            return_value={"ua_rotation": [MagicMock()]},
-        ) as mock_detect:
+        mock_detect = self._autospec_detector(return_value={"ua_rotation": [MagicMock()]})
+
+        with patch("django_waf.services.anomaly_detector.run_all_detectors", mock_detect):
             out = StringIO()
             call_command("django_waf_detect_anomalies", "--dry-run", "--window-minutes=20", stdout=out)
 
         mock_detect.assert_called_once_with(window_minutes=20)
         assert "dry-run" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_window_minutes_end_to_end_against_real_service(self):
+        """--window-minutes reaches the real run_all_detectors without mocking.
+
+        Regression test for the bug where the command forwarded
+        ``window_minutes`` to a ``run_all_detectors()`` that accepted no
+        parameters at all, raising ``TypeError`` (masked as a CommandError)
+        whenever ``--window-minutes`` was passed. No RequestLog data is
+        created, so no anomalies are expected; the point is that the command
+        completes successfully end-to-end with the flag set.
+        """
+        out = StringIO()
+        call_command("django_waf_detect_anomalies", "--window-minutes=10", stdout=out)
+
+        assert "No anomalies detected" in out.getvalue()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -437,6 +437,39 @@ class TestLoadRuleCache:
         # Still returns valid cache rebuilt from DB
         assert len(cache.block_rules) == 1
 
+    def test_rebuild_acquires_and_releases_stampede_lock(self, db):
+        """On a cache miss, the rebuild acquires the Redis lock and releases it after."""
+        BlockRuleFactory(is_active=True)
+
+        redis = _make_redis()
+        redis.set.return_value = True  # Lock acquired on first try
+
+        load_rule_cache(redis)
+
+        redis.set.assert_any_call("waf:rule_cache:lock", "1", nx=True, ex=5)
+        redis.delete.assert_any_call("waf:rule_cache:lock")
+
+    def test_rebuild_proceeds_fail_open_when_lock_unavailable(self, db):
+        """When the lock cannot be acquired after retrying, the rebuild proceeds anyway.
+
+        Per the stampede-protection fix: losing the lock race must not block
+        the request. The rebuild still returns a valid RuleCache and the
+        lock is never released by this process (it never held it).
+        """
+        BlockRuleFactory(is_active=True)
+
+        redis = _make_redis()
+        redis.set.return_value = False  # Lock always contended
+
+        with patch("time.sleep") as mock_sleep:
+            cache = load_rule_cache(redis)
+
+        assert len(cache.block_rules) == 1
+        # Retried up to 3 times, sleeping between attempts, then gave up.
+        assert mock_sleep.call_count == 3
+        # Never held the lock, so must not have tried to release it.
+        redis.delete.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # evaluate_request
@@ -1420,6 +1453,38 @@ class TestDetectSubnetBurst:
 
 
 # ---------------------------------------------------------------------------
+# _get_subnet_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestGetSubnetPrefix:
+    def test_ipv4_returns_slash24(self):
+        """An IPv4 address is truncated to its /24 network."""
+        from django_waf.services.anomaly_detector import _get_subnet_prefix
+
+        assert _get_subnet_prefix("192.0.2.100") == "192.0.2.0/24"
+
+    def test_ipv6_returns_slash48(self):
+        """An IPv6 address is truncated to its /48 network, not a /24.
+
+        Regression: naively applying "/24" to an IPv6 address (as
+        ipaddress.ip_network(f"{ip}/24", strict=False) does) produces an
+        absurdly wide network — a /24 IPv6 prefix still spans 2**104
+        addresses. /48 is the correct IPv6-equivalent aggregation.
+        """
+        from django_waf.services.anomaly_detector import _get_subnet_prefix
+
+        assert _get_subnet_prefix("2001:db8:abcd:1234::1") == "2001:db8:abcd::/48"
+
+    def test_invalid_ip_raises_value_error(self):
+        """An invalid IP string raises ValueError so callers can skip it."""
+        from django_waf.services.anomaly_detector import _get_subnet_prefix
+
+        with pytest.raises(ValueError):
+            _get_subnet_prefix("999.999.999.999")
+
+
+# ---------------------------------------------------------------------------
 # detect_challenge_farms
 # ---------------------------------------------------------------------------
 
@@ -1682,6 +1747,49 @@ class TestDetectSubnetBurstBranches:
             result = detect_subnet_burst(window_minutes=60)
 
         assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# detect_cloud_spray — IPv6 subnet aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestDetectCloudSprayIPv6:
+    def test_ipv6_suspicious_ips_are_aggregated_to_slash48_not_slash24(self, db):
+        """detect_cloud_spray aggregates IPv6 IPs to their /48 network.
+
+        Regression: the subnet aggregation step naively applied
+        ``ipaddress.ip_network(f"{ip}/24", strict=False)`` to every IP,
+        which for IPv6 addresses produces an absurdly wide network (a /24
+        IPv6 prefix still spans 2**104 addresses). It must instead go
+        through ``_get_subnet_prefix``, the same helper used by
+        ``detect_subnet_burst``, which truncates IPv6 to /48.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.services.anomaly_detector import detect_cloud_spray
+
+        now = timezone.now()
+        shared_ua = "curl/8.0.0"
+        # DJANGO_WAF_CLOUD_SPRAY_MIN_IPS distinct IPv6 IPs in the same /48,
+        # each making a single request with no referer.
+        min_ips = 20
+        for i in range(min_ips):
+            RequestLogFactory(
+                ip_address=f"2001:db8:abcd:1234::{i:x}",
+                user_agent=shared_ua,
+                referer="",
+                timestamp=now,
+            )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        assert len(created) == 1
+        assert created[0].pattern == "2001:db8:abcd::/48"
 
 
 # ---------------------------------------------------------------------------
@@ -2021,6 +2129,31 @@ class TestBuildTelemetryPayload:
             payload = build_telemetry_payload(period_start, period_end)
 
         assert isinstance(payload["subnets"], list)
+
+    def test_ipv6_subnets_are_truncated_to_slash48_not_full_address(self, db):
+        """IPv6 addresses are truncated to /48 subnets — a full IPv6 address
+        must never appear in the telemetry payload (BR-TEL-002).
+
+        Regression: the pre-fix code applied "/24" unconditionally, which for
+        IPv6 produces a network so wide it is effectively meaningless as
+        aggregation and leaks far more positional information than intended.
+        """
+        from django_waf.services.threat_feed import build_telemetry_payload
+
+        now = timezone.now()
+        period_start = now - timezone.timedelta(hours=1)
+        period_end = now
+
+        full_ip = "2001:db8:abcd:1234::1"
+        RequestLogFactory(ip_address=full_ip, timestamp=now - timezone.timedelta(minutes=5))
+
+        with patch("django_waf.services.threat_feed.get_or_create_install_id", return_value="id"):
+            payload = build_telemetry_payload(period_start, period_end)
+
+        subnet_cidrs = [s["cidr"] for s in payload["subnets"]]
+        assert "2001:db8:abcd::/48" in subnet_cidrs
+        # The full address must not appear anywhere in the payload.
+        assert full_ip not in str(payload)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -509,6 +509,22 @@ class TestDashboardTopBlockedPanelView:
         # Ordered by -blocked_requests
         assert str(ips[0].ip_address) == "1.1.1.1"
 
+    def test_db_error_degrades_to_empty_context(self):
+        """A DB error while fetching top-blocked IPs degrades to an empty panel
+        instead of raising (matches DashboardStatsPanel's fallback pattern)."""
+        client = Client()
+        user = _make_staff_user(username="stafftopblkerr", email="stafftopblkerr@example.com")
+        client.force_login(user)
+
+        with patch(
+            "django_waf.models.IPReputation.objects.order_by",
+            side_effect=Exception("db unavailable"),
+        ):
+            response = client.get("/waf/dashboard/top-blocked/")
+
+        assert response.status_code == 200
+        assert response.context["ips"] == []
+
 
 class TestDashboardAnomalyPanelView:
     """GET /dashboard/anomalies/ returns auto-generated rules from the last 48 hours."""
@@ -549,6 +565,22 @@ class TestDashboardAnomalyPanelView:
         assert all(r.source == RuleSource.AUTO for r in rules)
         rule_ids = [r.id for r in rules]
         assert auto_rule.id in rule_ids
+
+    def test_db_error_degrades_to_empty_context(self):
+        """A DB error while fetching anomaly rules degrades to an empty panel
+        instead of raising (matches DashboardStatsPanel's fallback pattern)."""
+        client = Client()
+        user = _make_staff_user(username="staffanomerr", email="staffanomerr@example.com")
+        client.force_login(user)
+
+        with patch(
+            "django_waf.models.BlockRule.objects.filter",
+            side_effect=Exception("db unavailable"),
+        ):
+            response = client.get("/waf/dashboard/anomalies/")
+
+        assert response.status_code == 200
+        assert response.context["rules"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ships the waf-releases plan's 1.0.x hardening trio plus two defects found during implementation, released as a minor per RELEASING.md semantics (new public API parameter and consumer-visible detection behaviour).

- IPv6 sources aggregate at /48 in detect_subnet_burst, detect_cloud_spray, and build_telemetry_payload via a shared _get_subnet_prefix() helper; telemetry can no longer approach full-IPv6 leakage
- load_rule_cache guards its DB rebuild with a 5s redis lock (3 retries at 100ms, fail-open)
- DashboardTopBlockedPanel and DashboardAnomalyPanel degrade to an empty context on backend errors
- run_all_detectors(window_minutes=None) threads the window to all five detectors, repairing the --window-minutes flag (raised TypeError since introduction); mocks autospec'd plus an end-to-end test

## Verification

- 711 tests pass (targeted new tests plus full suite)
- ruff check and ruff format clean
- python -m build succeeds; CHANGELOG has the dated 1.1.0 entry with the behaviour-change callout