### PR TITLE
fix(challenge): synchronous PoW hasher, sane difficulty defaults, runaway guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing `source=admin` rules first), plus `--dry-run`. Imported rules are
   always tagged `source=admin`, never re-tagged as feed/auto.
 
+### Fixed
+
+- Challenge/pow_gate solvers now use a synchronous SHA-256 batch loop
+  instead of awaiting `crypto.subtle.digest` once per nonce, raising client
+  hash throughput by orders of magnitude so challenges resolve in the
+  expected time.
+- `DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP` / `_MOBILE` now default to
+  `None`, so setting the single `DJANGO_WAF_CHALLENGE_DIFFICULTY` value
+  takes effect as documented instead of being silently overridden by the
+  per-band defaults. Single-value default lowered from `20` to `16`.
+- Both solvers now bound their attempt count at 64x the expected mean and
+  fail visibly rather than grinding indefinitely if difficulty is
+  misconfigured.
+
 ## [1.2.0] - 2026-07-11
 
 Minor because the feed URL defaults change consumer-visible behaviour: a

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ All settings are namespaced under `DJANGO_WAF_*` and have sensible defaults.
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `DJANGO_WAF_CHALLENGE_DIFFICULTY` | `20` | Fallback proof-of-work leading zero **bits** when the desktop/mobile overrides are not set. Average work is `2 ** bits` SHA-256 hashes |
-| `DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP` | `22` | PoW difficulty (bits) for non-mobile User-Agents. ~4M hashes, ~1 to 2s on a laptop |
-| `DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE` | `18` | PoW difficulty (bits) for mobile User-Agents. ~260k hashes, ~1 to 3s on a budget phone |
+| `DJANGO_WAF_CHALLENGE_DIFFICULTY` | `16` | Proof-of-work leading zero **bits**. Authoritative unless a desktop/mobile override below is explicitly set. Average work is `2 ** bits` SHA-256 hashes |
+| `DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP` | `None` | PoW difficulty (bits) for non-mobile User-Agents. `None` falls back to `DJANGO_WAF_CHALLENGE_DIFFICULTY`; set explicitly to give desktop clients a different cost |
+| `DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE` | `None` | PoW difficulty (bits) for mobile User-Agents. `None` falls back to `DJANGO_WAF_CHALLENGE_DIFFICULTY`; set explicitly to give budget devices a lower cost |
 | `DJANGO_WAF_CHALLENGE_URL` | `""` | Optional literal path to the challenge view. Set this in projects using per-request urlconf routing (django-hosts and similar) where `reverse("django_waf:challenge")` cannot resolve. Empty = use `reverse()` |
 | `DJANGO_WAF_VERIFY_URL` | `""` | Optional literal path to the verify view. Empty = use `reverse()` |
 | `DJANGO_WAF_CHALLENGE_COOKIE_TTL` | `86400` | Seconds a solved-challenge cookie remains valid |

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -133,19 +133,19 @@ DJANGO_WAF_FORM_DEFENCE_WEIGHTS: dict[str, float] = getattr(
 
 # Proof-of-work challenge difficulty — number of leading zero **bits** the
 # SHA-256(token + nonce) digest must contain. Average solve cost is
-# ``2 ** difficulty`` hashes. Acts as the single-value fallback when the
-# desktop/mobile overrides below are unset.
-DJANGO_WAF_CHALLENGE_DIFFICULTY: int = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY", 20)
+# ``2 ** difficulty`` hashes. This single value is the default and is
+# authoritative unless an operator explicitly overrides a device band below.
+DJANGO_WAF_CHALLENGE_DIFFICULTY: int = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY", 16)
 
-# Desktop-class clients (default 22 bits ≈ 4M hashes, ~1–2s on a laptop).
-# Slightly stronger than mobile because desktops have more CPU headroom.
-# Set to ``None`` to fall back to ``DJANGO_WAF_CHALLENGE_DIFFICULTY``.
-DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP: int | None = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22)
+# Desktop-class clients. Defaults to ``None``, which falls back to
+# ``DJANGO_WAF_CHALLENGE_DIFFICULTY``. Set an explicit value only to give
+# desktop clients a different (typically higher) cost than mobile.
+DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP: int | None = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP", None)
 
-# Mobile-class clients (default 18 bits ≈ 260k hashes, ~1–3s on a phone).
-# Set lower than desktop so budget devices don't time out.
-# Set to ``None`` to fall back to ``DJANGO_WAF_CHALLENGE_DIFFICULTY``.
-DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE: int | None = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18)
+# Mobile-class clients. Defaults to ``None``, which falls back to
+# ``DJANGO_WAF_CHALLENGE_DIFFICULTY``. Set an explicit value only to give
+# budget devices a lower cost than desktop.
+DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE: int | None = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE", None)
 
 # Optional literal-path overrides for the WAF's own challenge/verify URLs.
 # When set, the middleware uses these strings directly instead of calling

--- a/src/django_waf/forms/defences/pow_gate.py
+++ b/src/django_waf/forms/defences/pow_gate.py
@@ -39,23 +39,77 @@ _TOKEN_BIND_FIELD = "waf_pow_token"  # hidden mirror so we can verify without pa
 _HIDDEN_STYLE = "position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"
 
 
+# Compact, self-contained synchronous SHA-256 (standard 32-bit big-endian
+# implementation). Shared across every rendered form's solver script.
+# Byte-identical to Python's hashlib.sha256 — verified against
+# _digest_has_leading_zero_bits, the same server-side check _verify_nonce()
+# uses. No crypto.subtle dependency, so the batch loop below runs entirely
+# on the CPU instead of paying one promise resolution per nonce.
+_SHA256_JS = (
+    "function sha256(msg){"
+    "var b=new TextEncoder().encode(msg);"
+    "var K=[0x428a2f98,0x71374491,0xb5c0fbcf,0xe9b5dba5,0x3956c25b,0x59f111f1,0x923f82a4,0xab1c5ed5,"
+    "0xd807aa98,0x12835b01,0x243185be,0x550c7dc3,0x72be5d74,0x80deb1fe,0x9bdc06a7,0xc19bf174,"
+    "0xe49b69c1,0xefbe4786,0x0fc19dc6,0x240ca1cc,0x2de92c6f,0x4a7484aa,0x5cb0a9dc,0x76f988da,"
+    "0x983e5152,0xa831c66d,0xb00327c8,0xbf597fc7,0xc6e00bf3,0xd5a79147,0x06ca6351,0x14292967,"
+    "0x27b70a85,0x2e1b2138,0x4d2c6dfc,0x53380d13,0x650a7354,0x766a0abb,0x81c2c92e,0x92722c85,"
+    "0xa2bfe8a1,0xa81a664b,0xc24b8b70,0xc76c51a3,0xd192e819,0xd6990624,0xf40e3585,0x106aa070,"
+    "0x19a4c116,0x1e376c08,0x2748774c,0x34b0bcb5,0x391c0cb3,0x4ed8aa4a,0x5b9cca4f,0x682e6ff3,"
+    "0x748f82ee,0x78a5636f,0x84c87814,0x8cc70208,0x90befffa,0xa4506ceb,0xbef9a3f7,0xc67178f2];"
+    "var H=[0x6a09e667,0xbb67ae85,0x3c6ef372,0xa54ff53a,0x510e527f,0x9b05688c,0x1f83d9ab,0x5be0cd19];"
+    "var bl=b.length*8,w1=b.length+1,pl=((w1+8+63)&~63)-w1-8,tot=w1+pl+8;"
+    "var buf=new Uint8Array(tot);buf.set(b,0);buf[b.length]=0x80;"
+    "var hi=Math.floor(bl/0x100000000),lo=bl>>>0;"
+    "var dv=new DataView(buf.buffer);dv.setUint32(tot-8,hi,false);dv.setUint32(tot-4,lo,false);"
+    "var w=new Int32Array(64);"
+    "for(var o=0;o<tot;o+=64){"
+    "  for(var i=0;i<16;i++){ w[i]=dv.getInt32(o+i*4,false); }"
+    "  for(i=16;i<64;i++){"
+    "    var s0v=w[i-15],s0=((s0v>>>7)|(s0v<<25))^((s0v>>>18)|(s0v<<14))^(s0v>>>3);"
+    "    var s1v=w[i-2],s1=((s1v>>>17)|(s1v<<15))^((s1v>>>19)|(s1v<<13))^(s1v>>>10);"
+    "    w[i]=(w[i-16]+s0+w[i-7]+s1)|0;"
+    "  }"
+    "  var a=H[0],b2=H[1],c=H[2],d=H[3],e=H[4],f=H[5],g=H[6],h=H[7];"
+    "  for(i=0;i<64;i++){"
+    "    var S1=((e>>>6)|(e<<26))^((e>>>11)|(e<<21))^((e>>>25)|(e<<7));"
+    "    var ch=(e&f)^(~e&g);"
+    "    var t1=(h+S1+ch+K[i]+w[i])|0;"
+    "    var S0=((a>>>2)|(a<<30))^((a>>>13)|(a<<19))^((a>>>22)|(a<<10));"
+    "    var maj=(a&b2)^(a&c)^(b2&c);"
+    "    var t2=(S0+maj)|0;"
+    "    h=g;g=f;f=e;e=(d+t1)|0;d=c;c=b2;b2=a;a=(t1+t2)|0;"
+    "  }"
+    "  H[0]=(H[0]+a)|0;H[1]=(H[1]+b2)|0;H[2]=(H[2]+c)|0;H[3]=(H[3]+d)|0;"
+    "  H[4]=(H[4]+e)|0;H[5]=(H[5]+f)|0;H[6]=(H[6]+g)|0;H[7]=(H[7]+h)|0;"
+    "}"
+    "var out=new Uint8Array(32),ov=new DataView(out.buffer);"
+    "for(i=0;i<8;i++){ ov.setInt32(i*4,H[i],false); }"
+    "return out;"
+    "}"
+)
+
+
 def _solver_script(token_nonce: str, difficulty: int) -> str:
     """Render the inline JS that solves the PoW and writes the nonce.
 
     The script:
 
-    1. Hashes ``token_nonce + counter`` until the digest has
+    1. Hashes ``token_nonce + ":" + counter`` until the digest has
        ``difficulty`` leading zero bits.
     2. Writes the winning ``counter`` value into the hidden
        ``waf_pow_nonce`` field.
     3. Sets ``data-waf-pow-ready="true"`` on the surrounding form
        so operators can gate submit on it via attribute selectors.
 
-    Uses ``crypto.subtle.digest('SHA-256', ...)``, same API the
-    page-level challenge solver uses. Browsers without
-    ``crypto.subtle`` (very old) fall through with the field empty —
-    the defence will block on the missing nonce. Fine; those browsers
-    can't render modern sites anyway.
+    Uses a synchronous SHA-256 implementation (no ``crypto.subtle``),
+    so the batch loop below grinds hashes without paying one promise
+    resolution per nonce. Byte-identical to Python's ``hashlib.sha256``,
+    verified against ``_verify_nonce()``/``_digest_has_leading_zero_bits``.
+    Browsers without ``TextEncoder`` (very old) fall through with the
+    field empty — the defence will block on the missing nonce. Fine;
+    those browsers can't render modern sites anyway. On exceeding the
+    runaway guard the loop stops silently (no throw) with the nonce
+    field left empty, so the same missing-nonce fail-safe applies.
     """
     # The JS-side helper is the same bit-counting check as the
     # server. It's intentionally a single-purpose function — we don't
@@ -65,12 +119,11 @@ def _solver_script(token_nonce: str, difficulty: int) -> str:
     # function.
     return (
         '<script type="text/javascript">'
-        "(async function(){"
+        "(function(){"
         f"var token={token_nonce!r};"
         f"var difficulty={difficulty};"
-        "var enc=new TextEncoder();"
-        "function leadingZeroBits(buf,bits){"
-        "  var bytes=new Uint8Array(buf);"
+        + _SHA256_JS
+        + "function leadingZeroBits(bytes,bits){"
         "  var full=bits>>>3, rem=bits&7;"
         "  for(var i=0;i<full;i++){ if(bytes[i]!==0) return false; }"
         "  if(rem===0) return true;"
@@ -78,19 +131,28 @@ def _solver_script(token_nonce: str, difficulty: int) -> str:
         "  return (bytes[full]&mask)===0;"
         "}"
         "var n=0;"
-        "while(true){"
-        '  var msg=token+":"+n;'
-        '  var hash=await crypto.subtle.digest("SHA-256",enc.encode(msg));'
-        "  if(leadingZeroBits(hash,difficulty)){"
-        f"    var nonceEl=document.querySelector('input[name=\"{NONCE_FIELD}\"]');"
-        "    if(nonceEl) nonceEl.value=n.toString();"
-        "    var form=nonceEl ? nonceEl.form : null;"
-        '    if(form) form.setAttribute("data-waf-pow-ready","true");'
-        "    break;"
+        # Runaway guard: cap at 2**difficulty * 64 iterations. A genuine
+        # solve essentially never trips this; a mis-configured difficulty
+        # stops instead of grinding forever, leaving the nonce field empty
+        # so the server-side missing-nonce block applies.
+        f"var maxN=Math.pow(2,{difficulty})*64;"
+        "function step(){"
+        "  var batchEnd=n+2000;"
+        "  while(n<batchEnd){"
+        '    var hash=sha256(token+":"+n);'
+        "    if(leadingZeroBits(hash,difficulty)){"
+        f"      var nonceEl=document.querySelector('input[name=\"{NONCE_FIELD}\"]');"
+        "      if(nonceEl) nonceEl.value=n.toString();"
+        "      var form=nonceEl ? nonceEl.form : null;"
+        '      if(form) form.setAttribute("data-waf-pow-ready","true");'
+        "      return;"
+        "    }"
+        "    n++;"
+        "    if(n>maxN){ return; }"
         "  }"
-        "  n++;"
-        "  if(n%1000===0){ await new Promise(function(r){setTimeout(r,0);}); }"
+        "  setTimeout(step,0);"
         "}"
+        "step();"
         "})();"
         "</script>"
     )

--- a/src/django_waf/forms/defences/pow_gate.py
+++ b/src/django_waf/forms/defences/pow_gate.py
@@ -121,9 +121,7 @@ def _solver_script(token_nonce: str, difficulty: int) -> str:
         '<script type="text/javascript">'
         "(function(){"
         f"var token={token_nonce!r};"
-        f"var difficulty={difficulty};"
-        + _SHA256_JS
-        + "function leadingZeroBits(bytes,bits){"
+        f"var difficulty={difficulty};" + _SHA256_JS + "function leadingZeroBits(bytes,bits){"
         "  var full=bits>>>3, rem=bits&7;"
         "  for(var i=0;i<full;i++){ if(bytes[i]!==0) return false; }"
         "  if(rem===0) return true;"

--- a/src/django_waf/templates/django_waf/challenge.html
+++ b/src/django_waf/templates/django_waf/challenge.html
@@ -163,14 +163,88 @@
         // the progress bar (linear in attempts/expected) and the ETA, which
         // recomputes from observed hash rate every UI tick.
         var expectedAttempts = Math.pow(2, difficulty);
+        // Safety ceiling: 64x the expected mean. A genuine solve essentially
+        // never trips this (P(no solve after 64x mean) ~ e^-64); a
+        // mis-configured difficulty fails fast and visibly instead of
+        // grinding forever.
+        var maxAttempts = expectedAttempts * 64;
         var startTime = 0;
 
-        // --- SHA-256 via Web Crypto API ---
+        // --- Synchronous SHA-256 (standard 32-bit big-endian implementation) ---
+        // Runs entirely on the CPU with no await per call, so the solve loop
+        // below can grind millions of hashes/sec instead of being capped by
+        // one crypto.subtle.digest() promise resolution per nonce. Produces
+        // digests byte-identical to Python's hashlib.sha256 (verified against
+        // the server's _digest_has_leading_zero_bits check).
+        var SHA256_K = [
+            0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+            0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+            0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+            0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+            0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+            0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+            0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+            0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+        ];
+
         function sha256(message) {
-            var buf = new TextEncoder().encode(message);
-            return crypto.subtle.digest("SHA-256", buf).then(function (hash) {
-                return new Uint8Array(hash);
-            });
+            var bytes = new TextEncoder().encode(message);
+            var H = [
+                0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19
+            ];
+
+            var bitLen = bytes.length * 8;
+            var withOne = bytes.length + 1;
+            var padLen = ((withOne + 8 + 63) & ~63) - withOne - 8;
+            var total = withOne + padLen + 8;
+            var buf = new Uint8Array(total);
+            buf.set(bytes, 0);
+            buf[bytes.length] = 0x80;
+            var hi = Math.floor(bitLen / 0x100000000);
+            var lo = bitLen >>> 0;
+            var view = new DataView(buf.buffer);
+            view.setUint32(total - 8, hi, false);
+            view.setUint32(total - 4, lo, false);
+
+            var w = new Int32Array(64);
+            for (var offset = 0; offset < total; offset += 64) {
+                for (var i = 0; i < 16; i++) {
+                    w[i] = view.getInt32(offset + i * 4, false);
+                }
+                for (i = 16; i < 64; i++) {
+                    var s0v = w[i - 15];
+                    var s0 = ((s0v >>> 7) | (s0v << 25)) ^ ((s0v >>> 18) | (s0v << 14)) ^ (s0v >>> 3);
+                    var s1v = w[i - 2];
+                    var s1 = ((s1v >>> 17) | (s1v << 15)) ^ ((s1v >>> 19) | (s1v << 13)) ^ (s1v >>> 10);
+                    w[i] = (w[i - 16] + s0 + w[i - 7] + s1) | 0;
+                }
+
+                var a = H[0], b = H[1], c = H[2], d = H[3];
+                var e = H[4], f = H[5], g = H[6], h = H[7];
+
+                for (i = 0; i < 64; i++) {
+                    var S1 = ((e >>> 6) | (e << 26)) ^ ((e >>> 11) | (e << 21)) ^ ((e >>> 25) | (e << 7));
+                    var ch = (e & f) ^ (~e & g);
+                    var temp1 = (h + S1 + ch + SHA256_K[i] + w[i]) | 0;
+                    var S0 = ((a >>> 2) | (a << 30)) ^ ((a >>> 13) | (a << 19)) ^ ((a >>> 22) | (a << 10));
+                    var maj = (a & b) ^ (a & c) ^ (b & c);
+                    var temp2 = (S0 + maj) | 0;
+
+                    h = g; g = f; f = e; e = (d + temp1) | 0;
+                    d = c; c = b; b = a; a = (temp1 + temp2) | 0;
+                }
+
+                H[0] = (H[0] + a) | 0; H[1] = (H[1] + b) | 0; H[2] = (H[2] + c) | 0; H[3] = (H[3] + d) | 0;
+                H[4] = (H[4] + e) | 0; H[5] = (H[5] + f) | 0; H[6] = (H[6] + g) | 0; H[7] = (H[7] + h) | 0;
+            }
+
+            var out = new Uint8Array(32);
+            var outView = new DataView(out.buffer);
+            for (i = 0; i < 8; i++) {
+                outView.setInt32(i * 4, H[i], false);
+            }
+            return out;
         }
 
         // Return true iff the digest starts with `bits` zero bits.
@@ -220,7 +294,7 @@
         async function solve() {
             startTime = performance.now();
             while (true) {
-                var hash = await sha256(token + nonce.toString());
+                var hash = sha256(token + nonce.toString());
                 if (hasLeadingZeroBits(hash, difficulty)) {
                     statusEl.textContent = "Verified!";
                     statusEl.className = "success";
@@ -231,6 +305,10 @@
                     return;
                 }
                 nonce++;
+                if (nonce > maxAttempts) {
+                    showError("Verification is taking longer than expected. Please refresh the page.");
+                    return;
+                }
                 // Yield every 2 000 iterations to keep UI responsive and
                 // give the progress bar a chance to repaint.
                 if (nonce % 2000 === 0) {
@@ -290,8 +368,9 @@
             }
         }
 
-        // Check Web Crypto availability (required by all modern browsers).
-        if (typeof crypto === "undefined" || !crypto.subtle) {
+        // Check TextEncoder availability (required by all modern browsers).
+        // The synchronous SHA-256 above has no crypto.subtle dependency.
+        if (typeof TextEncoder === "undefined") {
             showError(
                 "Your browser does not support the security check. " +
                 "Please use a modern browser or enable JavaScript."

--- a/tests/forms/test_pow_gate_defence.py
+++ b/tests/forms/test_pow_gate_defence.py
@@ -58,7 +58,11 @@ class TestRenderFields:
 
         assert f'name="{NONCE_FIELD}"' in html
         assert "<script" in html
-        assert "crypto.subtle.digest" in html
+        # Synchronous SHA-256 batch loop, not crypto.subtle (v0.10.6+):
+        # awaiting crypto.subtle.digest() once per nonce capped throughput
+        # at tens of thousands of hashes/sec.
+        assert "crypto.subtle" not in html
+        assert "function sha256" in html
 
     def test_solver_script_includes_difficulty(self):
         """The JS solver uses the difficulty value — pin so a future


### PR DESCRIPTION
## Problem

The JS proof-of-work challenge ("Verifying your browser") ground on for millions of hashes in production. Three defects in 1.2.0:

1. **Mis-precedenced difficulty defaults (root cause).** `_pick_difficulty()` only falls back to the single `DJANGO_WAF_CHALLENGE_DIFFICULTY` when a device band is `None`, but the desktop/mobile bands shipped integer defaults (22/18). An operator who set only `DJANGO_WAF_CHALLENGE_DIFFICULTY=20` was silently overridden, and desktop clients got difficulty 22 (~4.2M expected hashes).
2. **Per-nonce `await crypto.subtle.digest`.** Both solvers (`challenge.html`, `forms/defences/pow_gate.py`) awaited Web Crypto once per nonce, capping client throughput at tens of thousands of hashes/sec so even a moderate difficulty felt stuck.
3. **No attempt ceiling.** A misconfigured difficulty could grind indefinitely with no visible failure.

## Fix

- Device-split difficulty defaults now `None`, so the single `DJANGO_WAF_CHALLENGE_DIFFICULTY` knob is authoritative unless a band is explicitly set. Single-value default lowered 20 -> 16.
- Both solvers replaced with a synchronous batched SHA-256, byte-identical to Python `hashlib` (verified in Node against both message layouts: `token+nonce` for the challenge, `token:n` for pow_gate). Yields to the UI every 2000 iterations.
- Runaway guard: both solvers bound attempts at 64x the expected mean and fail visibly (challenge shows an error; pow_gate leaves the nonce empty, which the server already blocks on).

## Verification

336 tests pass across the challenge/pow/services/checks/views modules. Byte-identity of the sync hasher confirmed against `hashlib.sha256` for empty string, `abc`, and block-boundary lengths (55/56/63/64/119/120 bytes), plus end-to-end solve+verify for both solvers.

CHANGELOG updated under `[Unreleased]`. Release bump follows in a separate release/1.3.0 PR.