### PR TITLE
feat(checks): W005 feed-URL scheme check + document feed as unauthenticated read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- System check `django_waf.W005`: warns when `DJANGO_WAF_FEED_ENABLED` is
+  true but `DJANGO_WAF_FEED_URL` is not `https://`. Feed responses become
+  `BlockRule` records, so a plaintext feed is a rule-injection vector. The
+  check inspects the URL scheme only and issues no request; fix by using an
+  HTTPS feed URL or setting `DJANGO_WAF_FEED_ENABLED = False`.
+
 ## [1.2.0] - 2026-07-11
 
 Minor because the feed URL defaults change consumer-visible behaviour: a

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -16,6 +16,12 @@ The signing-key check (``django_waf.W003``) was added in v0.11.0 alongside
 the form-protection subsystem. It surfaces when the package is falling
 back to a ``SECRET_KEY``-derived signing key — fine for development but
 worth a deliberate decision in production.
+
+The feed-URL scheme check (``django_waf.W005``) warns when the threat feed
+is enabled but its URL is not ``https://``. The feed drives BlockRule
+creation; fetching it over plaintext lets a network attacker inject or
+suppress rules in transit. Scheme validation only — the check never issues
+a live HTTP request.
 """
 
 from __future__ import annotations
@@ -107,3 +113,37 @@ def check_signing_key(app_configs, **kwargs):
             )
         ]
     return []
+
+
+@register()
+def check_feed_url_scheme(app_configs, **kwargs):
+    """Warn (``django_waf.W005``) when the threat feed is enabled but
+    ``DJANGO_WAF_FEED_URL`` is not served over HTTPS.
+
+    The feed response is turned directly into ``BlockRule`` records, so an
+    on-path attacker who can tamper with a plaintext feed can inject rules
+    that block legitimate traffic or suppress rules that would block theirs.
+    Only the URL scheme is inspected; no request is made.
+    """
+    from django_waf import conf
+
+    if not conf.DJANGO_WAF_FEED_ENABLED:
+        return []
+
+    url = conf.DJANGO_WAF_FEED_URL or ""
+    if url.startswith("https://"):
+        return []
+
+    return [
+        Warning(
+            f"DJANGO_WAF_FEED_URL is not HTTPS ({url!r}) while "
+            "DJANGO_WAF_FEED_ENABLED is True — feed rules would be fetched "
+            "over an untrusted channel.",
+            hint=(
+                "Use an https:// feed URL so an on-path attacker cannot "
+                "inject or suppress BlockRules in transit, or set "
+                "DJANGO_WAF_FEED_ENABLED = False to disable feed syncing."
+            ),
+            id="django_waf.W005",
+        )
+    ]

--- a/src/django_waf/services/threat_feed.py
+++ b/src/django_waf/services/threat_feed.py
@@ -53,6 +53,12 @@ def sync_feed(
     url = feed_url or conf.DJANGO_WAF_FEED_URL
     threshold = min_confidence if min_confidence is not None else conf.DJANGO_WAF_FEED_MIN_CONFIDENCE
 
+    # No Authorization header, by design. The feed is a public read: the
+    # collective threat intel is servable to every install without a key, so
+    # a bearer token is neither required nor sent even when
+    # DJANGO_WAF_FEED_API_KEY is set. Telemetry (submit_telemetry) is the
+    # authenticated write; see 06-threat-feed-api.md section 4 for the
+    # documented asymmetry. Do not add auth here without a contract change.
     try:
         response = httpx.get(url, timeout=30)
         response.raise_for_status()

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -23,6 +23,12 @@ def _run_signing_key_check():
     return check_signing_key(app_configs=None)
 
 
+def _run_feed_url_scheme_check():
+    from django_waf.checks import check_feed_url_scheme
+
+    return check_feed_url_scheme(app_configs=None)
+
+
 class TestChallengeDifficultyCheck:
     def test_recommended_defaults_produce_no_messages(self):
         import django_waf.conf as conf_mod
@@ -122,3 +128,46 @@ class TestSigningKeyCheck:
         # part of the message so future edits don't lose the remediation.
         assert "secrets.token_urlsafe" in messages[0].hint
         assert "DJANGO_WAF_SIGNING_KEY" in messages[0].hint
+
+
+class TestFeedUrlSchemeCheck:
+    """W005 — warns when the threat feed is enabled but not served over HTTPS.
+
+    Feed responses become BlockRules, so a plaintext feed lets an on-path
+    attacker inject or suppress rules. The check inspects only the URL
+    scheme; it never issues a live request.
+    """
+
+    def test_https_feed_produces_no_messages(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_FEED_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_FEED_URL", "https://threats.drystane.com/v1/feed.json"),
+        ):
+            assert _run_feed_url_scheme_check() == []
+
+    def test_non_https_feed_emits_w005_warning(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_FEED_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_FEED_URL", "http://threats.drystane.com/v1/feed.json"),
+        ):
+            messages = _run_feed_url_scheme_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W005"
+        # The hint must offer both remediations — switch to https or disable.
+        assert "https://" in messages[0].hint
+        assert "DJANGO_WAF_FEED_ENABLED" in messages[0].hint
+
+    def test_disabled_feed_skips_scheme_check(self):
+        """A non-HTTPS URL is harmless when the feed is off — no warning."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_FEED_ENABLED", False),
+            patch.object(conf_mod, "DJANGO_WAF_FEED_URL", "http://threats.drystane.com/v1/feed.json"),
+        ):
+            assert _run_feed_url_scheme_check() == []


### PR DESCRIPTION
Phase 9 of the waf-releases plan (ships in v1.3.0).

## What

- **W005 system check** (`check_feed_url_scheme`): warns when `DJANGO_WAF_FEED_ENABLED` is true but `DJANGO_WAF_FEED_URL` is not `https://`. Feed responses become `BlockRule` records, so a plaintext feed is a rule-injection vector. Scheme inspection only, no HTTP request.
- **sync_feed stays unauthenticated** (resolved 'no' on the open Authorization question): the feed is a public read; telemetry is the authenticated write. Codified with an explanatory comment so it is not 'fixed' later. Matches `06-threat-feed-api.md` section 4.
- Three W005 tests (https clean / non-https warns / disabled skips).
- CHANGELOG `[Unreleased]` entry.

## Tests

`pytest tests/test_checks.py` → 11 passed.

## Notes

Not a release. No `v*` tag; version-label remap (per ROADMAP) means the plan's '1.1.0 Consumer DX' block ships as v1.3.0.