### PR TITLE
feat: Consumer DX batch (prune-challenges, beat schedule, W004, test utils, log formatter)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,11 @@ htmlcov/
 .idea/
 uv.lock
 
+# Virtual environments
+venv/
+.venv/
+env/
+.env
+
 # Agent working areas
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `BlockRule` records, so a plaintext feed is a rule-injection vector. The
   check inspects the URL scheme only and issues no request; fix by using an
   HTTPS feed URL or setting `DJANGO_WAF_FEED_ENABLED = False`.
+- Celery task `prune_challenge_tokens` and management command
+  `django_waf_prune_challenges`: delete pending/failed `ChallengeToken`
+  records older than a configurable age (default 24 hours). Scheduled
+  daily at 04:15 alongside the existing `prune_request_logs` task.
+- `django_waf.conf.DJANGO_WAF_CELERY_BEAT_SCHEDULE`: a ready-made
+  `CELERY_BEAT_SCHEDULE` fragment covering every periodic django-waf task,
+  merged into a project's own schedule with `{**DJANGO_WAF_CELERY_BEAT_SCHEDULE, ...}`
+  instead of hand-transcribing task names and cadences. Stays importable
+  even when `celery` is not installed: the interval-based entries
+  (`*/N minute` tasks) are always present, and the wall-clock entries that
+  need `celery.schedules.crontab` are omitted rather than approximated.
+- System check `django_waf.W004`: warns when `WafMiddleware` is placed
+  before `AuthenticationMiddleware` in `MIDDLEWARE` (or when
+  `AuthenticationMiddleware` is missing). `request.user` is not available
+  yet in that ordering, so the staff/superuser bypass silently fails and
+  staff accounts get blocked/challenged like anonymous traffic.
+- `django_waf.testing.fixtures`: pytest fixtures for consuming-project test
+  suites — `disable_waf`, `waf_redis_mock` (requires `fakeredis`),
+  `block_rule`, `allow_rule`, `challenge_token`. Re-exported from
+  `django_waf.testing`.
+- `django_waf.testing.helpers`: `create_blocked_request()` and
+  `create_challenged_request()` test helpers that create the matching
+  `BlockRule` and issue a request through the Django test client.
+  Re-exported from `django_waf.testing`.
+- `django_waf.logging.WafStructuredFormatter`: a JSON logging formatter for
+  the `django_waf` logger hierarchy — one object per line with timestamp,
+  level, logger, message, and (when present on the record) ip, verdict,
+  rule_id, anomaly_score, latency_ms, path, method, and user_agent
+  (truncated to 200 characters).
 
 ## [1.2.0] - 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -315,52 +315,91 @@ waf = FormProtection(
 )
 ```
 
-## Celery Beat Schedule
+## Structured Logging
 
-If using Celery, configure the beat schedule for automated tasks:
+`django_waf.logging.WafStructuredFormatter` renders each log record as one
+JSON object per line, ready for a log aggregator (ELK, Loki, CloudWatch
+Logs, etc.). It always includes `timestamp`, `level`, `logger`, and
+`message`; it additionally includes `ip`, `verdict`, `rule_id`,
+`anomaly_score`, `latency_ms`, `path`, `method`, and `user_agent` (truncated
+to 200 characters) whenever those attributes are present on the log record
+— fields that are absent are omitted entirely rather than emitted as
+`null`.
+
+Wire it into the `django_waf` logger via `LOGGING`:
 
 ```python
-from celery.schedules import crontab
-
-CELERY_BEAT_SCHEDULE = {
-    "django-waf-flush-rule-hit-counts": {
-        "task": "django_waf.tasks.flush_rule_hit_counts",
-        "schedule": crontab(minute="*/5"),
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "waf_json": {
+            "()": "django_waf.logging.WafStructuredFormatter",
+        },
     },
-    "django-waf-generate-blocklist": {
-        "task": "django_waf.tasks.generate_blocklist",
-        "schedule": crontab(minute="*/5"),
+    "handlers": {
+        "waf_json": {
+            "class": "logging.StreamHandler",
+            "formatter": "waf_json",
+        },
     },
-    "django-waf-detect-anomalies": {
-        "task": "django_waf.tasks.detect_anomalies",
-        "schedule": crontab(minute="*/15"),
-    },
-    "django-waf-parse-access-log": {
-        "task": "django_waf.tasks.parse_access_log",
-        "schedule": crontab(minute="*/10"),
-    },
-    "django-waf-expire-rules": {
-        "task": "django_waf.tasks.expire_rules",
-        "schedule": crontab(minute="*/30"),
-    },
-    "django-waf-update-ip-reputation": {
-        "task": "django_waf.tasks.update_ip_reputation",
-        "schedule": crontab(hour="*/6", minute=0),
-    },
-    "django-waf-prune-request-logs": {
-        "task": "django_waf.tasks.prune_request_logs",
-        "schedule": crontab(hour=4, minute=0),
-    },
-    "django-waf-sync-threat-feed": {
-        "task": "django_waf.tasks.sync_threat_feed",
-        "schedule": crontab(hour=4, minute=30),
-    },
-    "django-waf-report-threat-telemetry": {
-        "task": "django_waf.tasks.report_threat_telemetry",
-        "schedule": crontab(hour=5, minute=0),
+    "loggers": {
+        "django_waf": {
+            "handlers": ["waf_json"],
+            "level": "INFO",
+            "propagate": False,
+        },
     },
 }
 ```
+
+## Celery Beat Schedule
+
+If using Celery, `django_waf.conf.DJANGO_WAF_CELERY_BEAT_SCHEDULE` provides a
+ready-made schedule fragment covering every periodic django-waf task. Merge
+it into your project's `CELERY_BEAT_SCHEDULE` rather than hand-transcribing
+task names and cadences:
+
+```python
+from django_waf.conf import DJANGO_WAF_CELERY_BEAT_SCHEDULE
+
+CELERY_BEAT_SCHEDULE = {
+    **DJANGO_WAF_CELERY_BEAT_SCHEDULE,
+    # ... your project's own periodic tasks
+}
+```
+
+The `*/N minute` tasks (`generate_blocklist`, `flush_rule_hit_counts`,
+`detect_anomalies`, `parse_access_log`, `expire_rules`,
+`update_ip_reputation`) are expressed as plain second-interval schedules, so
+they are always present regardless of whether `celery` is installed.
+
+The wall-clock tasks (`prune_request_logs`, `prune_challenge_tokens`,
+`sync_threat_feed`, `report_threat_telemetry`, `update_geoip_database`) need
+`celery.schedules.crontab` to build their schedule. Because `django_waf.conf`
+must stay importable even when `celery` is entirely absent from the
+environment, the `crontab` import is guarded: if `celery` is not installed,
+these five entries are simply omitted from the dict rather than
+approximated. Install the `celery` extra (`pip install django-waf[celery]`)
+to get the full schedule:
+
+| Task | Cadence |
+|------|---------|
+| `generate_blocklist` | every 5 minutes |
+| `flush_rule_hit_counts` | every 5 minutes |
+| `detect_anomalies` | every 15 minutes |
+| `parse_access_log` | every 10 minutes |
+| `expire_rules` | every 30 minutes |
+| `update_ip_reputation` | every 6 hours |
+| `prune_request_logs` | daily 04:00 |
+| `prune_challenge_tokens` | daily 04:15 |
+| `sync_threat_feed` | daily 04:30 |
+| `report_threat_telemetry` | daily 05:00 |
+| `update_geoip_database` | weekly, Sunday 03:00 UTC |
+
+You may of course still hand-write `CELERY_BEAT_SCHEDULE` entries yourself
+(or override `DJANGO_WAF_CELERY_BEAT_SCHEDULE` via the setting of the same
+name) if you need different cadences.
 
 ## Management Commands
 
@@ -369,6 +408,7 @@ CELERY_BEAT_SCHEDULE = {
 | `django_waf_generate_blocklist` | Generate the nginx blocklist file (`--dry-run` to preview) |
 | `django_waf_detect_anomalies` | Run anomaly detectors and auto-create block rules (`--dry-run`) |
 | `django_waf_prune_logs` | Delete `RequestLog` entries older than the retention period (`--dry-run`) |
+| `django_waf_prune_challenges` | Delete pending/failed `ChallengeToken` entries older than N hours (`--hours`, `--dry-run`) |
 | `django_waf_sync_feed` | Fetch and import rules from the collective threat feed (`--dry-run`) |
 
 ## Dashboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pytest-django>=4.8",
     "pytest-cov>=5.0",
     "factory-boy>=3.3",
+    "fakeredis>=2.20",
     "ruff>=0.5.0",
     "mypy>=1.10",
     "django-stubs>=5.0",
@@ -79,6 +80,10 @@ ignore = ["S101", "S104", "S105", "S106", "S107", "S110", "S112", "S311", "S603"
 # frequently exceed the 120-char line limit. Migrations are not
 # hand-edited, so lint rules for them are relaxed.
 "src/django_waf/migrations/*.py" = ["E501"]
+# Pytest fixtures imported from django_waf.testing.fixtures are used as
+# test-function parameters of the same name — the standard pytest fixture
+# pattern, which ruff's F811 misreads as shadowing/redefinition.
+"tests/test_testing_fixtures.py" = ["F811"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -22,6 +22,13 @@ is enabled but its URL is not ``https://``. The feed drives BlockRule
 creation; fetching it over plaintext lets a network attacker inject or
 suppress rules in transit. Scheme validation only — the check never issues
 a live HTTP request.
+
+The middleware-ordering check (``django_waf.W004``) warns when
+``WafMiddleware`` is placed before ``AuthenticationMiddleware`` in
+``MIDDLEWARE``, or when ``AuthenticationMiddleware`` is missing entirely.
+``request.user`` is not available at that point, so the staff bypass
+silently fails and staff/superuser accounts can be blocked or challenged
+like anonymous traffic.
 """
 
 from __future__ import annotations
@@ -147,3 +154,47 @@ def check_feed_url_scheme(app_configs, **kwargs):
             id="django_waf.W005",
         )
     ]
+
+
+@register()
+def check_middleware_ordering(app_configs, **kwargs):
+    """Warn (``django_waf.W004``) when ``WafMiddleware`` runs before
+    Django's ``AuthenticationMiddleware``.
+
+    The staff dashboard bypass and any authenticated-user logic in the WAF
+    middleware reads ``request.user``, which ``AuthenticationMiddleware``
+    attaches. If the WAF runs first, ``request.user`` is not yet available
+    (or not yet resolved), so the staff bypass silently fails and staff
+    users can be blocked/challenged like anyone else.
+    """
+    from django.conf import settings
+
+    middleware = list(getattr(settings, "MIDDLEWARE", []))
+    waf_name = "django_waf.middleware.WafMiddleware"
+    auth_name = "django.contrib.auth.middleware.AuthenticationMiddleware"
+
+    if waf_name not in middleware:
+        return []
+
+    waf_index = middleware.index(waf_name)
+    auth_index = middleware.index(auth_name) if auth_name in middleware else None
+
+    if auth_index is None or auth_index > waf_index:
+        return [
+            Warning(
+                "django_waf.middleware.WafMiddleware runs before "
+                "django.contrib.auth.middleware.AuthenticationMiddleware "
+                "(or AuthenticationMiddleware is missing) — request.user is "
+                "not available when the WAF evaluates the request, so the "
+                "staff bypass silently fails and staff/superuser accounts "
+                "can be blocked or challenged like anonymous traffic.",
+                hint=(
+                    "Place django_waf.middleware.WafMiddleware after "
+                    "django.contrib.auth.middleware.AuthenticationMiddleware "
+                    "in MIDDLEWARE."
+                ),
+                id="django_waf.W004",
+            )
+        ]
+
+    return []

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -8,6 +8,11 @@ at call time to respect pytest settings overrides.
 
 from django.conf import settings
 
+try:
+    from celery.schedules import crontab
+except ImportError:
+    crontab = None  # type: ignore[assignment]
+
 # Enable or disable the WAF middleware entirely.
 DJANGO_WAF_ENABLED: bool = getattr(settings, "DJANGO_WAF_ENABLED", True)
 
@@ -371,3 +376,89 @@ DJANGO_WAF_ESCALATION_BLOCK_TTL: int = getattr(settings, "DJANGO_WAF_ESCALATION_
 # Cloud spray detection: many distinct IPs with identical behaviour.
 DJANGO_WAF_CLOUD_SPRAY_MIN_IPS: int = getattr(settings, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 20)
 DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP: int = getattr(settings, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3)
+
+# ---------------------------------------------------------------------------
+# Celery Beat schedule helper
+# ---------------------------------------------------------------------------
+# Ready-made CELERY_BEAT_SCHEDULE entries for every periodic django-waf task.
+# Consuming projects merge this into their own schedule rather than
+# hand-transcribing task names and cadences::
+#
+#     CELERY_BEAT_SCHEDULE = {
+#         **DJANGO_WAF_CELERY_BEAT_SCHEDULE,
+#         "my-other-task": {...},
+#     }
+#
+# Building this dict never imports celery at settings-module-import time in a
+# way that can fail: the ``crontab`` import above is guarded, so entries that
+# need a wall-clock time (``crontab(hour=.., minute=..)``) are only included
+# when celery is installed. The ``*/N minute`` entries use a plain integer
+# number of seconds, which Celery Beat accepts without importing
+# ``crontab`` at all, so they are always present regardless of whether
+# celery is installed. This module must remain importable even when celery
+# is entirely absent from the environment (e.g. projects that don't use
+# Celery at all still import django_waf.conf indirectly via checks/admin).
+_CELERY_BEAT_INTERVAL_ENTRIES: dict = {
+    "django-waf-generate-blocklist": {
+        "task": "django_waf.tasks.generate_blocklist",
+        "schedule": 300.0,  # every 5 minutes
+    },
+    "django-waf-flush-rule-hit-counts": {
+        "task": "django_waf.tasks.flush_rule_hit_counts",
+        "schedule": 300.0,  # every 5 minutes
+    },
+    "django-waf-detect-anomalies": {
+        "task": "django_waf.tasks.detect_anomalies",
+        "schedule": 900.0,  # every 15 minutes
+    },
+    "django-waf-parse-access-log": {
+        "task": "django_waf.tasks.parse_access_log",
+        "schedule": 600.0,  # every 10 minutes
+    },
+    "django-waf-expire-rules": {
+        "task": "django_waf.tasks.expire_rules",
+        "schedule": 1800.0,  # every 30 minutes
+    },
+    "django-waf-update-ip-reputation": {
+        "task": "django_waf.tasks.update_ip_reputation",
+        "schedule": 21600.0,  # every 6 hours
+    },
+}
+
+if crontab is not None:
+    _CELERY_BEAT_CRON_ENTRIES: dict = {
+        "django-waf-prune-request-logs": {
+            "task": "django_waf.tasks.prune_request_logs",
+            "schedule": crontab(hour=4, minute=0),
+        },
+        "django-waf-prune-challenge-tokens": {
+            "task": "django_waf.tasks.prune_challenge_tokens",
+            "schedule": crontab(hour=4, minute=15),
+        },
+        "django-waf-sync-threat-feed": {
+            "task": "django_waf.tasks.sync_threat_feed",
+            "schedule": crontab(hour=4, minute=30),
+        },
+        "django-waf-report-threat-telemetry": {
+            "task": "django_waf.tasks.report_threat_telemetry",
+            "schedule": crontab(hour=5, minute=0),
+        },
+        "django-waf-update-geoip-database": {
+            "task": "django_waf.tasks.update_geoip_database",
+            "schedule": crontab(day_of_week=0, hour=3, minute=0),  # weekly, Sunday 03:00 UTC
+        },
+    }
+else:
+    # celery is not installed — the cron-time entries above need
+    # crontab() to build a schedule, so they are omitted rather than
+    # guessed at with a plain interval. The */N minute entries above still
+    # work fine as they don't touch crontab at all.
+    _CELERY_BEAT_CRON_ENTRIES = {}
+
+# Ready-made CELERY_BEAT_SCHEDULE fragment covering every periodic
+# django-waf task. See the module docstring above this block for usage.
+DJANGO_WAF_CELERY_BEAT_SCHEDULE: dict = getattr(
+    settings,
+    "DJANGO_WAF_CELERY_BEAT_SCHEDULE",
+    {**_CELERY_BEAT_INTERVAL_ENTRIES, **_CELERY_BEAT_CRON_ENTRIES},
+)

--- a/src/django_waf/logging.py
+++ b/src/django_waf/logging.py
@@ -1,0 +1,64 @@
+"""Structured (JSON) logging formatter for django-waf.
+
+Distinct from ``django_waf.forms.logging``, which is the form-protection
+subsystem's own structured logger. This module provides a general-purpose
+``logging.Formatter`` for consuming projects to attach to the ``django_waf``
+logger (and its ``django_waf.middleware``, ``django_waf.views``,
+``django_waf.tasks`` children) so WAF log lines can be ingested by a log
+aggregator as one JSON object per line.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+# Fields pulled from the LogRecord when present. user_agent is truncated;
+# everything else is included verbatim. A field absent from the record
+# (getattr returns None) is omitted from the output entirely rather than
+# being written as null.
+_OPTIONAL_FIELDS = (
+    "ip",
+    "verdict",
+    "rule_id",
+    "anomaly_score",
+    "latency_ms",
+    "path",
+    "method",
+    "user_agent",
+)
+
+_USER_AGENT_MAX_LENGTH = 200
+
+
+class WafStructuredFormatter(logging.Formatter):
+    """JSON log formatter: one object per line.
+
+    Always includes ``timestamp`` (ISO 8601, from ``record.created``),
+    ``level``, ``logger``, and ``message``. Optionally includes ``ip``,
+    ``verdict``, ``rule_id``, ``anomaly_score``, ``latency_ms``, ``path``,
+    ``method``, and ``user_agent`` when present as attributes on the log
+    record (e.g. via ``logger.info(..., extra={"ip": ip, ...})``).
+    ``user_agent`` is truncated to 200 characters. Fields that are missing
+    or ``None`` on the record are omitted from the output entirely, not
+    written as ``null``.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=UTC).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+
+        for field in _OPTIONAL_FIELDS:
+            value = getattr(record, field, None)
+            if value is None:
+                continue
+            if field == "user_agent":
+                value = str(value)[:_USER_AGENT_MAX_LENGTH]
+            payload[field] = value
+
+        return json.dumps(payload)

--- a/src/django_waf/management/commands/django_waf_prune_challenges.py
+++ b/src/django_waf/management/commands/django_waf_prune_challenges.py
@@ -56,6 +56,4 @@ class Command(BaseCommand):
         except Exception as exc:
             raise CommandError(f"Challenge token pruning failed: {exc}") from exc
 
-        self.stdout.write(
-            self.style.SUCCESS(f"Deleted {deleted_count} challenge token(s) older than {hours} hour(s).")
-        )
+        self.stdout.write(self.style.SUCCESS(f"Deleted {deleted_count} challenge token(s) older than {hours} hour(s)."))

--- a/src/django_waf/management/commands/django_waf_prune_challenges.py
+++ b/src/django_waf/management/commands/django_waf_prune_challenges.py
@@ -1,0 +1,61 @@
+"""
+Management command: django_waf_prune_challenges
+
+Deletes pending or failed ChallengeToken records older than the given
+age threshold. Mirrors the behaviour of the prune_challenge_tokens Celery
+task for manual invocation.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Delete pending or failed WAF challenge token records older than N hours."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--hours",
+            type=int,
+            default=24,
+            help="Age threshold in hours, measured against expires_at (default: 24).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Report the number of records that would be deleted without deleting them.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        from django.utils import timezone
+
+        from django_waf.enums import ChallengeStatus
+        from django_waf.models import ChallengeToken
+
+        hours: int = options["hours"]
+        dry_run: bool = options["dry_run"]
+
+        if hours < 1:
+            raise CommandError("--hours must be a positive integer.")
+
+        cutoff = timezone.now() - timezone.timedelta(hours=hours)
+        purgeable_qs = ChallengeToken.objects.filter(
+            status__in=[ChallengeStatus.PENDING, ChallengeStatus.FAILED],
+            expires_at__lt=cutoff,
+        )
+
+        if dry_run:
+            count = purgeable_qs.count()
+            self.stdout.write(
+                self.style.WARNING(f"[dry-run] Would delete {count} challenge token(s) older than {hours} hour(s).")
+            )
+            return
+
+        try:
+            deleted_count, _ = purgeable_qs.delete()
+        except Exception as exc:
+            raise CommandError(f"Challenge token pruning failed: {exc}") from exc
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Deleted {deleted_count} challenge token(s) older than {hours} hour(s).")
+        )

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -10,6 +10,7 @@ Scheduled tasks (Celery Beat):
   - detect_anomalies        — every 15 minutes (BR-ANOM-005)
   - parse_access_log        — every 10 minutes
   - prune_request_logs      — daily 04:00 (BR-LOG-003)
+  - prune_challenge_tokens  — daily 04:15
   - expire_rules            — every 30 minutes (BR-LIFE-002)
   - update_ip_reputation    — every 6 hours
   - sync_threat_feed        — daily 04:30
@@ -178,6 +179,34 @@ def prune_request_logs(days: int | None = None) -> dict:
     cutoff = timezone.now() - timedelta(days=retention_days)
     deleted, _ = RequestLog.objects.filter(timestamp__lt=cutoff).delete()
     logger.info("django-waf: pruned %d RequestLog records older than %d days", deleted, retention_days)
+    return {"deleted_count": deleted}
+
+
+@shared_task
+def prune_challenge_tokens(hours: int = 24) -> dict:
+    """Delete expired or failed ChallengeToken records older than N hours.
+
+    Only PENDING and FAILED tokens are pruned — SOLVED tokens are kept for
+    reputation aggregation (see update_ip_reputation) and EXPIRED tokens are
+    handled separately by the challenge-verification flow, not this task.
+
+    Args:
+        hours: Age threshold in hours, measured against expires_at. Defaults to 24.
+
+    Returns:
+        Dict with keys: deleted_count.
+
+    Scheduled: daily at 04:15.
+    """
+    from django_waf.enums import ChallengeStatus
+    from django_waf.models import ChallengeToken
+
+    cutoff = timezone.now() - timedelta(hours=hours)
+    deleted, _ = ChallengeToken.objects.filter(
+        status__in=[ChallengeStatus.PENDING, ChallengeStatus.FAILED],
+        expires_at__lt=cutoff,
+    ).delete()
+    logger.info("django-waf: pruned %d ChallengeToken records older than %d hours", deleted, hours)
     return {"deleted_count": deleted}
 
 

--- a/src/django_waf/testing/__init__.py
+++ b/src/django_waf/testing/__init__.py
@@ -1,7 +1,7 @@
 """Test utilities for projects consuming django-waf.
 
-Provides factory-boy factories and pytest fixtures for use in consuming
-project test suites.
+Provides factory-boy factories, pytest fixtures, and test helpers for use
+in consuming project test suites.
 """
 
 from django_waf.testing.factories import (
@@ -11,6 +11,17 @@ from django_waf.testing.factories import (
     IPReputationFactory,
     RequestLogFactory,
 )
+from django_waf.testing.fixtures import (
+    allow_rule,
+    block_rule,
+    challenge_token,
+    disable_waf,
+    waf_redis_mock,
+)
+from django_waf.testing.helpers import (
+    create_blocked_request,
+    create_challenged_request,
+)
 
 __all__ = [
     "AllowRuleFactory",
@@ -18,4 +29,11 @@ __all__ = [
     "ChallengeTokenFactory",
     "IPReputationFactory",
     "RequestLogFactory",
+    "allow_rule",
+    "block_rule",
+    "challenge_token",
+    "create_blocked_request",
+    "create_challenged_request",
+    "disable_waf",
+    "waf_redis_mock",
 ]

--- a/src/django_waf/testing/fixtures.py
+++ b/src/django_waf/testing/fixtures.py
@@ -1,0 +1,96 @@
+"""pytest fixtures for projects consuming django-waf.
+
+These fixtures require ``pytest`` and, for ``waf_redis_mock``,
+``fakeredis``. Both are development-only dependencies of django-waf itself
+(``pip install django-waf[dev]``); consuming projects that want to use
+these fixtures should install ``fakeredis`` alongside ``pytest`` in their
+own test dependencies. Imports are kept lazy inside each fixture so that
+importing this module never fails for a project that only wants the
+non-Redis fixtures.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from django_waf.models import AllowRule, BlockRule, ChallengeToken
+
+
+@pytest.fixture
+def disable_waf(monkeypatch: pytest.MonkeyPatch):
+    """Disable the WAF middleware for the duration of a test.
+
+    Patches ``django_waf.conf.DJANGO_WAF_ENABLED`` to ``False``. Restored
+    automatically by ``monkeypatch`` at teardown.
+    """
+    from django_waf import conf
+
+    monkeypatch.setattr(conf, "DJANGO_WAF_ENABLED", False)
+    yield
+
+
+@pytest.fixture
+def waf_redis_mock(monkeypatch: pytest.MonkeyPatch):
+    """Patch every Redis accessor django-waf uses to return a shared fakeredis instance.
+
+    Covers the middleware, the challenge/verify views, and the
+    form-protection subsystem's default Redis factory — the three places
+    that independently resolve a Redis client via ``django_redis`` or the
+    Django cache fallback.
+
+    Requires ``fakeredis``. Raises ``ImportError`` with an actionable
+    message if it is not installed.
+
+    Yields:
+        The shared ``fakeredis.FakeRedis`` instance, so tests can assert on
+        Redis state directly.
+    """
+    try:
+        import fakeredis
+    except ImportError as exc:
+        raise ImportError(
+            "The waf_redis_mock fixture requires fakeredis. Install it with "
+            "`pip install fakeredis` (or `pip install django-waf[dev]` when "
+            "developing django-waf itself)."
+        ) from exc
+
+    import django_waf.forms.protection as protection_mod
+    import django_waf.handlers as handlers_mod
+    import django_waf.middleware as middleware_mod
+    import django_waf.views as views_mod
+
+    fake_client = fakeredis.FakeRedis()
+
+    monkeypatch.setattr(middleware_mod, "_get_redis_client", lambda: fake_client)
+    monkeypatch.setattr(views_mod, "_get_redis_client", lambda: fake_client)
+    monkeypatch.setattr(protection_mod, "_default_redis_factory", lambda: fake_client)
+    monkeypatch.setattr(handlers_mod, "_get_cache", lambda: fake_client)
+
+    yield fake_client
+
+
+@pytest.fixture
+def block_rule(db) -> BlockRule:
+    """Create and return a default BlockRule instance via BlockRuleFactory."""
+    from django_waf.testing.factories import BlockRuleFactory
+
+    return BlockRuleFactory()
+
+
+@pytest.fixture
+def allow_rule(db) -> AllowRule:
+    """Create and return a default AllowRule instance via AllowRuleFactory."""
+    from django_waf.testing.factories import AllowRuleFactory
+
+    return AllowRuleFactory()
+
+
+@pytest.fixture
+def challenge_token(db) -> ChallengeToken:
+    """Create and return a default ChallengeToken instance via ChallengeTokenFactory."""
+    from django_waf.testing.factories import ChallengeTokenFactory
+
+    return ChallengeTokenFactory()

--- a/src/django_waf/testing/helpers.py
+++ b/src/django_waf/testing/helpers.py
@@ -1,0 +1,66 @@
+"""Test helpers for projects consuming django-waf.
+
+Thin wrappers over BlockRule creation plus a Django test client request,
+for exercising the middleware's block/challenge paths without hand-rolling
+the rule setup in every test.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.http import HttpResponse
+    from django.test import Client
+
+
+def create_blocked_request(client: Client, path: str = "/", ip: str = "192.0.2.99") -> HttpResponse:
+    """Create a block rule for ``ip`` and issue a GET request from it.
+
+    Args:
+        client: A Django test client instance.
+        path: The path to request. Defaults to "/".
+        ip: The IP address to block and request from. Defaults to a
+            TEST-NET-1 documentation address.
+
+    Returns:
+        The response from ``client.get(path, REMOTE_ADDR=ip)``.
+    """
+    from django_waf.enums import RuleAction, RuleType
+    from django_waf.models import BlockRule
+
+    BlockRule.objects.create(
+        name=f"test-block-{ip}",
+        rule_type=RuleType.IP,
+        match_type="exact",
+        pattern=ip,
+        action=RuleAction.BLOCK,
+    )
+
+    return client.get(path, REMOTE_ADDR=ip)
+
+
+def create_challenged_request(client: Client, path: str = "/", ua: str = "python-requests/2.28") -> HttpResponse:
+    """Create a challenge-action rule for ``ua`` and issue a GET request with it.
+
+    Args:
+        client: A Django test client instance.
+        path: The path to request. Defaults to "/".
+        ua: The User-Agent string to challenge and request with. Defaults
+            to a common scripted-client UA.
+
+    Returns:
+        The response from ``client.get(path, HTTP_USER_AGENT=ua)``.
+    """
+    from django_waf.enums import RuleAction, RuleType
+    from django_waf.models import BlockRule
+
+    BlockRule.objects.create(
+        name=f"test-challenge-{ua}",
+        rule_type=RuleType.UA,
+        match_type="exact",
+        pattern=ua,
+        action=RuleAction.CHALLENGE,
+    )
+
+    return client.get(path, HTTP_USER_AGENT=ua)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -20,6 +20,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django_waf.middleware.WafMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -10,11 +10,19 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from django.test import override_settings
+
 
 def _run_checks():
     from django_waf.checks import check_challenge_difficulty
 
     return check_challenge_difficulty(app_configs=None)
+
+
+def _run_middleware_ordering_check():
+    from django_waf.checks import check_middleware_ordering
+
+    return check_middleware_ordering(app_configs=None)
 
 
 def _run_signing_key_check():
@@ -171,3 +179,60 @@ class TestFeedUrlSchemeCheck:
             patch.object(conf_mod, "DJANGO_WAF_FEED_URL", "http://threats.drystane.com/v1/feed.json"),
         ):
             assert _run_feed_url_scheme_check() == []
+
+
+class TestMiddlewareOrderingCheck:
+    """W004 — warns when WafMiddleware runs before AuthenticationMiddleware.
+
+    request.user is not available until AuthenticationMiddleware has run,
+    so a WAF that evaluates the request first can never see the staff
+    bypass, silently blocking/challenging staff and superuser accounts.
+    """
+
+    def test_warns_when_waf_runs_before_auth(self):
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django_waf.middleware.WafMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+        ]
+
+        with override_settings(MIDDLEWARE=middleware):
+            messages = _run_middleware_ordering_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W004"
+        assert "AuthenticationMiddleware" in messages[0].hint
+
+    def test_passes_when_waf_runs_after_auth(self):
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "django_waf.middleware.WafMiddleware",
+        ]
+
+        with override_settings(MIDDLEWARE=middleware):
+            assert _run_middleware_ordering_check() == []
+
+    def test_passes_when_waf_middleware_absent(self):
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+        ]
+
+        with override_settings(MIDDLEWARE=middleware):
+            assert _run_middleware_ordering_check() == []
+
+    def test_warns_when_auth_middleware_missing_entirely(self):
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django_waf.middleware.WafMiddleware",
+        ]
+
+        with override_settings(MIDDLEWARE=middleware):
+            messages = _run_middleware_ordering_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W004"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -18,7 +18,7 @@ from django.core.management.base import CommandError
 from django.utils import timezone
 
 from django_waf.services.anomaly_detector import run_all_detectors
-from django_waf.testing.factories import BlockRuleFactory, RequestLogFactory
+from django_waf.testing.factories import BlockRuleFactory, ChallengeTokenFactory, RequestLogFactory
 
 # ---------------------------------------------------------------------------
 # django_waf_generate_blocklist
@@ -323,6 +323,74 @@ class TestPruneLogsCommand:
 
         call_command("django_waf_prune_logs")
         assert RequestLog.objects.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# django_waf_prune_challenges
+# ---------------------------------------------------------------------------
+
+
+class TestPruneChallengesCommand:
+    """Tests for the ``django_waf_prune_challenges`` management command."""
+
+    @pytest.mark.django_db
+    def test_dry_run_counts_without_deleting(self):
+        """Dry-run reports the stale token count and does not delete anything."""
+        from django_waf.enums import ChallengeStatus
+
+        old_cutoff = timezone.now() - timezone.timedelta(hours=25)
+        for _ in range(2):
+            ChallengeTokenFactory(status=ChallengeStatus.PENDING, expires_at=old_cutoff)
+        ChallengeTokenFactory(status=ChallengeStatus.SOLVED, expires_at=old_cutoff)  # not pruned — solved
+
+        out = StringIO()
+        call_command("django_waf_prune_challenges", "--dry-run", "--hours=24", stdout=out)
+
+        from django_waf.models import ChallengeToken
+
+        assert ChallengeToken.objects.count() == 3
+        output = out.getvalue()
+        assert "dry-run" in output
+        assert "2 challenge token(s)" in output
+
+    @pytest.mark.django_db
+    def test_normal_run_deletes_expired_pending_and_failed_tokens(self):
+        """Normal run deletes PENDING/FAILED tokens older than the threshold."""
+        from django_waf.enums import ChallengeStatus
+
+        old_cutoff = timezone.now() - timezone.timedelta(hours=25)
+        ChallengeTokenFactory(status=ChallengeStatus.PENDING, expires_at=old_cutoff)
+        ChallengeTokenFactory(status=ChallengeStatus.FAILED, expires_at=old_cutoff)
+        survivor = ChallengeTokenFactory(
+            status=ChallengeStatus.PENDING, expires_at=timezone.now() + timezone.timedelta(hours=1)
+        )
+
+        from django_waf.models import ChallengeToken
+
+        out = StringIO()
+        call_command("django_waf_prune_challenges", "--hours=24", stdout=out)
+
+        assert ChallengeToken.objects.count() == 1
+        assert ChallengeToken.objects.filter(pk=survivor.pk).exists()
+        assert "Deleted 2 challenge token(s)" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_zero_hours_raises_command_error(self):
+        """--hours=0 is rejected with a CommandError."""
+        with pytest.raises(CommandError, match="positive integer"):
+            call_command("django_waf_prune_challenges", "--hours=0")
+
+    @pytest.mark.django_db
+    def test_no_stale_tokens_reports_zero_deleted(self):
+        """When no tokens are stale the command reports zero deletions."""
+        from django_waf.enums import ChallengeStatus
+
+        ChallengeTokenFactory(status=ChallengeStatus.PENDING, expires_at=timezone.now() + timezone.timedelta(hours=1))
+
+        out = StringIO()
+        call_command("django_waf_prune_challenges", "--hours=24", stdout=out)
+
+        assert "Deleted 0 challenge token(s)" in out.getvalue()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -35,3 +35,62 @@ class TestThreatFeedDefaults:
     def test_feed_report_still_defaults_false(self):
         """Telemetry stays opt-in regardless of the URL repoint (ADR-021 point 4)."""
         assert conf_mod.DJANGO_WAF_FEED_REPORT is False
+
+
+class TestCeleryBeatScheduleDefault:
+    """DJANGO_WAF_CELERY_BEAT_SCHEDULE covers every periodic task.
+
+    celery is present in this dev environment, so both the interval
+    entries (plain second counts) and the crontab entries are expected.
+    """
+
+    def test_contains_an_entry_for_every_periodic_task(self):
+        expected_tasks = {
+            "django_waf.tasks.generate_blocklist",
+            "django_waf.tasks.flush_rule_hit_counts",
+            "django_waf.tasks.detect_anomalies",
+            "django_waf.tasks.parse_access_log",
+            "django_waf.tasks.expire_rules",
+            "django_waf.tasks.update_ip_reputation",
+            "django_waf.tasks.prune_request_logs",
+            "django_waf.tasks.prune_challenge_tokens",
+            "django_waf.tasks.sync_threat_feed",
+            "django_waf.tasks.report_threat_telemetry",
+            "django_waf.tasks.update_geoip_database",
+        }
+        actual_tasks = {entry["task"] for entry in conf_mod.DJANGO_WAF_CELERY_BEAT_SCHEDULE.values()}
+        assert actual_tasks == expected_tasks
+
+    def test_interval_entries_use_plain_second_counts(self):
+        entry = conf_mod.DJANGO_WAF_CELERY_BEAT_SCHEDULE["django-waf-generate-blocklist"]
+        assert entry["schedule"] == 300.0
+
+    def test_module_is_importable_without_celery(self):
+        """conf.py must stay importable even when celery is entirely absent.
+
+        Simulates celery being unavailable by reloading conf with the
+        celery.schedules import forced to fail, then restores the real
+        module so later tests are unaffected.
+        """
+        import builtins
+        import importlib
+        import sys
+
+        real_import = builtins.__import__
+
+        def _blocking_import(name, *args, **kwargs):
+            if name == "celery.schedules" or name.startswith("celery.schedules."):
+                raise ImportError("celery not installed")
+            return real_import(name, *args, **kwargs)
+
+        builtins.__import__ = _blocking_import
+        try:
+            reloaded = importlib.reload(conf_mod)
+            assert reloaded.crontab is None
+            # The cron-time entries are omitted; interval entries remain.
+            assert "django-waf-prune-request-logs" not in reloaded.DJANGO_WAF_CELERY_BEAT_SCHEDULE
+            assert "django-waf-generate-blocklist" in reloaded.DJANGO_WAF_CELERY_BEAT_SCHEDULE
+        finally:
+            builtins.__import__ = real_import
+            importlib.reload(conf_mod)
+            sys.modules["django_waf.conf"] = conf_mod

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,97 @@
+"""Tests for django_waf.logging.WafStructuredFormatter.
+
+Distinct from django_waf.forms.logging, which is the form-protection
+subsystem's own structured logger — this covers the general-purpose
+JSON formatter consuming projects attach to the ``django_waf`` logger.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from django_waf.logging import WafStructuredFormatter
+
+
+def _make_record(message: str = "test message", **extra) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="django_waf.middleware",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=None,
+        exc_info=None,
+    )
+    for key, value in extra.items():
+        setattr(record, key, value)
+    return record
+
+
+class TestWafStructuredFormatter:
+    def test_produces_valid_json(self):
+        formatter = WafStructuredFormatter()
+        record = _make_record("blocked request", ip="203.0.113.1", verdict="blocked")
+
+        output = formatter.format(record)
+
+        parsed = json.loads(output)
+        assert parsed["message"] == "blocked request"
+        assert parsed["level"] == "INFO"
+        assert parsed["logger"] == "django_waf.middleware"
+        assert "timestamp" in parsed
+        assert parsed["ip"] == "203.0.113.1"
+        assert parsed["verdict"] == "blocked"
+
+    def test_absent_optional_fields_are_omitted(self):
+        formatter = WafStructuredFormatter()
+        record = _make_record("plain message")
+
+        output = json.loads(formatter.format(record))
+
+        for field in ("ip", "verdict", "rule_id", "anomaly_score", "latency_ms", "path", "method", "user_agent"):
+            assert field not in output
+
+    def test_none_optional_fields_are_omitted(self):
+        formatter = WafStructuredFormatter()
+        record = _make_record("plain message", ip=None, verdict=None)
+
+        output = json.loads(formatter.format(record))
+
+        assert "ip" not in output
+        assert "verdict" not in output
+
+    def test_user_agent_is_truncated_to_200_chars(self):
+        formatter = WafStructuredFormatter()
+        long_ua = "Mozilla/5.0 " + ("A" * 300)
+        record = _make_record("request logged", user_agent=long_ua)
+
+        output = json.loads(formatter.format(record))
+
+        assert len(output["user_agent"]) == 200
+        assert output["user_agent"] == long_ua[:200]
+
+    def test_all_optional_fields_included_when_present(self):
+        formatter = WafStructuredFormatter()
+        record = _make_record(
+            "full record",
+            ip="198.51.100.7",
+            verdict="challenged",
+            rule_id="abc-123",
+            anomaly_score=6.5,
+            latency_ms=12.3,
+            path="/login/",
+            method="POST",
+            user_agent="curl/8.0",
+        )
+
+        output = json.loads(formatter.format(record))
+
+        assert output["ip"] == "198.51.100.7"
+        assert output["verdict"] == "challenged"
+        assert output["rule_id"] == "abc-123"
+        assert output["anomaly_score"] == 6.5
+        assert output["latency_ms"] == 12.3
+        assert output["path"] == "/login/"
+        assert output["method"] == "POST"
+        assert output["user_agent"] == "curl/8.0"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 from django_waf.enums import Verdict
 from django_waf.testing.factories import (
     BlockRuleFactory,
+    ChallengeTokenFactory,
     IPReputationFactory,
     RequestLogFactory,
 )
@@ -323,6 +324,61 @@ class TestPruneRequestLogs:
         from django_waf.models import RequestLog
 
         assert not RequestLog.objects.filter(pk=log.pk).exists()
+
+
+# ---------------------------------------------------------------------------
+# prune_challenge_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestPruneChallengeTokens:
+    @pytest.mark.django_db
+    def test_deletes_expired_pending_and_failed_tokens(self):
+        """PENDING and FAILED tokens whose expiry is older than the threshold are deleted."""
+        from django_waf.enums import ChallengeStatus
+
+        old_pending = ChallengeTokenFactory(
+            status=ChallengeStatus.PENDING,
+            expires_at=timezone.now() - timedelta(hours=25),
+        )
+        old_failed = ChallengeTokenFactory(
+            status=ChallengeStatus.FAILED,
+            expires_at=timezone.now() - timedelta(hours=48),
+        )
+
+        from django_waf.tasks import prune_challenge_tokens
+
+        result = prune_challenge_tokens(hours=24)
+
+        from django_waf.models import ChallengeToken
+
+        assert result["deleted_count"] == 2
+        assert not ChallengeToken.objects.filter(pk=old_pending.pk).exists()
+        assert not ChallengeToken.objects.filter(pk=old_failed.pk).exists()
+
+    @pytest.mark.django_db
+    def test_leaves_solved_and_non_expired_tokens(self):
+        """SOLVED tokens and tokens within the age threshold survive pruning."""
+        from django_waf.enums import ChallengeStatus
+
+        solved_old = ChallengeTokenFactory(
+            status=ChallengeStatus.SOLVED,
+            expires_at=timezone.now() - timedelta(hours=48),
+        )
+        recent_pending = ChallengeTokenFactory(
+            status=ChallengeStatus.PENDING,
+            expires_at=timezone.now() + timedelta(hours=1),
+        )
+
+        from django_waf.tasks import prune_challenge_tokens
+
+        result = prune_challenge_tokens(hours=24)
+
+        from django_waf.models import ChallengeToken
+
+        assert result["deleted_count"] == 0
+        assert ChallengeToken.objects.filter(pk=solved_old.pk).exists()
+        assert ChallengeToken.objects.filter(pk=recent_pending.pk).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_testing_fixtures.py
+++ b/tests/test_testing_fixtures.py
@@ -1,0 +1,136 @@
+"""Tests for the pytest fixtures and helpers in django_waf.testing.
+
+Each fixture/helper gets a focused test verifying it does what its name
+says. These are consumed by projects via ``django_waf.testing`` — the
+tests here double as usage examples.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_waf.testing.fixtures import (  # noqa: F401 — re-exported as pytest fixtures
+    allow_rule,
+    block_rule,
+    challenge_token,
+    disable_waf,
+    waf_redis_mock,
+)
+
+# ---------------------------------------------------------------------------
+# disable_waf
+# ---------------------------------------------------------------------------
+
+
+class TestDisableWafFixture:
+    def test_disable_waf_flips_the_conf_flag(self, disable_waf):
+        from django_waf import conf
+
+        assert conf.DJANGO_WAF_ENABLED is False
+
+    def test_disable_waf_restored_after_test(self):
+        """Sanity check: outside the fixture, the flag reflects the real setting again."""
+        from django_waf import conf
+
+        assert conf.DJANGO_WAF_ENABLED is True
+
+
+# ---------------------------------------------------------------------------
+# block_rule / allow_rule / challenge_token
+# ---------------------------------------------------------------------------
+
+
+class TestModelFixtures:
+    @pytest.mark.django_db
+    def test_block_rule_fixture_creates_instance(self, block_rule):
+        from django_waf.models import BlockRule
+
+        assert isinstance(block_rule, BlockRule)
+        assert BlockRule.objects.filter(pk=block_rule.pk).exists()
+
+    @pytest.mark.django_db
+    def test_allow_rule_fixture_creates_instance(self, allow_rule):
+        from django_waf.models import AllowRule
+
+        assert isinstance(allow_rule, AllowRule)
+        assert AllowRule.objects.filter(pk=allow_rule.pk).exists()
+
+    @pytest.mark.django_db
+    def test_challenge_token_fixture_creates_instance(self, challenge_token):
+        from django_waf.models import ChallengeToken
+
+        assert isinstance(challenge_token, ChallengeToken)
+        assert ChallengeToken.objects.filter(pk=challenge_token.pk).exists()
+
+
+# ---------------------------------------------------------------------------
+# waf_redis_mock
+# ---------------------------------------------------------------------------
+
+
+class TestWafRedisMockFixture:
+    def test_returns_a_working_fake_redis_client(self, waf_redis_mock):
+        waf_redis_mock.set("waf:test:key", "1")
+        assert waf_redis_mock.get("waf:test:key") == b"1"
+
+    def test_patches_middleware_redis_accessor(self, waf_redis_mock):
+        from django_waf.middleware import _get_redis_client
+
+        assert _get_redis_client() is waf_redis_mock
+
+    def test_patches_views_redis_accessor(self, waf_redis_mock):
+        from django_waf.views import _get_redis_client
+
+        assert _get_redis_client() is waf_redis_mock
+
+    def test_patches_form_protection_default_redis_factory(self, waf_redis_mock):
+        from django_waf.forms.protection import _default_redis_factory
+
+        assert _default_redis_factory() is waf_redis_mock
+
+
+# ---------------------------------------------------------------------------
+# create_blocked_request / create_challenged_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestCreateBlockedRequestHelper:
+    def test_creates_ip_block_rule_and_blocks_the_request(self, client, waf_redis_mock):
+        from django_waf.testing.helpers import create_blocked_request
+
+        response = create_blocked_request(client, path="/", ip="192.0.2.99")
+
+        assert response.status_code == 403
+
+    def test_creates_a_block_rule_for_the_given_ip(self, client, waf_redis_mock):
+        from django_waf.enums import RuleAction, RuleType
+        from django_waf.models import BlockRule
+        from django_waf.testing.helpers import create_blocked_request
+
+        create_blocked_request(client, path="/", ip="203.0.113.55")
+
+        rule = BlockRule.objects.get(pattern="203.0.113.55")
+        assert rule.rule_type == RuleType.IP
+        assert rule.action == RuleAction.BLOCK
+
+
+@pytest.mark.django_db
+class TestCreateChallengedRequestHelper:
+    def test_creates_ua_challenge_rule_and_challenges_the_request(self, client, waf_redis_mock):
+        from django_waf.testing.helpers import create_challenged_request
+
+        response = create_challenged_request(client, path="/", ua="python-requests/2.28")
+
+        assert response.status_code in (302, 403)
+
+    def test_creates_a_challenge_rule_for_the_given_ua(self, client, waf_redis_mock):
+        from django_waf.enums import RuleAction, RuleType
+        from django_waf.models import BlockRule
+        from django_waf.testing.helpers import create_challenged_request
+
+        create_challenged_request(client, path="/", ua="scrapy-bot/1.0")
+
+        rule = BlockRule.objects.get(pattern="scrapy-bot/1.0")
+        assert rule.rule_type == RuleType.UA
+        assert rule.action == RuleAction.CHALLENGE

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -9,8 +9,16 @@ Usage in tests:
     settings.ROOT_URLCONF = "tests.urls"    # or overridden via autouse fixture
 """
 
+from django.http import HttpResponse
 from django.urls import include, path
 
+
+def noop_view(request):
+    """A simple view that returns a 200 OK response."""
+    return HttpResponse("OK")
+
+
 urlpatterns = [
+    path("", noop_view, name="root"),
     path("waf/", include("django_waf.urls", namespace="django_waf")),
 ]


### PR DESCRIPTION
Six phases of the waf-releases plan **Consumer DX** block (ships in v1.3.0). All additive, no model changes, no new migrations.

## Phases

| Phase | Feature |
|---|---|
| 1.1 | `prune_challenge_tokens` task + `django_waf_prune_challenges` command (`--hours`, `--dry-run`) |
| 1.2 | `DJANGO_WAF_CELERY_BEAT_SCHEDULE` ready-made beat entries for all periodic tasks |
| 1.3 | `check_middleware_ordering` (W004) — warns when WafMiddleware runs before AuthenticationMiddleware |
| 2.1 | Test fixtures: `disable_waf`, `waf_redis_mock`, `block_rule`, `allow_rule`, `challenge_token` |
| 2.2 | Test helpers: `create_blocked_request`, `create_challenged_request` |
| 8 | `logging.WafStructuredFormatter` — one JSON object per line, optional fields omitted, UA truncated to 200 |

## Notes

- **Celery-optional**: `celery.schedules.crontab` imported under `try/except`; `conf.py` stays importable without celery installed. The wall-clock beat entries are omitted (not approximated) when celery is absent; the `*/N min` interval entries are always present.
- **gitignore**: added `venv/ .venv/ env/` — the repo had no virtualenv entries.
- **fakeredis** added to the `dev` extra (required by `waf_redis_mock`).

## Tests

Full suite **755 passed** (was ~700), `ruff check` clean. Not a release — no `v*` tag.