### PR TITLE
ci: pin ruff to 0.15.22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,6 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      - run: pip install "ruff==0.15.22"
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/


### PR DESCRIPTION
Pins ruff to 0.15.22 to match the umbrella CI template (icvoss/icv-oss-umbrella#31, icv-ads#16). Unpinned `pip install ruff` pulls the latest release, so a new ruff can silently change format/lint defaults and fail `ruff format --check` on previously-clean code, breaking unrelated PRs. One-line CI change.