### PR TITLE
feat: per-path rate limiting, country blocking, rule import/export (Phases 3, 4, 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   level, logger, message, and (when present on the record) ip, verdict,
   rule_id, anomaly_score, latency_ms, path, method, and user_agent
   (truncated to 200 characters).
+- `DJANGO_WAF_RATE_LIMIT_PATHS`: per-path rate limiting. A dict of
+  `{path_prefix: (max_requests, window_seconds)}` checked before the global
+  IP rate-limit windows; the longest matching prefix wins. Lets a site set a
+  tight limit on `/api/login/` without touching the general request budget.
+- `DJANGO_WAF_BLOCKED_COUNTRIES`: country blocking. A list of ISO 3166-1
+  alpha-2 codes (e.g. `["CN", "RU"]`) rejected outright with a 403, checked
+  after IP extraction and before the staff bypass. Requires a GeoIP database
+  (`django_waf_install_geoip`); fails open when the lookup is unavailable so
+  a missing/broken database never blocks traffic.
+- Management commands `django_waf_export_rules` and `django_waf_import_rules`:
+  serialise `BlockRule`/`AllowRule` records to JSON and load them back on
+  another site. Import supports `--merge` (default, skips rules that already
+  exist by `rule_type`/`match_type`/`pattern`) and `--replace` (deletes
+  existing `source=admin` rules first), plus `--dry-run`. Imported rules are
+  always tagged `source=admin`, never re-tagged as feed/auto.
 
 ## [1.2.0] - 2026-07-11
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ All settings are namespaced under `DJANGO_WAF_*` and have sensible defaults.
 | `DJANGO_WAF_RATE_LIMIT_BURST` | `10` | Max requests per IP per second |
 | `DJANGO_WAF_RATE_LIMIT_PER_MINUTE` | `120` | Max requests per IP per minute |
 | `DJANGO_WAF_RATE_LIMIT_PER_5MIN` | `600` | Max requests per IP per 5 minutes |
+| `DJANGO_WAF_RATE_LIMIT_PATHS` | `{}` | Per-path rate limits: `{path_prefix: (max_requests, window_seconds)}`. Checked before the global windows; the longest matching prefix wins |
 
 ### Challenges
 
@@ -187,6 +188,7 @@ All settings are namespaced under `DJANGO_WAF_*` and have sensible defaults.
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `DJANGO_WAF_GEOIP_PATH` | `None` | Filesystem path to a MaxMind GeoLite2-Country `.mmdb` database. `None` disables GeoIP. |
+| `DJANGO_WAF_BLOCKED_COUNTRIES` | `[]` | ISO 3166-1 alpha-2 country codes to block outright (e.g. `["CN", "RU"]`). Empty disables country blocking. Requires `DJANGO_WAF_GEOIP_PATH`; fails open when the lookup is unavailable. |
 
 ### nginx Integration
 
@@ -410,6 +412,8 @@ name) if you need different cadences.
 | `django_waf_prune_logs` | Delete `RequestLog` entries older than the retention period (`--dry-run`) |
 | `django_waf_prune_challenges` | Delete pending/failed `ChallengeToken` entries older than N hours (`--hours`, `--dry-run`) |
 | `django_waf_sync_feed` | Fetch and import rules from the collective threat feed (`--dry-run`) |
+| `django_waf_export_rules` | Export `BlockRule`/`AllowRule` records to JSON (`--output`, `--source`, `--rule-type`) |
+| `django_waf_import_rules` | Import `BlockRule`/`AllowRule` records from JSON produced by `django_waf_export_rules` (`--merge`, `--replace`, `--dry-run`) |
 
 ## Dashboard
 

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -377,6 +377,15 @@ DJANGO_WAF_ESCALATION_BLOCK_TTL: int = getattr(settings, "DJANGO_WAF_ESCALATION_
 DJANGO_WAF_CLOUD_SPRAY_MIN_IPS: int = getattr(settings, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 20)
 DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP: int = getattr(settings, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3)
 
+# Per-path rate limits: {path_prefix: (max_requests, window_seconds)}.
+# Longest-prefix match wins; checked before the global IP windows.
+DJANGO_WAF_RATE_LIMIT_PATHS: dict = getattr(settings, "DJANGO_WAF_RATE_LIMIT_PATHS", {})
+
+# ISO 3166-1 alpha-2 country codes to block outright (e.g. ["CN", "RU"]).
+# Empty disables country blocking. Requires a GeoIP database (see
+# django_waf_install_geoip); fails open when lookup is unavailable.
+DJANGO_WAF_BLOCKED_COUNTRIES: list = getattr(settings, "DJANGO_WAF_BLOCKED_COUNTRIES", [])
+
 # ---------------------------------------------------------------------------
 # Celery Beat schedule helper
 # ---------------------------------------------------------------------------

--- a/src/django_waf/management/commands/django_waf_export_rules.py
+++ b/src/django_waf/management/commands/django_waf_export_rules.py
@@ -1,0 +1,122 @@
+"""
+Management command: django_waf_export_rules
+
+Serialises BlockRule and AllowRule records to JSON for backup or transfer
+to another site. Pairs with django_waf_import_rules.
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Export WAF block and allow rules to JSON."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--output",
+            default=None,
+            help="File path to write the JSON to (default: stdout).",
+        )
+        parser.add_argument(
+            "--source",
+            choices=["admin", "auto", "feed", "all"],
+            default="all",
+            help="Only export rules from this source (default: all).",
+        )
+        parser.add_argument(
+            "--rule-type",
+            choices=["block", "allow", "all"],
+            default="all",
+            help="Only export block rules, allow rules, or both (default: all).",
+        )
+
+    def handle(self, *args, **options) -> None:
+        import json
+
+        from django.utils import timezone
+
+        from django_waf.models import AllowRule, BlockRule
+
+        source: str = options["source"]
+        rule_type: str = options["rule_type"]
+        output: str | None = options["output"]
+
+        block_rules: list[dict] = []
+        allow_rules: list[dict] = []
+
+        if rule_type in ("block", "all"):
+            qs = BlockRule.objects.all()
+            if source != "all":
+                qs = qs.filter(source=source)
+            block_rules = [_serialise_block_rule(rule) for rule in qs]
+
+        if rule_type in ("allow", "all"):
+            qs = AllowRule.objects.all()
+            allow_rules = [_serialise_allow_rule(rule) for rule in qs]
+
+        payload = {
+            "version": 1,
+            "exported_at": timezone.now().isoformat(),
+            "block_rules": block_rules,
+            "allow_rules": allow_rules,
+        }
+
+        text = json.dumps(payload, indent=2)
+
+        if output:
+            try:
+                with open(output, "w") as fh:
+                    fh.write(text)
+            except OSError as exc:
+                raise CommandError(f"Could not write to {output}: {exc}") from exc
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"Exported {len(block_rules)} block rule(s) and {len(allow_rules)} allow rule(s) to {output}."
+                )
+            )
+            return
+
+        self.stdout.write(text)
+
+
+def _serialise_block_rule(rule) -> dict:
+    """Return a JSON-serialisable dict of the meaningful BlockRule fields.
+
+    Excludes id, created_at, and updated_at — those are regenerated on
+    import.
+    """
+    return {
+        "name": rule.name,
+        "rule_type": rule.rule_type,
+        "match_type": rule.match_type,
+        "pattern": rule.pattern,
+        "action": rule.action,
+        "priority": rule.priority,
+        "is_active": rule.is_active,
+        "source": rule.source,
+        "expires_at": rule.expires_at.isoformat() if rule.expires_at else None,
+        "confidence": str(rule.confidence),
+        "feed_first_seen": rule.feed_first_seen.isoformat() if rule.feed_first_seen else None,
+        "feed_reporters": rule.feed_reporters,
+        "notes": rule.notes,
+    }
+
+
+def _serialise_allow_rule(rule) -> dict:
+    """Return a JSON-serialisable dict of the meaningful AllowRule fields.
+
+    Excludes id, created_at, and updated_at — those are regenerated on
+    import.
+    """
+    return {
+        "name": rule.name,
+        "rule_type": rule.rule_type,
+        "match_type": rule.match_type,
+        "pattern": rule.pattern,
+        "verify_rdns": rule.verify_rdns,
+        "rdns_pattern": rule.rdns_pattern,
+        "is_active": rule.is_active,
+        "notes": rule.notes,
+    }

--- a/src/django_waf/management/commands/django_waf_import_rules.py
+++ b/src/django_waf/management/commands/django_waf_import_rules.py
@@ -1,0 +1,151 @@
+"""
+Management command: django_waf_import_rules
+
+Loads BlockRule and AllowRule records from the JSON produced by
+django_waf_export_rules. Imported rules are always tagged
+source=admin — they are never re-tagged as feed/auto, regardless of
+what the exporting site originally recorded.
+"""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Import WAF block and allow rules from JSON produced by django_waf_export_rules."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument("file", help="Path to the JSON file to import.")
+        parser.add_argument(
+            "--merge",
+            action="store_true",
+            default=False,
+            help="Skip rules that already exist (matched on rule_type, match_type, pattern). Default mode.",
+        )
+        parser.add_argument(
+            "--replace",
+            action="store_true",
+            default=False,
+            help="Delete existing source=admin rules before importing.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Report what would be created/skipped/replaced without writing any changes.",
+        )
+
+    def handle(self, *args, **options) -> None:
+        import json
+
+        from django.db import transaction
+        from django.utils.dateparse import parse_datetime
+
+        from django_waf.enums import RuleSource
+        from django_waf.models import AllowRule, BlockRule
+
+        file_path: str = options["file"]
+        merge: bool = options["merge"]
+        replace: bool = options["replace"]
+        dry_run: bool = options["dry_run"]
+
+        if merge and replace:
+            raise CommandError("--merge and --replace are mutually exclusive.")
+
+        # --merge is the default when neither flag is given.
+        if not merge and not replace:
+            merge = True
+
+        try:
+            with open(file_path) as fh:
+                payload = json.load(fh)
+        except OSError as exc:
+            raise CommandError(f"Could not read {file_path}: {exc}") from exc
+        except json.JSONDecodeError as exc:
+            raise CommandError(f"{file_path} is not valid JSON: {exc}") from exc
+
+        block_rules = payload.get("block_rules", [])
+        allow_rules = payload.get("allow_rules", [])
+
+        created = 0
+        skipped = 0
+        replaced = 0
+
+        with transaction.atomic():
+            if replace:
+                # AllowRule has no source field — "admin rules" for allow
+                # rules means all of them, since every AllowRule is
+                # hand-authored (there is no auto/feed source for allows).
+                replaced_block_count = BlockRule.objects.filter(source=RuleSource.ADMIN).count()
+                replaced_allow_count = AllowRule.objects.count()
+                if not dry_run:
+                    BlockRule.objects.filter(source=RuleSource.ADMIN).delete()
+                    AllowRule.objects.all().delete()
+                replaced = replaced_block_count + replaced_allow_count
+
+            existing_block_keys = set()
+            if merge:
+                existing_block_keys = set(BlockRule.objects.values_list("rule_type", "match_type", "pattern"))
+            existing_allow_keys = set()
+            if merge:
+                existing_allow_keys = set(AllowRule.objects.values_list("rule_type", "match_type", "pattern"))
+
+            for entry in block_rules:
+                key = (entry["rule_type"], entry["match_type"], entry["pattern"])
+                if merge and key in existing_block_keys:
+                    skipped += 1
+                    continue
+                if dry_run:
+                    created += 1
+                    continue
+                expires_at = parse_datetime(entry["expires_at"]) if entry.get("expires_at") else None
+                feed_first_seen = entry.get("feed_first_seen") or None
+                BlockRule.objects.create(
+                    name=entry["name"],
+                    rule_type=entry["rule_type"],
+                    match_type=entry["match_type"],
+                    pattern=entry["pattern"],
+                    action=entry["action"],
+                    priority=entry.get("priority", 100),
+                    is_active=entry.get("is_active", True),
+                    source=RuleSource.ADMIN,
+                    expires_at=expires_at,
+                    confidence=entry.get("confidence", "1.00"),
+                    feed_first_seen=feed_first_seen,
+                    feed_reporters=entry.get("feed_reporters", 0),
+                    notes=entry.get("notes", ""),
+                )
+                created += 1
+                existing_block_keys.add(key)
+
+            for entry in allow_rules:
+                key = (entry["rule_type"], entry["match_type"], entry["pattern"])
+                if merge and key in existing_allow_keys:
+                    skipped += 1
+                    continue
+                if dry_run:
+                    created += 1
+                    continue
+                AllowRule.objects.create(
+                    name=entry["name"],
+                    rule_type=entry["rule_type"],
+                    match_type=entry["match_type"],
+                    pattern=entry["pattern"],
+                    verify_rdns=entry.get("verify_rdns", False),
+                    rdns_pattern=entry.get("rdns_pattern", ""),
+                    is_active=entry.get("is_active", True),
+                    notes=entry.get("notes", ""),
+                )
+                created += 1
+                existing_allow_keys.add(key)
+
+            if dry_run:
+                # Roll back — dry-run must not persist anything.
+                transaction.set_rollback(True)
+
+        prefix = "[dry-run] " if dry_run else ""
+        self.stdout.write(self.style.SUCCESS(f"{prefix}Created: {created}"))
+        self.stdout.write(self.style.WARNING(f"{prefix}Skipped (already exists): {skipped}"))
+        if replace:
+            self.stdout.write(self.style.WARNING(f"{prefix}Replaced (deleted admin rules): {replaced}"))

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -84,6 +84,12 @@ class WafMiddleware:
             return self.get_response(request)
         user_agent = request.META.get("HTTP_USER_AGENT", "")
 
+        # Country blocking — fail-open on any GeoIP error or missing database.
+        if conf.DJANGO_WAF_BLOCKED_COUNTRIES:
+            blocked_response = self._check_country_block(request, ip_address, user_agent, path)
+            if blocked_response is not None:
+                return blocked_response
+
         # BR-RATE-003: staff/superuser bypass — skip WAF entirely
         if _is_staff_user(request):
             return self.get_response(request)
@@ -144,6 +150,61 @@ class WafMiddleware:
         )
 
         return response
+
+    def _check_country_block(self, request, ip_address, user_agent, path):
+        """Return a 403 response if the request's country is blocked, else None.
+
+        Fails open: any error resolving the country (missing database,
+        geoip2 not installed, lookup exception) falls through to normal
+        evaluation rather than blocking. Logging the block is best-effort —
+        a logging failure never prevents the 403 from being returned.
+        """
+        from django_waf import conf
+
+        try:
+            from django_waf.services.geoip import lookup_country
+
+            country = lookup_country(ip_address)
+            if not country:
+                # No database / lookup failure — fail open.
+                return None
+
+            blocked_countries = {c.upper() for c in conf.DJANGO_WAF_BLOCKED_COUNTRIES}
+            if country.upper() not in blocked_countries:
+                return None
+
+            self._log_country_block(request, ip_address, user_agent, path, country)
+            return HttpResponseForbidden("Access denied.")
+        except Exception:
+            logger.exception("django-waf: error during country-block check — failing open")
+            return None
+
+    def _log_country_block(self, request, ip_address, user_agent, path, country):
+        """Best-effort RequestLog entry for a country-blocked request."""
+        try:
+            from django.utils import timezone
+
+            from django_waf.enums import Verdict
+            from django_waf.models import RequestLog
+
+            RequestLog.objects.create(
+                timestamp=timezone.now(),
+                ip_address=ip_address,
+                user_agent=user_agent[:1024],
+                path=path[:2048],
+                method=request.method,
+                verdict=Verdict.BLOCKED,
+                matched_rule_id=None,
+                matched_rule_type="",
+                anomaly_score=None,
+                response_code=403,
+                referer=request.META.get("HTTP_REFERER", "")[:2048],
+                http_fingerprint=_compute_fingerprint(request),
+                fingerprint_verdict=_classify_fingerprint(request),
+                country_code=country,
+            )
+        except Exception:
+            logger.exception("django-waf: error creating RequestLog record for country block")
 
     def _handle_verdict(self, request, result, ip_address, user_agent, path, redis_client):
         from django_waf.enums import Verdict

--- a/src/django_waf/services/rate_limiter.py
+++ b/src/django_waf/services/rate_limiter.py
@@ -7,6 +7,7 @@ checked: per-second burst, per-minute, and per-5-minute (BR-RATE-001).
 
 from __future__ import annotations
 
+import hashlib
 import time
 from typing import NamedTuple
 
@@ -30,9 +31,74 @@ _WINDOWS: list[tuple[str, int]] = [
 ]
 
 
+def _check_path_rate_limit(
+    ip_address: str,
+    path: str,
+    redis_client,
+    now: float,
+) -> RateLimitResult | None:
+    """Check the per-path rate limit for the longest matching configured prefix.
+
+    Mirrors the sliding-window sorted-set algorithm used by the global
+    windows in ``check_rate_limit`` (ZADD, ZREMRANGEBYSCORE, ZCARD, EXPIRE),
+    but keyed per-prefix so a hot path can be throttled independently of
+    the IP's overall traffic.
+
+    Args:
+        ip_address: Client IP address string.
+        path: Request path to match against configured prefixes.
+        redis_client: Configured Redis client instance.
+        now: Current time (``time.time()``), passed in so callers share a
+            single timestamp across the path and global checks.
+
+    Returns:
+        A ``RateLimitResult`` with ``window="path"`` if the matching prefix's
+        limit was breached, or ``None`` if no prefix matched or the matching
+        prefix's limit was not breached.
+    """
+    from django_waf import conf  # lazy — avoids circular import at module load
+
+    rate_limit_paths = conf.DJANGO_WAF_RATE_LIMIT_PATHS
+    if not path or not rate_limit_paths:
+        return None
+
+    # Longest-prefix match wins.
+    matched_prefix = None
+    for prefix in rate_limit_paths:
+        if path.startswith(prefix) and (matched_prefix is None or len(prefix) > len(matched_prefix)):
+            matched_prefix = prefix
+
+    if matched_prefix is None:
+        return None
+
+    max_requests, window_seconds = rate_limit_paths[matched_prefix]
+    # Not a security use — just a stable, short cache-key fragment derived
+    # from the configured prefix string.
+    prefix_hash = hashlib.sha1(matched_prefix.encode(), usedforsecurity=False).hexdigest()[:12]
+    key = f"waf:rate:{ip_address}:path:{prefix_hash}"
+    cutoff = now - window_seconds
+
+    pipe = redis_client.pipeline()
+    pipe.zadd(key, {str(now): now})
+    pipe.zremrangebyscore(key, 0, cutoff)
+    pipe.zcard(key)
+    pipe.expire(key, window_seconds + 10)
+    results = pipe.execute()
+
+    count = results[2]
+
+    if count > max_requests:
+        retry_after = int(window_seconds - (now - cutoff))
+        retry_after = max(1, retry_after)
+        return RateLimitResult(exceeded=True, window="path", retry_after=retry_after)
+
+    return None
+
+
 def check_rate_limit(
     ip_address: str,
     redis_client,
+    path: str = "",
 ) -> RateLimitResult:
     """Check whether the IP has exceeded any rate limit window.
 
@@ -42,11 +108,19 @@ def check_rate_limit(
     3. ZCARD to count remaining entries
     4. EXPIRE the key with window_seconds + small buffer
 
+    When ``path`` is supplied and ``DJANGO_WAF_RATE_LIMIT_PATHS`` configures a
+    matching prefix, that per-path limit is checked first using the same
+    sliding-window algorithm, keyed independently of the global IP windows.
+    The longest matching prefix wins. A breach there returns immediately
+    with ``window="path"`` without touching the global windows.
+
     Per BR-RATE-001 and BR-RATE-002.
 
     Args:
         ip_address: Client IP address string.
         redis_client: Configured Redis client instance.
+        path: Request path, used to match per-path rate limits. Empty string
+            (default) skips per-path checking entirely.
 
     Returns:
         RateLimitResult namedtuple. If any window is exceeded, ``exceeded``
@@ -67,6 +141,10 @@ def check_rate_limit(
     }
 
     now = time.time()
+
+    path_result = _check_path_rate_limit(ip_address, path, redis_client, now)
+    if path_result is not None:
+        return path_result
 
     for window_name, window_seconds in _WINDOWS:
         key = f"waf:rate:{ip_address}:{window_name}"

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -352,7 +352,7 @@ def evaluate_request(
         )
 
     # Step 7: Rate limits
-    rate_result = check_rate_limit(ip_address, redis_client)
+    rate_result = check_rate_limit(ip_address, redis_client, path=path)
     if rate_result.exceeded:
         return EvaluationResult(
             verdict=Verdict.THROTTLED,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -18,7 +18,12 @@ from django.core.management.base import CommandError
 from django.utils import timezone
 
 from django_waf.services.anomaly_detector import run_all_detectors
-from django_waf.testing.factories import BlockRuleFactory, ChallengeTokenFactory, RequestLogFactory
+from django_waf.testing.factories import (
+    AllowRuleFactory,
+    BlockRuleFactory,
+    ChallengeTokenFactory,
+    RequestLogFactory,
+)
 
 # ---------------------------------------------------------------------------
 # django_waf_generate_blocklist
@@ -860,3 +865,185 @@ class TestInstallGeoipCommand:
             pytest.raises(CommandError, match="Download failed: MaxMind"),
         ):
             call_command("django_waf_install_geoip")
+
+
+# ---------------------------------------------------------------------------
+# django_waf_export_rules / django_waf_import_rules
+# ---------------------------------------------------------------------------
+
+
+class TestExportRulesCommand:
+    """Tests for the ``django_waf_export_rules`` management command."""
+
+    @pytest.mark.django_db
+    def test_export_emits_valid_json_with_envelope(self):
+        """Output is valid JSON with the version/exported_at envelope."""
+        import json
+
+        BlockRuleFactory()
+        AllowRuleFactory()
+
+        out = StringIO()
+        call_command("django_waf_export_rules", stdout=out)
+
+        payload = json.loads(out.getvalue())
+        assert payload["version"] == 1
+        assert "exported_at" in payload
+        assert len(payload["block_rules"]) == 1
+        assert len(payload["allow_rules"]) == 1
+        # id / created_at / updated_at must not leak into the export.
+        assert "id" not in payload["block_rules"][0]
+        assert "created_at" not in payload["block_rules"][0]
+        assert "updated_at" not in payload["block_rules"][0]
+
+    @pytest.mark.django_db
+    def test_export_filters_by_source(self):
+        """--source restricts BlockRule export to the matching source."""
+        import json
+
+        BlockRuleFactory(source="admin")
+        BlockRuleFactory(source="feed")
+
+        out = StringIO()
+        call_command("django_waf_export_rules", "--source=feed", stdout=out)
+
+        payload = json.loads(out.getvalue())
+        assert len(payload["block_rules"]) == 1
+        assert payload["block_rules"][0]["source"] == "feed"
+
+    @pytest.mark.django_db
+    def test_export_rule_type_block_only(self):
+        """--rule-type=block excludes allow rules from the export."""
+        import json
+
+        BlockRuleFactory()
+        AllowRuleFactory()
+
+        out = StringIO()
+        call_command("django_waf_export_rules", "--rule-type=block", stdout=out)
+
+        payload = json.loads(out.getvalue())
+        assert len(payload["block_rules"]) == 1
+        assert payload["allow_rules"] == []
+
+
+class TestImportRulesCommand:
+    """Tests for the ``django_waf_import_rules`` management command."""
+
+    def _write_export(self, tmp_path, block_rules=None, allow_rules=None):
+        import json
+
+        payload = {
+            "version": 1,
+            "exported_at": "2026-01-01T00:00:00+00:00",
+            "block_rules": block_rules or [],
+            "allow_rules": allow_rules or [],
+        }
+        path = tmp_path / "export.json"
+        path.write_text(json.dumps(payload))
+        return str(path)
+
+    def _block_rule_entry(self, **overrides) -> dict:
+        entry = {
+            "name": "imported-block",
+            "rule_type": "ip",
+            "match_type": "exact",
+            "pattern": "203.0.113.5",
+            "action": "block",
+            "priority": 100,
+            "is_active": True,
+            "source": "feed",
+            "expires_at": None,
+            "confidence": "1.00",
+            "feed_first_seen": None,
+            "feed_reporters": 0,
+            "notes": "",
+        }
+        entry.update(overrides)
+        return entry
+
+    @pytest.mark.django_db
+    def test_import_creates_rules(self, tmp_path):
+        """A fresh import creates the block and allow rules from the file."""
+        from django_waf.enums import RuleSource
+        from django_waf.models import AllowRule, BlockRule
+
+        allow_entry = {
+            "name": "imported-allow",
+            "rule_type": "ip",
+            "match_type": "exact",
+            "pattern": "198.51.100.5",
+            "verify_rdns": False,
+            "rdns_pattern": "",
+            "is_active": True,
+            "notes": "",
+        }
+        path = self._write_export(
+            tmp_path,
+            block_rules=[self._block_rule_entry()],
+            allow_rules=[allow_entry],
+        )
+
+        out = StringIO()
+        call_command("django_waf_import_rules", path, stdout=out)
+
+        assert BlockRule.objects.filter(pattern="203.0.113.5").exists()
+        assert AllowRule.objects.filter(pattern="198.51.100.5").exists()
+        # Imported rules are always tagged admin, even though the export
+        # said source=feed.
+        assert BlockRule.objects.get(pattern="203.0.113.5").source == RuleSource.ADMIN
+        assert "Created: 2" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_merge_skips_existing_rule(self, tmp_path):
+        """--merge (the default) skips a rule whose (rule_type, match_type, pattern) already exists."""
+        from django_waf.models import BlockRule
+
+        BlockRuleFactory(rule_type="ip", match_type="exact", pattern="203.0.113.5")
+        path = self._write_export(tmp_path, block_rules=[self._block_rule_entry()])
+
+        out = StringIO()
+        call_command("django_waf_import_rules", path, "--merge", stdout=out)
+
+        assert BlockRule.objects.filter(pattern="203.0.113.5").count() == 1
+        assert "Skipped (already exists): 1" in out.getvalue()
+        assert "Created: 0" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_replace_deletes_existing_admin_rules_first(self, tmp_path):
+        """--replace deletes existing source=admin rules before importing."""
+        from django_waf.models import BlockRule
+
+        BlockRuleFactory(source="admin", pattern="10.0.0.1")
+        BlockRuleFactory(source="feed", pattern="10.0.0.2")
+        path = self._write_export(tmp_path, block_rules=[self._block_rule_entry()])
+
+        out = StringIO()
+        call_command("django_waf_import_rules", path, "--replace", stdout=out)
+
+        # The pre-existing admin rule is gone; the feed rule is untouched
+        # (--replace only clears admin-sourced rules); the imported rule exists.
+        assert not BlockRule.objects.filter(pattern="10.0.0.1").exists()
+        assert BlockRule.objects.filter(pattern="10.0.0.2").exists()
+        assert BlockRule.objects.filter(pattern="203.0.113.5").exists()
+        assert "Replaced (deleted admin rules): 1" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_dry_run_makes_no_db_changes(self, tmp_path):
+        """--dry-run reports counts without writing anything."""
+        from django_waf.models import BlockRule
+
+        path = self._write_export(tmp_path, block_rules=[self._block_rule_entry()])
+
+        out = StringIO()
+        call_command("django_waf_import_rules", path, "--dry-run", stdout=out)
+
+        assert BlockRule.objects.count() == 0
+        assert "[dry-run] Created: 1" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_merge_and_replace_are_mutually_exclusive(self, tmp_path):
+        path = self._write_export(tmp_path)
+
+        with pytest.raises(CommandError, match="mutually exclusive"):
+            call_command("django_waf_import_rules", path, "--merge", "--replace")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -805,6 +805,99 @@ class TestRequestLogging:
 
 
 # ---------------------------------------------------------------------------
+# Country blocking
+# ---------------------------------------------------------------------------
+
+
+class TestCountryBlocking:
+    """DJANGO_WAF_BLOCKED_COUNTRIES rejects requests from listed countries (fail-open)."""
+
+    @pytest.mark.django_db
+    @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCKED_COUNTRIES=["CN", "RU"])
+    def test_request_from_blocked_country_returns_403(self):
+        import importlib
+
+        import django_waf.conf as conf_mod
+
+        importlib.reload(conf_mod)
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        get_response = MagicMock(return_value=HttpResponse("ok"))
+        middleware = _make_middleware(get_response)
+
+        with patch("django_waf.services.geoip.lookup_country", return_value="CN"):
+            response = middleware(request)
+
+        assert response.status_code == 403
+        get_response.assert_not_called()
+
+    @pytest.mark.django_db
+    @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCKED_COUNTRIES=["CN", "RU"])
+    def test_request_from_unlisted_country_passes_through_to_normal_evaluation(self):
+        import importlib
+
+        import django_waf.conf as conf_mod
+
+        importlib.reload(conf_mod)
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("ok"))
+        middleware = _make_middleware(get_response)
+
+        with (
+            patch("django_waf.services.geoip.lookup_country", return_value="GB"),
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result("allowed")
+
+            response = middleware(request)
+
+        assert response.status_code == 200
+        get_response.assert_called_once_with(request)
+
+    @pytest.mark.django_db
+    @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCKED_COUNTRIES=["CN", "RU"])
+    def test_empty_geoip_result_fails_open(self):
+        """No GeoIP database / lookup failure returns '' — the request is not blocked."""
+        import importlib
+
+        import django_waf.conf as conf_mod
+
+        importlib.reload(conf_mod)
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("ok"))
+        middleware = _make_middleware(get_response)
+
+        with (
+            patch("django_waf.services.geoip.lookup_country", return_value=""),
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result("allowed")
+
+            response = middleware(request)
+
+        assert response.status_code == 200
+        get_response.assert_called_once_with(request)
+
+
+# ---------------------------------------------------------------------------
 # Middleware helper functions
 # ---------------------------------------------------------------------------
 

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -339,6 +339,105 @@ class TestCheckRateLimit:
 
 
 # ---------------------------------------------------------------------------
+# check_rate_limit — per-path limits (DJANGO_WAF_RATE_LIMIT_PATHS)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRateLimitPerPath:
+    """Tests for the per-path rate limiting layer of check_rate_limit."""
+
+    def test_path_limit_breach_returns_exceeded_window_path(self):
+        """A path matching a configured prefix that exceeds its limit is throttled."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(11)  # over the limit of 10
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (10, 60)}):
+            result = check_rate_limit("1.2.3.4", redis, path="/api/widgets/")
+
+        assert result.exceeded is True
+        assert result.window == "path"
+        assert result.retry_after is not None
+        assert result.retry_after >= 1
+
+    def test_unmatched_path_falls_through_to_global_windows(self):
+        """A path with no matching configured prefix only checks the global windows."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(1)  # within all limits
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (10, 60)}),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_BURST", 10),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_MINUTE", 120),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_5MIN", 600),
+        ):
+            result = check_rate_limit("1.2.3.4", redis, path="/blog/post/")
+
+        assert result.exceeded is False
+        # Only the global window keys were touched — no "path" key.
+        zadd_calls = redis.pipeline.return_value.zadd.call_args_list
+        used_keys = {c.args[0] for c in zadd_calls}
+        assert not any(":path:" in key for key in used_keys)
+
+    def test_global_limit_still_applies_when_under_path_limit(self):
+        """When the path limit is not breached, the global windows still run and can throttle."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+
+        call_count = 0
+
+        def pipeline_side_effect():
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return _make_pipeline_mock(1)  # path window — within limit
+            return _make_pipeline_mock(6)  # global 1s window — exceeded
+
+        redis.pipeline.side_effect = pipeline_side_effect
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (100, 60)}),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_BURST", 5),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_MINUTE", 120),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_5MIN", 600),
+        ):
+            result = check_rate_limit("1.2.3.4", redis, path="/api/widgets/")
+
+        assert result.exceeded is True
+        assert result.window == "1s"
+
+    def test_longest_prefix_wins_when_multiple_match(self):
+        """When several configured prefixes match, the most specific one is enforced."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(3)  # over the login limit of 2
+
+        rate_limit_paths = {
+            "/api/": (1000, 60),
+            "/api/login/": (2, 60),
+        }
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", rate_limit_paths):
+            result = check_rate_limit("1.2.3.4", redis, path="/api/login/")
+
+        assert result.exceeded is True
+        assert result.window == "path"
+
+        # Confirm the key used was derived from the longer, more specific prefix.
+        import hashlib
+
+        expected_hash = hashlib.sha1(b"/api/login/").hexdigest()[:12]
+        zadd_calls = redis.pipeline.return_value.zadd.call_args_list
+        used_keys = {c.args[0] for c in zadd_calls}
+        assert f"waf:rate:1.2.3.4:path:{expected_hash}" in used_keys
+
+
+# ---------------------------------------------------------------------------
 # load_rule_cache
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Three phases of the waf-releases **Consumer DX** block (v1.3.0). Additive, no model changes, no migration.

| Phase | Feature |
|---|---|
| 3 | Per-path rate limiting: `DJANGO_WAF_RATE_LIMIT_PATHS` maps path prefixes to `(max_requests, window_seconds)`; longest-prefix match, checked before the global IP windows |
| 4 | Country blocking: `DJANGO_WAF_BLOCKED_COUNTRIES` enforced in middleware via the existing GeoIP lookup; fails open when no DB / lookup error |
| 5 | Rule import/export: `django_waf_export_rules` and `django_waf_import_rules` move BlockRule/AllowRule sets as versioned JSON |

## Notes

- **Phase 3** derives the per-path Redis key from a stable `sha1(prefix)` (not the process-salted builtin `hash()`, which would scatter keys across restarts).
- **Phase 4** logs a blocked `RequestLog` for each country block and wraps the check + logging in `try/except` so a GeoIP error fails open, matching the middleware's fail-open discipline.
- **Phase 5** forces `source=admin` on all imported rules and wraps writes in a transaction. `--replace` deletes `source=admin` BlockRules only (feed/auto untouched); for AllowRule, which has no `source` field, it deletes all allow rules (every allow rule is hand-authored).

## Tests

Full suite **770 passed** (15 new), `ruff check` + `ruff format --check` clean. Not a release.