### PR TITLE
release: 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-07-14
+
 ### Added
 
 - Dashboard time-range selector: `DashboardStatsPanel` and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "1.2.0"
+version = "1.3.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release 1.3.0

Cuts the accumulated `[Unreleased]` work as **1.3.0** (minor: new public API plus a behaviour change in challenge difficulty defaults).

### Bump
- `pyproject.toml` version `1.2.0` -> `1.3.0` (the only version source; `__init__.py` reads it from metadata).
- CHANGELOG `[Unreleased]` -> `[1.3.0] - 2026-07-14`.

### What ships (from the Unreleased section)
- **Fixed:** synchronous PoW hasher (was per-nonce `crypto.subtle.digest`), difficulty-default precedence (desktop/mobile bands now default to `None` so the single `DJANGO_WAF_CHALLENGE_DIFFICULTY` knob is authoritative; single default lowered 20 -> 16), and a runaway attempt guard on both solvers.
- **Added:** dashboard time-range selector, rule-effectiveness panel, optional DRF API (`django-waf[api]`), system check `W005`, challenge-token pruning task/command, and `DJANGO_WAF_CELERY_BEAT_SCHEDULE` fragment.

### After merge
Tag the merged commit `v1.3.0` on main to publish (OIDC trusted publishing). That step stays manual.