### PR TITLE
feat(dashboard): time-range selector + rule-effectiveness panel (Phase 7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Dashboard time-range selector: `DashboardStatsPanel` and
+  `DashboardTopBlockedPanel` accept `?range=today|7d|30d` (default
+  `today`). The stats panel aggregates `RequestLog` verdict counts directly
+  from the database for `7d`/`30d` (the Redis snapshot only covers "today");
+  the top-blocked panel filters `IPReputation` by `last_seen_at`. The
+  selector lives inside `stats_panel.html` so its active state survives each
+  HTMX swap; the dashboard shell's 30 s auto-refresh always requests the
+  default `today` range.
+- Rule-effectiveness dashboard panel (`/waf/dashboard/rule-effectiveness/`,
+  `DashboardRuleEffectivenessPanel`): lists the top 10 active `BlockRule`
+  records by `hit_count` and flags active rules with `hit_count=0` as
+  removal candidates.
 - System check `django_waf.W005`: warns when `DJANGO_WAF_FEED_ENABLED` is
   true but `DJANGO_WAF_FEED_URL` is not `https://`. Feed responses become
   `BlockRule` records, so a plaintext feed is a rule-injection vector. The

--- a/README.md
+++ b/README.md
@@ -420,8 +420,11 @@ name) if you need different cadences.
 The staff dashboard is available at `/waf/dashboard/` for authenticated staff
 users. It provides:
 
-- Real-time traffic counters (allowed, blocked, challenged, throttled)
-- Top 10 blocked IPs
+- Real-time traffic counters (allowed, blocked, challenged, throttled), with a
+  Today / 7d / 30d time-range selector
+- Top 10 blocked IPs, filterable by the same time-range selector
+- Rule effectiveness: the top 10 active block rules by hit count, plus a list
+  of active rules with zero hits (removal candidates)
 - Auto-detected anomalies awaiting review
 
 Superusers can **confirm** auto-generated rules (promoting them to permanent) or

--- a/src/django_waf/templates/django_waf/dashboard.html
+++ b/src/django_waf/templates/django_waf/dashboard.html
@@ -175,6 +175,33 @@
         }
 
         .htmx-request .btn { opacity: 0.5; pointer-events: none; }
+
+        .range-selector {
+            display: flex;
+            gap: 0.4rem;
+            margin-bottom: 1rem;
+        }
+
+        .range-btn {
+            padding: 0.25rem 0.65rem;
+            border: 1px solid #e5e7eb;
+            border-radius: 4px;
+            background: #fff;
+            color: #6b7280;
+            cursor: pointer;
+            font-size: 0.75rem;
+            font-weight: 600;
+            line-height: 1.4;
+            transition: opacity 0.15s;
+        }
+
+        .range-btn:hover { opacity: 0.82; }
+
+        .range-btn.active {
+            background: #1d4ed8;
+            border-color: #1d4ed8;
+            color: #fff;
+        }
     </style>
 </head>
 <body>
@@ -215,6 +242,17 @@
             <h2>{% trans "Anomaly Alerts" %}</h2>
             <div id="waf-anomalies-panel"
                  hx-get="{{ anomalies_url }}"
+                 hx-trigger="load"
+                 hx-swap="innerHTML">
+                <div class="loading">{% trans "Loading…" %}</div>
+            </div>
+        </div>
+
+        {# Rule effectiveness — full width #}
+        <div class="panel panel-full">
+            <h2>{% trans "Rule Effectiveness" %}</h2>
+            <div id="waf-rule-effectiveness-panel"
+                 hx-get="{{ rule_effectiveness_url }}"
                  hx-trigger="load"
                  hx-swap="innerHTML">
                 <div class="loading">{% trans "Loading…" %}</div>

--- a/src/django_waf/templates/django_waf/partials/rule_effectiveness_panel.html
+++ b/src/django_waf/templates/django_waf/partials/rule_effectiveness_panel.html
@@ -1,0 +1,73 @@
+{% load i18n %}
+{% if top_rules %}
+<table>
+    <thead>
+        <tr>
+            <th>{% trans "Name" %}</th>
+            <th>{% trans "Type" %}</th>
+            <th>{% trans "Action" %}</th>
+            <th>{% trans "Hits" %}</th>
+            <th>{% trans "Last hit" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for rule in top_rules %}
+        <tr>
+            <td title="{{ rule.pattern }}">{{ rule.name }}</td>
+            <td>{{ rule.get_rule_type_display }}</td>
+            <td>
+                {% if rule.action == "block" %}
+                    <span class="badge badge-block">{% trans "Block" %}</span>
+                {% elif rule.action == "challenge" %}
+                    <span class="badge badge-challenge">{% trans "Challenge" %}</span>
+                {% elif rule.action == "throttle" %}
+                    <span class="badge badge-throttle">{% trans "Throttle" %}</span>
+                {% else %}
+                    <span class="badge badge-log">{{ rule.get_action_display }}</span>
+                {% endif %}
+            </td>
+            <td>{{ rule.hit_count }}</td>
+            <td>
+                {% if rule.last_hit_at %}
+                    {{ rule.last_hit_at|date:"d M Y H:i" }}
+                {% else %}
+                    &mdash;
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p style="color:#9ca3af;font-size:0.875rem;text-align:center;padding:1rem 0;">
+    {% trans "No active rules with recorded hits yet." %}
+</p>
+{% endif %}
+
+<h3 style="font-size:0.8rem;font-weight:600;margin:1.25rem 0 0.6rem;color:#374151;">
+    {% trans "Unused active rules (removal candidates)" %}
+</h3>
+{% if unused_rules %}
+<table>
+    <thead>
+        <tr>
+            <th>{% trans "Name" %}</th>
+            <th>{% trans "Type" %}</th>
+            <th>{% trans "Pattern" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for rule in unused_rules %}
+        <tr>
+            <td>{{ rule.name }}</td>
+            <td>{{ rule.get_rule_type_display }}</td>
+            <td><code title="{{ rule.pattern }}">{{ rule.pattern|truncatechars:40 }}</code></td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
+<p style="color:#9ca3af;font-size:0.875rem;text-align:center;padding:1rem 0;">
+    {% trans "No unused active rules." %}
+</p>
+{% endif %}

--- a/src/django_waf/templates/django_waf/partials/stats_panel.html
+++ b/src/django_waf/templates/django_waf/partials/stats_panel.html
@@ -1,4 +1,27 @@
 {% load i18n %}
+<div class="range-selector" role="group" aria-label="{% trans "Time range" %}">
+    <button type="button"
+            class="range-btn{% if range_param == "today" %} active{% endif %}"
+            hx-get="{{ stats_url }}?range=today"
+            hx-target="#waf-stats-panel"
+            hx-swap="innerHTML">
+        {% trans "Today" %}
+    </button>
+    <button type="button"
+            class="range-btn{% if range_param == "7d" %} active{% endif %}"
+            hx-get="{{ stats_url }}?range=7d"
+            hx-target="#waf-stats-panel"
+            hx-swap="innerHTML">
+        {% trans "7d" %}
+    </button>
+    <button type="button"
+            class="range-btn{% if range_param == "30d" %} active{% endif %}"
+            hx-get="{{ stats_url }}?range=30d"
+            hx-target="#waf-stats-panel"
+            hx-swap="innerHTML">
+        {% trans "30d" %}
+    </button>
+</div>
 <div class="stat-grid">
     <div class="stat">
         <div class="stat-value">{{ total|default:"0" }}</div>

--- a/src/django_waf/urls.py
+++ b/src/django_waf/urls.py
@@ -27,6 +27,11 @@ urlpatterns = [
     path("dashboard/stats/", views.dashboard_stats_panel, name="dashboard-stats"),
     path("dashboard/top-blocked/", views.dashboard_top_blocked_panel, name="dashboard-top-blocked"),
     path("dashboard/anomalies/", views.dashboard_anomalies_panel, name="dashboard-anomalies"),
+    path(
+        "dashboard/rule-effectiveness/",
+        views.dashboard_rule_effectiveness_panel,
+        name="dashboard-rule-effectiveness",
+    ),
     # Superuser-only anomaly actions
     path(
         "dashboard/anomalies/<uuid:rule_id>/confirm/",

--- a/src/django_waf/views.py
+++ b/src/django_waf/views.py
@@ -10,6 +10,7 @@ Staff dashboard (staff/superuser only):
     GET  /waf/dashboard/stats/             — DashboardStatsPanel
     GET  /waf/dashboard/top-blocked/       — DashboardTopBlockedPanel
     GET  /waf/dashboard/anomalies/         — DashboardAnomalyPanel
+    GET  /waf/dashboard/rule-effectiveness/ — DashboardRuleEffectivenessPanel
     POST /waf/dashboard/anomalies/<id>/confirm/  — DashboardAnomalyConfirmView
     POST /waf/dashboard/anomalies/<id>/reject/   — DashboardAnomalyRejectView
 """
@@ -118,6 +119,32 @@ def _is_staff(request: HttpRequest) -> bool:
 
 def _is_superuser(request: HttpRequest) -> bool:
     return request.user.is_authenticated and request.user.is_superuser  # type: ignore[union-attr]
+
+
+# Time-range options for the dashboard's stats and top-blocked panels.
+_DASHBOARD_RANGES = {"today", "7d", "30d"}
+
+
+def _clean_range_param(request: HttpRequest) -> str:
+    """Return a validated ?range= value, defaulting to 'today' on anything unrecognised."""
+    range_param = request.GET.get("range", "today")
+    if range_param not in _DASHBOARD_RANGES:
+        return "today"
+    return range_param
+
+
+def _range_since(range_param: str):
+    """Return the datetime a given range param starts from."""
+    from datetime import timedelta
+
+    from django.utils import timezone
+
+    now = timezone.now()
+    if range_param == "7d":
+        return now - timedelta(days=7)
+    if range_param == "30d":
+        return now - timedelta(days=30)
+    return now.replace(hour=0, minute=0, second=0, microsecond=0)
 
 
 # ---------------------------------------------------------------------------
@@ -309,6 +336,7 @@ class DashboardView(StaffRequiredMixin, TemplateView):
         ctx["stats_url"] = reverse("django_waf:dashboard-stats")
         ctx["top_blocked_url"] = reverse("django_waf:dashboard-top-blocked")
         ctx["anomalies_url"] = reverse("django_waf:dashboard-anomalies")
+        ctx["rule_effectiveness_url"] = reverse("django_waf:dashboard-rule-effectiveness")
         return ctx
 
 
@@ -317,10 +345,12 @@ dashboard_view = DashboardView.as_view()
 
 class DashboardStatsPanel(StaffRequiredMixin, TemplateView):
     """
-    GET /waf/dashboard/stats/
+    GET /waf/dashboard/stats/?range=today|7d|30d
 
-    HTMX fragment: real-time counters from Redis or RequestLog fallback.
-    Auto-refreshed every 30 s by the dashboard shell.
+    HTMX fragment: real-time counters from Redis (range="today" only) or a
+    RequestLog DB aggregate. Auto-refreshed every 30 s by the dashboard shell
+    (always at the default "today" range — see the range selector inside
+    stats_panel.html for the user-driven 7d/30d views).
     Access: Staff only.
     """
 
@@ -328,11 +358,22 @@ class DashboardStatsPanel(StaffRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs) -> dict:
         ctx = super().get_context_data(**kwargs)
-        ctx.update(self._fetch_stats())
+        range_param = _clean_range_param(self.request)
+        ctx["range_param"] = range_param
+        ctx["stats_url"] = reverse("django_waf:dashboard-stats")
+        ctx.update(self._fetch_stats(range_param))
         return ctx
 
-    def _fetch_stats(self) -> dict:
-        """Return today's counter dict, preferring Redis over DB aggregate."""
+    def _fetch_stats(self, range_param: str) -> dict:
+        """Return the counter dict for the given range.
+
+        "today" prefers the Redis live snapshot, falling back to a DB
+        aggregate from midnight. "7d"/"30d" have no Redis snapshot, so they
+        go straight to the DB aggregate over the wider window.
+        """
+        if range_param != "today":
+            return self._db_stats(_range_since(range_param))
+
         try:
             redis_client = _get_redis_client()
             raw: dict = {}
@@ -356,7 +397,7 @@ class DashboardStatsPanel(StaffRequiredMixin, TemplateView):
 
         except Exception:
             logger.warning("django-waf: could not fetch stats from Redis; falling back to DB")
-            raw = self._db_stats_today()
+            return self._db_stats(_range_since("today"))
 
         return {
             "total": int(raw.get("total", 0)),
@@ -368,15 +409,14 @@ class DashboardStatsPanel(StaffRequiredMixin, TemplateView):
         }
 
     @staticmethod
-    def _db_stats_today() -> dict:
+    def _db_stats(since) -> dict:
+        """Aggregate RequestLog verdict counts for timestamp >= since."""
         from django.db.models import Count
-        from django.utils import timezone
 
         from django_waf.enums import Verdict
         from django_waf.models import RequestLog
 
-        today = timezone.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        rows = RequestLog.objects.filter(timestamp__gte=today).values("verdict").annotate(n=Count("id"))
+        rows = RequestLog.objects.filter(timestamp__gte=since).values("verdict").annotate(n=Count("id"))
         mapping = {row["verdict"]: row["n"] for row in rows}
         total = sum(mapping.values())
         return {
@@ -388,15 +428,27 @@ class DashboardStatsPanel(StaffRequiredMixin, TemplateView):
             "passed": mapping.get(Verdict.PASSED, 0),
         }
 
+    @classmethod
+    def _db_stats_today(cls) -> dict:
+        """Retained for backwards compatibility with any external callers."""
+        return cls._db_stats(_range_since("today"))
+
 
 dashboard_stats_panel = DashboardStatsPanel.as_view()
 
 
 class DashboardTopBlockedPanel(StaffRequiredMixin, TemplateView):
     """
-    GET /waf/dashboard/top-blocked/
+    GET /waf/dashboard/top-blocked/?range=today|7d|30d
 
     HTMX fragment: top 10 IPs by blocked_requests from IPReputation.
+
+    IPReputation is a rolling, per-IP aggregate maintained by the scoring
+    service (one row per IP, continuously updated) rather than a per-request
+    log — there is no "requests in the last 7 days" figure to sum. The range
+    filter is applied to ``last_seen_at`` instead: it narrows the IP list to
+    addresses seen within the window, which is the closest honest reading of
+    "top blocked IPs in this range" the model supports.
     Access: Staff only.
     """
 
@@ -404,10 +456,13 @@ class DashboardTopBlockedPanel(StaffRequiredMixin, TemplateView):
 
     def get_context_data(self, **kwargs) -> dict:
         ctx = super().get_context_data(**kwargs)
+        range_param = _clean_range_param(self.request)
+        ctx["range_param"] = range_param
         try:
             from django_waf.models import IPReputation
 
-            ctx["ips"] = IPReputation.objects.order_by("-blocked_requests")[:10]
+            since = _range_since(range_param)
+            ctx["ips"] = IPReputation.objects.filter(last_seen_at__gte=since).order_by("-blocked_requests")[:10]
         except Exception:
             logger.warning("django-waf: could not fetch top-blocked IPs; degrading to empty panel")
             ctx["ips"] = []
@@ -415,6 +470,35 @@ class DashboardTopBlockedPanel(StaffRequiredMixin, TemplateView):
 
 
 dashboard_top_blocked_panel = DashboardTopBlockedPanel.as_view()
+
+
+class DashboardRuleEffectivenessPanel(StaffRequiredMixin, TemplateView):
+    """
+    GET /waf/dashboard/rule-effectiveness/
+
+    HTMX fragment: which active BlockRules are pulling weight and which
+    are dead. Surfaces the top 10 active rules by hit_count, and lists
+    active rules with hit_count=0 as removal candidates.
+    Access: Staff only.
+    """
+
+    template_name = "django_waf/partials/rule_effectiveness_panel.html"
+
+    def get_context_data(self, **kwargs) -> dict:
+        ctx = super().get_context_data(**kwargs)
+        try:
+            from django_waf.models import BlockRule
+
+            ctx["top_rules"] = BlockRule.objects.filter(is_active=True, hit_count__gt=0).order_by("-hit_count")[:10]
+            ctx["unused_rules"] = BlockRule.objects.filter(is_active=True, hit_count=0)[:20]
+        except Exception:
+            logger.warning("django-waf: could not fetch rule effectiveness data; degrading to empty panel")
+            ctx["top_rules"] = []
+            ctx["unused_rules"] = []
+        return ctx
+
+
+dashboard_rule_effectiveness_panel = DashboardRuleEffectivenessPanel.as_view()
 
 
 class DashboardAnomalyPanel(StaffRequiredMixin, TemplateView):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -564,6 +564,46 @@ class TestDashboardStatsPanelView:
         assert response.status_code == 200
         assert "django_waf/partials/stats_panel.html" in [t.name for t in response.templates]
 
+    def test_range_7d_returns_200_and_aggregates_wider_window(self):
+        """?range=7d skips the Redis snapshot and aggregates RequestLog over 7 days,
+        picking up rows older than "today" that the default range would miss."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from django_waf.enums import Verdict
+        from django_waf.testing.factories import RequestLogFactory
+
+        client = Client()
+        user = _make_staff_user(username="staffrange7d", email="staffrange7d@example.com")
+        client.force_login(user)
+
+        # One request today, one three days ago — only the 7d range should see both.
+        RequestLogFactory(verdict=Verdict.BLOCKED, timestamp=timezone.now())
+        RequestLogFactory(verdict=Verdict.BLOCKED, timestamp=timezone.now() - timedelta(days=3))
+
+        response_today = client.get(
+            "/waf/dashboard/stats/",
+            {"range": "today"},
+        )
+        response_7d = client.get("/waf/dashboard/stats/", {"range": "7d"})
+
+        assert response_today.status_code == 200
+        assert response_7d.status_code == 200
+        assert response_7d.context["range_param"] == "7d"
+        assert response_7d.context["blocked"] >= response_today.context["blocked"]
+        assert response_7d.context["blocked"] == 2
+
+    def test_invalid_range_falls_back_to_today(self):
+        client = Client()
+        user = _make_staff_user(username="staffrangebogus", email="staffrangebogus@example.com")
+        client.force_login(user)
+
+        response = client.get("/waf/dashboard/stats/", {"range": "bogus"})
+
+        assert response.status_code == 200
+        assert response.context["range_param"] == "today"
+
 
 class TestDashboardTopBlockedPanelView:
     """GET /dashboard/top-blocked/ returns the top-blocked IP partial."""
@@ -611,13 +651,85 @@ class TestDashboardTopBlockedPanelView:
         client.force_login(user)
 
         with patch(
-            "django_waf.models.IPReputation.objects.order_by",
+            "django_waf.models.IPReputation.objects.filter",
             side_effect=Exception("db unavailable"),
         ):
             response = client.get("/waf/dashboard/top-blocked/")
 
         assert response.status_code == 200
         assert response.context["ips"] == []
+
+
+class TestDashboardRuleEffectivenessPanelView:
+    """GET /dashboard/rule-effectiveness/ lists top and unused active BlockRules."""
+
+    def test_anonymous_redirects(self):
+        client = Client()
+
+        response = client.get("/waf/dashboard/rule-effectiveness/")
+
+        assert response.status_code == 302
+
+    def test_non_staff_authenticated_user_gets_403(self):
+        client = Client()
+        user = User.objects.create_user(
+            username="ruleeffnonstaff",
+            email="ruleeffnonstaff@example.com",
+            password="password",
+            is_staff=False,
+        )
+        client.force_login(user)
+
+        response = client.get("/waf/dashboard/rule-effectiveness/")
+
+        assert response.status_code == 403
+
+    def test_staff_gets_200(self):
+        client = Client()
+        user = _make_staff_user(username="staffruleeff", email="staffruleeff@example.com")
+        client.force_login(user)
+
+        response = client.get("/waf/dashboard/rule-effectiveness/")
+
+        assert response.status_code == 200
+        assert "django_waf/partials/rule_effectiveness_panel.html" in [t.name for t in response.templates]
+
+    def test_lists_high_hit_rule_and_flags_zero_hit_rule(self):
+        from django_waf.testing.factories import BlockRuleFactory
+
+        high_hit_rule = BlockRuleFactory(name="frequent-offender", hit_count=42, is_active=True)
+        unused_rule = BlockRuleFactory(name="never-fired", hit_count=0, is_active=True)
+
+        client = Client()
+        user = _make_staff_user(username="staffruleeffdata", email="staffruleeffdata@example.com")
+        client.force_login(user)
+
+        response = client.get("/waf/dashboard/rule-effectiveness/")
+
+        assert response.status_code == 200
+        top_rule_ids = [r.id for r in response.context["top_rules"]]
+        unused_rule_ids = [r.id for r in response.context["unused_rules"]]
+        assert high_hit_rule.id in top_rule_ids
+        assert unused_rule.id in unused_rule_ids
+        assert high_hit_rule.id not in unused_rule_ids
+        assert unused_rule.id not in top_rule_ids
+
+    def test_db_error_degrades_to_empty_context(self):
+        """A DB error while fetching rule effectiveness data degrades to an empty
+        panel instead of raising (matches the other panels' fallback pattern)."""
+        client = Client()
+        user = _make_staff_user(username="staffruleefferr", email="staffruleefferr@example.com")
+        client.force_login(user)
+
+        with patch(
+            "django_waf.models.BlockRule.objects.filter",
+            side_effect=Exception("db unavailable"),
+        ):
+            response = client.get("/waf/dashboard/rule-effectiveness/")
+
+        assert response.status_code == 200
+        assert response.context["top_rules"] == []
+        assert response.context["unused_rules"] == []
 
 
 class TestDashboardAnomalyPanelView:


### PR DESCRIPTION
Phase 7 of the waf-releases **Consumer DX** block (v1.3.0). UI only, no model changes. This is the **last phase** before v1.3.0 can be tagged.

## What

- **7.1 Time-range selector**: `DashboardStatsPanel` and `DashboardTopBlockedPanel` accept `?range=today|7d|30d` (default today; invalid values fall back). Stats refactored `_db_stats_today` → `_db_stats(since)`; today keeps the Redis-preferred path, 7d/30d aggregate from the DB. Top-blocked ranges on `IPReputation.last_seen_at`. Three-button HTMX selector rendered inside the stats fragment.
- **7.2 Rule-effectiveness panel**: `DashboardRuleEffectivenessPanel` at `dashboard/rule-effectiveness/` — top 10 active BlockRules by `hit_count` plus zero-hit active rules (removal candidates); new partial slotted into the dashboard shell.

## Notes

- The stats panel's 30s auto-refresh still shows *today*; the range selection is a manual HTMX action. Documented, not a stateful refresh (deliberately not over-engineered).

## Tests

Full suite **777 passed** (6 new), `ruff check` + `ruff format --check` clean. Not a release.