### PR TITLE
feat(api): optional DRF API layer under waf/api/ (Phase 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Optional DRF API under `waf/api/`: `BlockRuleViewSet` and `AllowRuleViewSet`
+  (full CRUD, restricted to superusers or staff with `django_waf.change_blockrule`
+  via the new `IsWafAdmin` permission), and read-only `RequestLogViewSet`
+  (`?verdict=`, `?ip_address=`, `?from_ts=` filters) and `IPReputationViewSet`
+  (`?min_threat_score=` filter), both restricted to Django admin users. Off by
+  default — set `DJANGO_WAF_API_ENABLED = True` to mount the routes, and every
+  endpoint returns `503` while disabled. Requires the new `django-waf[api]`
+  extra (`djangorestframework>=3.14`); `djangorestframework` stays fully
+  optional otherwise — the package imports and every existing test passes
+  with it absent from the environment.
 - System check `django_waf.W005`: warns when `DJANGO_WAF_FEED_ENABLED` is
   true but `DJANGO_WAF_FEED_URL` is not `https://`. Feed responses become
   `BlockRule` records, so a plaintext feed is a rule-injection vector. The

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ all configurable without a reverse-proxy vendor.
 - `httpx >= 0.27` (for threat feed sync)
 - Optional: `celery >= 5.3` (for scheduled tasks)
 - Optional: `maxminddb >= 2.4` (for GeoIP lookups)
+- Optional: `djangorestframework >= 3.14` (for the REST API — see [REST API (optional)](#rest-api-optional))
 
 ## Installation
 
@@ -69,6 +70,7 @@ With optional extras:
 ```bash
 pip install django-waf[geoip]    # adds maxminddb for GeoIP support
 pip install django-waf[celery]   # adds celery for scheduled tasks
+pip install django-waf[api]      # adds djangorestframework for the REST API
 ```
 
 Add to `INSTALLED_APPS`:
@@ -426,6 +428,51 @@ users. It provides:
 
 Superusers can **confirm** auto-generated rules (promoting them to permanent) or
 **reject** them (deactivating) directly from the anomalies panel.
+
+## REST API (optional)
+
+An optional DRF API is available under `waf/api/` for integrating django-waf
+with external tooling (a hosted console, a CLI, a second site's dashboard).
+It is off by default.
+
+**Enable it:**
+
+```bash
+pip install django-waf[api]
+```
+
+```python
+DJANGO_WAF_API_ENABLED = True
+```
+
+The routes are mounted automatically by `django_waf.urls` when the setting is
+true and `djangorestframework` is importable — no extra `include()` needed
+beyond the existing `path("waf/", include("django_waf.urls", namespace="django_waf"))`.
+If the setting is true but `djangorestframework` is not installed, the
+routes are skipped and a warning is logged at import time; every endpoint
+also returns `503 Service Unavailable` while the setting is false.
+
+**Endpoints** (all under `waf/api/`, registered with a DRF `DefaultRouter`):
+
+| Endpoint | Viewset | Access |
+|----------|---------|--------|
+| `block-rules/` | `BlockRuleViewSet` — full CRUD | `IsWafAdmin` |
+| `allow-rules/` | `AllowRuleViewSet` — full CRUD | `IsWafAdmin` |
+| `request-logs/` | `RequestLogViewSet` — read-only, `?verdict=`, `?ip_address=`, `?from_ts=` (ISO 8601) filters | `IsAdminUser` |
+| `ip-reputation/` | `IPReputationViewSet` — read-only, `?min_threat_score=` filter | `IsAdminUser` |
+
+**Permission model:**
+
+- `IsWafAdmin` — grants access to superusers, and to staff users holding the
+  `django_waf.change_blockrule` permission. Used on the two writable
+  endpoints (`block-rules/`, `allow-rules/`).
+- `IsAdminUser` (DRF's built-in) — grants access to `is_staff` users. Used on
+  the two read-only audit endpoints (`request-logs/`, `ip-reputation/`),
+  which carry no write actions to restrict further.
+
+`hit_count`, `last_hit_at`, and `source` on `BlockRuleViewSet` are read-only:
+they are maintained by the rule engine and the threat-feed sync task, not by
+API clients.
 
 ## Architecture
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ Changelog = "https://github.com/icvoss/django-waf/blob/main/CHANGELOG.md"
 "Source Code" = "https://github.com/icvoss/django-waf"
 
 [project.optional-dependencies]
+api = ["djangorestframework>=3.14"]
 celery = ["celery>=5.3", "django-celery-beat>=2.6"]
 geoip = ["geoip2>=4.8"]
 dev = [
@@ -54,6 +55,7 @@ dev = [
     "ruff>=0.5.0",
     "mypy>=1.10",
     "django-stubs>=5.0",
+    "djangorestframework>=3.14",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/django_waf/api/__init__.py
+++ b/src/django_waf/api/__init__.py
@@ -1,0 +1,13 @@
+"""Optional DRF API for django-waf.
+
+Nothing in this package is imported by ``django_waf/__init__.py``,
+``django_waf/apps.py``, or the top-level ``django_waf/urls.py`` import path.
+It is only reached when a consuming project sets ``DJANGO_WAF_API_ENABLED =
+True``, at which point ``django_waf/urls.py`` imports ``django_waf.api.urls``
+inside a ``try``/``except ImportError`` block. This keeps
+``djangorestframework`` an optional dependency (the ``[api]`` extra): the
+package imports cleanly, and every existing test passes, whether or not DRF
+is installed.
+"""
+
+from __future__ import annotations

--- a/src/django_waf/api/permissions.py
+++ b/src/django_waf/api/permissions.py
@@ -1,0 +1,26 @@
+"""DRF permission classes for the django-waf API.
+
+See the module docstring in ``api/serializers.py`` for why a plain
+``rest_framework`` import is safe here.
+"""
+
+from __future__ import annotations
+
+from rest_framework.permissions import BasePermission
+
+
+class IsWafAdmin(BasePermission):
+    """Grants access to superusers, or staff users with rule-management rights.
+
+    Matches the existing staff-dashboard access model in ``django_waf.views``
+    (superuser or staff), narrowed for write endpoints by requiring the
+    ``django_waf.change_blockrule`` permission on non-superuser staff.
+    """
+
+    def has_permission(self, request, view) -> bool:
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        if user.is_superuser:
+            return True
+        return bool(user.is_staff and user.has_perm("django_waf.change_blockrule"))

--- a/src/django_waf/api/serializers.py
+++ b/src/django_waf/api/serializers.py
@@ -1,0 +1,60 @@
+"""DRF serializers for the django-waf API.
+
+This module is only ever imported from within the API wiring (``api/urls.py``
+via ``django_waf/urls.py``, guarded by ``DJANGO_WAF_API_ENABLED`` and a
+``try``/``except ImportError``), so a plain ``rest_framework`` import here is
+safe: nothing at package-import time reaches this module.
+"""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+from django_waf.models import AllowRule, BlockRule, IPReputation, RequestLog
+
+
+class BlockRuleSerializer(serializers.ModelSerializer):
+    """Full CRUD serializer for BlockRule.
+
+    Hit-tracking and provenance fields are maintained by the rule engine and
+    the threat-feed sync task, not by API clients, so they are read-only.
+    """
+
+    class Meta:
+        model = BlockRule
+        fields = "__all__"
+        read_only_fields = [
+            "id",
+            "created_at",
+            "updated_at",
+            "hit_count",
+            "last_hit_at",
+            "source",
+        ]
+
+
+class AllowRuleSerializer(serializers.ModelSerializer):
+    """Full CRUD serializer for AllowRule."""
+
+    class Meta:
+        model = AllowRule
+        fields = "__all__"
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class RequestLogSerializer(serializers.ModelSerializer):
+    """Read-only serializer for RequestLog — an audit log, never written via the API."""
+
+    class Meta:
+        model = RequestLog
+        fields = "__all__"
+        read_only_fields = [field.name for field in RequestLog._meta.get_fields() if hasattr(field, "attname")]
+
+
+class IPReputationSerializer(serializers.ModelSerializer):
+    """Read-only serializer for IPReputation — maintained by the scoring service."""
+
+    class Meta:
+        model = IPReputation
+        fields = "__all__"
+        read_only_fields = [field.name for field in IPReputation._meta.get_fields() if hasattr(field, "attname")]

--- a/src/django_waf/api/urls.py
+++ b/src/django_waf/api/urls.py
@@ -1,0 +1,28 @@
+"""URL routing for the optional django-waf DRF API.
+
+Mounted by ``django_waf/urls.py`` under ``waf/api/`` when
+``DJANGO_WAF_API_ENABLED`` is true and ``djangorestframework`` is installed.
+See the module docstring in ``api/serializers.py`` for why a plain
+``rest_framework`` import is safe here.
+"""
+
+from __future__ import annotations
+
+from rest_framework.routers import DefaultRouter
+
+from django_waf.api.viewsets import (
+    AllowRuleViewSet,
+    BlockRuleViewSet,
+    IPReputationViewSet,
+    RequestLogViewSet,
+)
+
+app_name = "django_waf_api"
+
+router = DefaultRouter()
+router.register(r"block-rules", BlockRuleViewSet, basename="block-rule")
+router.register(r"allow-rules", AllowRuleViewSet, basename="allow-rule")
+router.register(r"request-logs", RequestLogViewSet, basename="request-log")
+router.register(r"ip-reputation", IPReputationViewSet, basename="ip-reputation")
+
+urlpatterns = router.urls

--- a/src/django_waf/api/viewsets.py
+++ b/src/django_waf/api/viewsets.py
@@ -1,0 +1,111 @@
+"""DRF viewsets for the django-waf API.
+
+See the module docstring in ``api/serializers.py`` for why a plain
+``rest_framework`` import is safe here.
+"""
+
+from __future__ import annotations
+
+from django.utils.translation import gettext_lazy as _
+from rest_framework.exceptions import APIException
+from rest_framework.permissions import IsAdminUser
+from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
+
+from django_waf.api.permissions import IsWafAdmin
+from django_waf.api.serializers import (
+    AllowRuleSerializer,
+    BlockRuleSerializer,
+    IPReputationSerializer,
+    RequestLogSerializer,
+)
+from django_waf.models import AllowRule, BlockRule, IPReputation, RequestLog
+
+
+class ServiceUnavailable(APIException):
+    """Raised by every django-waf API viewset when the API is disabled."""
+
+    status_code = 503
+    default_detail = _("The django-waf API is disabled. Set DJANGO_WAF_API_ENABLED = True to enable it.")
+
+
+class WafApiEnabledMixin:
+    """Raises a 503 before dispatching when DJANGO_WAF_API_ENABLED is False.
+
+    Read live rather than at import time, so a test (or a runtime setting
+    change) that flips the flag takes effect on the next request.
+    """
+
+    def initial(self, request, *args, **kwargs):
+        from django_waf import conf
+
+        if not conf.DJANGO_WAF_API_ENABLED:
+            raise ServiceUnavailable()
+        super().initial(request, *args, **kwargs)
+
+
+class BlockRuleViewSet(WafApiEnabledMixin, ModelViewSet):
+    """Full CRUD on BlockRule, restricted to WAF admins."""
+
+    queryset = BlockRule.objects.all()
+    serializer_class = BlockRuleSerializer
+    permission_classes = [IsWafAdmin]
+
+
+class AllowRuleViewSet(WafApiEnabledMixin, ModelViewSet):
+    """Full CRUD on AllowRule, restricted to WAF admins."""
+
+    queryset = AllowRule.objects.all()
+    serializer_class = AllowRuleSerializer
+    permission_classes = [IsWafAdmin]
+
+
+class RequestLogViewSet(WafApiEnabledMixin, ReadOnlyModelViewSet):
+    """Read-only access to the request audit log, restricted to Django admin users.
+
+    Supports ``?verdict=``, ``?ip_address=``, and ``?from_ts=`` (an ISO 8601
+    datetime, filtering to ``timestamp__gte``) query filters.
+    """
+
+    queryset = RequestLog.objects.all().order_by("-timestamp")
+    serializer_class = RequestLogSerializer
+    permission_classes = [IsAdminUser]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        params = self.request.query_params
+
+        verdict = params.get("verdict")
+        if verdict:
+            queryset = queryset.filter(verdict=verdict)
+
+        ip_address = params.get("ip_address")
+        if ip_address:
+            queryset = queryset.filter(ip_address=ip_address)
+
+        from_ts = params.get("from_ts")
+        if from_ts:
+            from django.utils.dateparse import parse_datetime
+
+            parsed = parse_datetime(from_ts)
+            if parsed is not None:
+                queryset = queryset.filter(timestamp__gte=parsed)
+
+        return queryset
+
+
+class IPReputationViewSet(WafApiEnabledMixin, ReadOnlyModelViewSet):
+    """Read-only access to aggregated IP reputation, restricted to Django admin users.
+
+    Supports a ``?min_threat_score=`` query filter (``threat_score__gte``).
+    """
+
+    queryset = IPReputation.objects.all().order_by("-threat_score")
+    serializer_class = IPReputationSerializer
+    permission_classes = [IsAdminUser]
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        min_threat_score = self.request.query_params.get("min_threat_score")
+        if min_threat_score:
+            queryset = queryset.filter(threat_score__gte=min_threat_score)
+        return queryset

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -386,6 +386,9 @@ DJANGO_WAF_RATE_LIMIT_PATHS: dict = getattr(settings, "DJANGO_WAF_RATE_LIMIT_PAT
 # django_waf_install_geoip); fails open when lookup is unavailable.
 DJANGO_WAF_BLOCKED_COUNTRIES: list = getattr(settings, "DJANGO_WAF_BLOCKED_COUNTRIES", [])
 
+# Enable the optional DRF API under waf/api/ (requires the [api] extra).
+DJANGO_WAF_API_ENABLED: bool = getattr(settings, "DJANGO_WAF_API_ENABLED", False)
+
 # ---------------------------------------------------------------------------
 # Celery Beat schedule helper
 # ---------------------------------------------------------------------------

--- a/src/django_waf/urls.py
+++ b/src/django_waf/urls.py
@@ -6,11 +6,21 @@ Consuming projects include these routes in their root URL conf:
     path("waf/", include("django_waf.urls", namespace="django_waf"))
 
 The namespace must be "django_waf" to match reverse() calls throughout the package.
+
+The optional DRF API is mounted under waf/api/ only when
+DJANGO_WAF_API_ENABLED is true (see django_waf.conf). This is read once, at
+urlconf-import time, which is the Django norm for urlpatterns — matches how
+ROOT_URLCONF itself is only re-evaluated on process restart or explicit
+urlconf-cache clearing. Importing this module with the API disabled never
+imports rest_framework, keeping djangorestframework an optional dependency
+(the [api] extra).
 """
 
-from django.urls import path
+import logging
 
-from django_waf import views
+from django.urls import include, path
+
+from django_waf import conf, views
 
 app_name = "django_waf"
 
@@ -39,3 +49,19 @@ urlpatterns = [
         name="anomaly-reject",
     ),
 ]
+
+# -----------------------------------------------------------------------
+# Optional DRF API — off by default, requires django-waf[api]
+# -----------------------------------------------------------------------
+if conf.DJANGO_WAF_API_ENABLED:
+    try:
+        from django_waf.api import urls as api_urls
+
+        urlpatterns += [
+            path("api/", include((api_urls.urlpatterns, "django_waf_api"), namespace="api")),
+        ]
+    except ImportError:
+        logging.getLogger("django_waf").warning(
+            "DJANGO_WAF_API_ENABLED is True but djangorestframework is not installed; "
+            "install django-waf[api]. The API routes are not mounted."
+        )

--- a/src/django_waf/urls.py
+++ b/src/django_waf/urls.py
@@ -8,19 +8,29 @@ Consuming projects include these routes in their root URL conf:
 The namespace must be "django_waf" to match reverse() calls throughout the package.
 
 The optional DRF API is mounted under waf/api/ only when
-DJANGO_WAF_API_ENABLED is true (see django_waf.conf). This is read once, at
-urlconf-import time, which is the Django norm for urlpatterns — matches how
-ROOT_URLCONF itself is only re-evaluated on process restart or explicit
-urlconf-cache clearing. Importing this module with the API disabled never
-imports rest_framework, keeping djangorestframework an optional dependency
-(the [api] extra).
+DJANGO_WAF_API_ENABLED is true. This is read once, at urlconf-import time,
+which is the Django norm for urlpatterns — matches how ROOT_URLCONF itself
+is only re-evaluated on process restart or explicit urlconf-cache clearing.
+
+The flag is read directly from django.conf.settings here rather than from
+the cached django_waf.conf.DJANGO_WAF_API_ENABLED constant. Django resolves
+a urlconf lazily, on first URL dispatch, not at ROOT_URLCONF assignment —
+so this module's body can execute at an arbitrary later point in a process
+(e.g. mid-test, inside another test's mock.patch of django_waf.conf). Reading
+straight off settings here means the mount decision reflects the settings
+that were active for the whole process, not whatever happened to be patched
+onto django_waf.conf at the moment something first triggered a dispatch.
+
+Importing this module with the API disabled never imports rest_framework,
+keeping djangorestframework an optional dependency (the [api] extra).
 """
 
 import logging
 
+from django.conf import settings
 from django.urls import include, path
 
-from django_waf import conf, views
+from django_waf import views
 
 app_name = "django_waf"
 
@@ -53,14 +63,14 @@ urlpatterns = [
 # -----------------------------------------------------------------------
 # Optional DRF API — off by default, requires django-waf[api]
 # -----------------------------------------------------------------------
-if conf.DJANGO_WAF_API_ENABLED:
+if getattr(settings, "DJANGO_WAF_API_ENABLED", False):
     try:
         from django_waf.api import urls as api_urls
 
         urlpatterns += [
             path("api/", include((api_urls.urlpatterns, "django_waf_api"), namespace="api")),
         ]
-    except ImportError:
+    except ImportError:  # pragma: no cover - exercised only when djangorestframework is absent
         logging.getLogger("django_waf").warning(
             "DJANGO_WAF_API_ENABLED is True but djangorestframework is not installed; "
             "install django-waf[api]. The API routes are not mounted."

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -11,6 +11,10 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    # Registered so the browsable API and DRF's own app config work when the
+    # dev extra (which pulls in djangorestframework) is installed. The
+    # package itself never requires this — see django_waf/api/__init__.py.
+    "rest_framework",
     "django_waf",
 ]
 
@@ -83,3 +87,9 @@ DJANGO_WAF_ENABLED = True
 DJANGO_WAF_FEED_ENABLED = False  # Never hit the real feed in tests
 DJANGO_WAF_FEED_REPORT = False  # Never report to the feed in tests
 DJANGO_WAF_LOG_SAMPLE_RATE = 1.0  # Log everything in tests
+
+# Enabled at urlconf-import time so waf/api/ routes exist for tests/test_api.py.
+# Individual tests exercise the disabled (503) path by patching
+# django_waf.conf.DJANGO_WAF_API_ENABLED directly, which api/viewsets.py reads
+# live on every request via WafApiEnabledMixin.initial().
+DJANGO_WAF_API_ENABLED = True

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,257 @@
+"""Tests for the optional django-waf DRF API.
+
+Requires djangorestframework, which is guaranteed present here via the [dev]
+extra (see pyproject.toml). tests/settings.py sets DJANGO_WAF_API_ENABLED =
+True so the waf/api/ routes exist at urlconf-import time (mounting is
+conditional on that flag when django_waf.urls is first imported); individual
+tests exercise the disabled (503) path by patching
+django_waf.conf.DJANGO_WAF_API_ENABLED directly, which
+WafApiEnabledMixin.initial() reads live on every request.
+
+ROOT_URLCONF is tests.urls, which includes django_waf.urls under "waf/", so
+the API lives at /waf/api/.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from unittest.mock import patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+
+from django_waf.enums import MatchType, RuleAction, RuleType, Verdict
+from django_waf.models import AllowRule, BlockRule
+from django_waf.testing.factories import (
+    BlockRuleFactory,
+    IPReputationFactory,
+    RequestLogFactory,
+)
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user(*, username="user", is_staff=False, is_superuser=False, perms=()):
+    """Create and return a saved User, optionally staff/superuser with permissions."""
+    user = User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="password",
+        is_staff=is_staff,
+        is_superuser=is_superuser,
+    )
+    for perm in perms:
+        app_label, codename = perm.split(".")
+        from django.contrib.auth.models import Permission
+
+        user.user_permissions.add(Permission.objects.get(content_type__app_label=app_label, codename=codename))
+    return user
+
+
+def _waf_admin_user(**kwargs):
+    """A staff user with django_waf.change_blockrule — satisfies IsWafAdmin without superuser."""
+    return _make_user(is_staff=True, perms=["django_waf.change_blockrule"], **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# API disabled
+# ---------------------------------------------------------------------------
+
+
+class TestApiDisabled:
+    def test_returns_503_when_disabled(self):
+        superuser = _make_user(username="super1", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=superuser)
+
+        with patch("django_waf.conf.DJANGO_WAF_API_ENABLED", False):
+            response = client.get("/waf/api/block-rules/")
+
+        assert response.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Permission enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestPermissions:
+    def test_unauthenticated_request_is_denied(self):
+        client = APIClient()
+
+        response = client.get("/waf/api/block-rules/")
+
+        assert response.status_code in (401, 403)
+
+    def test_non_staff_authenticated_user_denied_on_block_rules(self):
+        user = _make_user(username="plainuser")
+        client = APIClient()
+        client.force_authenticate(user=user)
+
+        response = client.get("/waf/api/block-rules/")
+
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# BlockRuleViewSet
+# ---------------------------------------------------------------------------
+
+
+class TestBlockRuleViewSet:
+    def test_waf_admin_can_list_block_rules(self):
+        BlockRuleFactory.create_batch(3)
+        admin = _make_user(username="admin1", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.get("/waf/api/block-rules/")
+
+        assert response.status_code == 200
+        assert len(response.data) == 3
+
+    def test_waf_admin_can_create_block_rule(self):
+        admin = _make_user(username="admin2", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        payload = {
+            "name": "block-tor-exit",
+            "rule_type": RuleType.IP,
+            "match_type": MatchType.EXACT,
+            "pattern": "203.0.113.5",
+            "action": RuleAction.BLOCK,
+            "priority": 50,
+            "is_active": True,
+            "confidence": "1.00",
+            "feed_reporters": 0,
+            "notes": "",
+        }
+
+        response = client.post("/waf/api/block-rules/", payload, format="json")
+
+        assert response.status_code == 201
+        assert BlockRule.objects.filter(name="block-tor-exit", pattern="203.0.113.5").exists()
+
+    def test_waf_admin_can_update_block_rule(self):
+        rule = BlockRuleFactory(name="original-name", priority=100)
+        admin = _make_user(username="admin3", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.patch(f"/waf/api/block-rules/{rule.id}/", {"priority": 10}, format="json")
+
+        assert response.status_code == 200
+        rule.refresh_from_db()
+        assert rule.priority == 10
+
+    def test_staff_with_change_blockrule_permission_can_list(self):
+        BlockRuleFactory()
+        waf_admin = _waf_admin_user(username="wafadmin")
+        client = APIClient()
+        client.force_authenticate(user=waf_admin)
+
+        response = client.get("/waf/api/block-rules/")
+
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# AllowRuleViewSet
+# ---------------------------------------------------------------------------
+
+
+class TestAllowRuleViewSet:
+    def test_waf_admin_can_create_allow_rule(self):
+        admin = _make_user(username="admin4", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        payload = {
+            "name": "allow-office-ip",
+            "rule_type": RuleType.IP,
+            "match_type": MatchType.EXACT,
+            "pattern": "198.51.100.10",
+            "verify_rdns": False,
+            "rdns_pattern": "",
+            "is_active": True,
+            "notes": "",
+        }
+
+        response = client.post("/waf/api/allow-rules/", payload, format="json")
+
+        assert response.status_code == 201
+        assert AllowRule.objects.filter(name="allow-office-ip").exists()
+
+
+# ---------------------------------------------------------------------------
+# RequestLogViewSet
+# ---------------------------------------------------------------------------
+
+
+class TestRequestLogViewSet:
+    def test_list_is_read_only_for_admin(self):
+        RequestLogFactory.create_batch(2)
+        admin = _make_user(username="admin5", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.get("/waf/api/request-logs/")
+
+        assert response.status_code == 200
+        assert len(response.data) == 2
+
+    def test_post_is_not_allowed(self):
+        admin = _make_user(username="admin6", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.post("/waf/api/request-logs/", {"path": "/x/"}, format="json")
+
+        assert response.status_code == 405
+
+    def test_verdict_filter_narrows_results(self):
+        RequestLogFactory(verdict=Verdict.ALLOWED)
+        RequestLogFactory(verdict=Verdict.BLOCKED)
+        RequestLogFactory(verdict=Verdict.BLOCKED)
+        admin = _make_user(username="admin7", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.get("/waf/api/request-logs/", {"verdict": Verdict.BLOCKED})
+
+        assert response.status_code == 200
+        assert len(response.data) == 2
+        assert all(row["verdict"] == Verdict.BLOCKED for row in response.data)
+
+
+# ---------------------------------------------------------------------------
+# IPReputationViewSet
+# ---------------------------------------------------------------------------
+
+
+class TestIPReputationViewSet:
+    def test_list_and_min_threat_score_filter(self):
+        IPReputationFactory(ip_address="10.9.0.1", threat_score=Decimal("0.10"))
+        IPReputationFactory(ip_address="10.9.0.2", threat_score=Decimal("0.80"))
+        IPReputationFactory(ip_address="10.9.0.3", threat_score=Decimal("0.90"))
+        admin = _make_user(username="admin8", is_staff=True, is_superuser=True)
+        client = APIClient()
+        client.force_authenticate(user=admin)
+
+        response = client.get("/waf/api/ip-reputation/")
+        assert response.status_code == 200
+        assert len(response.data) == 3
+
+        filtered = client.get("/waf/api/ip-reputation/", {"min_threat_score": "0.75"})
+        assert filtered.status_code == 200
+        assert len(filtered.data) == 2
+        assert all(Decimal(row["threat_score"]) >= Decimal("0.75") for row in filtered.data)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,14 +2,29 @@
 
 Requires djangorestframework, which is guaranteed present here via the [dev]
 extra (see pyproject.toml). tests/settings.py sets DJANGO_WAF_API_ENABLED =
-True so the waf/api/ routes exist at urlconf-import time (mounting is
-conditional on that flag when django_waf.urls is first imported); individual
-tests exercise the disabled (503) path by patching
-django_waf.conf.DJANGO_WAF_API_ENABLED directly, which
+True so the waf/api/ routes exist at urlconf-import time; django_waf.urls
+reads the flag straight off django.conf.settings when its module body first
+runs, which happens lazily on the first URL dispatch in the whole test
+session rather than at tests.settings import time (see the docstring in
+django_waf/urls.py). Individual tests exercise the disabled (503) path by
+patching django_waf.conf.DJANGO_WAF_API_ENABLED directly, which
 WafApiEnabledMixin.initial() reads live on every request.
 
 ROOT_URLCONF is tests.urls, which includes django_waf.urls under "waf/", so
 the API lives at /waf/api/.
+
+Every request here goes through the real MIDDLEWARE stack, including
+WafMiddleware, because these tests use APIClient rather than a direct view
+call. DJANGO_WAF_ENABLED is turned off for the module (see the
+_disable_waf_middleware fixture below) so requests skip WAF evaluation
+entirely: these tests assert DRF permission/CRUD behaviour, not WAF
+middleware behaviour (that's test_middleware.py's job), and letting requests
+through the real evaluator means every non-staff-bypassed request tries a
+Redis-only cache write (redis_client.setex) against the LocMemCache backend
+configured in tests/settings.py, which doesn't support it. WafMiddleware
+fails open on that error so it doesn't affect these assertions, but it is a
+real exception logged on every request; skipping WAF evaluation here avoids
+the noise without weakening what these tests check.
 """
 
 from __future__ import annotations
@@ -32,6 +47,31 @@ from django_waf.testing.factories import (
 User = get_user_model()
 
 pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture(autouse=True)
+def _disable_waf_middleware(settings):
+    """Skip WafMiddleware evaluation for every request in this module.
+
+    These tests exercise the DRF API layer (permissions, serializers,
+    viewsets), not WAF request evaluation, so there's no need to route
+    through the real evaluator (and its Redis-only cache writes) at all.
+
+    django_waf.conf.DJANGO_WAF_ENABLED is a module-level constant read once
+    at conf.py's first import, so flipping settings.DJANGO_WAF_ENABLED alone
+    doesn't reach WafMiddleware (which reads conf.DJANGO_WAF_ENABLED, not
+    django.conf.settings directly). Reload conf to pick up the override, and
+    reload again on teardown to restore it for other test modules — same
+    pattern used throughout test_middleware.py.
+    """
+    import importlib
+
+    import django_waf.conf as conf_mod
+
+    settings.DJANGO_WAF_ENABLED = False
+    importlib.reload(conf_mod)
+    yield
+    importlib.reload(conf_mod)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Phase 6 of the waf-releases **Consumer DX** block (v1.3.0). Commercial prerequisite: the hosted console (waf-commercial.md Phase 3) consumes this API.

## What

- **`DJANGO_WAF_API_ENABLED`** (default `False`) gates the API.
- **`src/django_waf/api/`**: serializers (BlockRule/AllowRule writable; RequestLog/IPReputation read-only), `IsWafAdmin` permission, four viewsets — `block-rules`/`allow-rules` (CRUD, IsWafAdmin), `request-logs`/`ip-reputation` (read-only, IsAdminUser, with `?verdict`/`?ip_address`/`?from_ts` and `?min_threat_score` filters) — and a router. Each viewset returns **503** when the API is disabled.
- **`urls.py`** mounts `waf/api/` only when enabled **and** DRF importable.

## DRF stays optional

New `[api]` extra (`djangorestframework>=3.14`), also added to `dev` so the suite exercises it. **Verified in a DRF-absent venv**: importing `django_waf.urls` with the API disabled pulls in zero `rest_framework` (asserted `sys.modules` clean); the urlconf resolves to the original 8 patterns, 9 when enabled.

## Tests

Full suite **782 passed** (12 new API tests), `ruff check` + `ruff format --check` clean. Not a release.