### PR TITLE
fix: dedent the inert shebang on make_migrations.py

### DIFF
--- a/make_migrations.py
+++ b/make_migrations.py
@@ -1,4 +1,4 @@
-    #!/usr/bin/env python
+#!/usr/bin/env python
 """Generate migrations for the reusable django_waf app.
 
 This package ships no manage.py. ``tests/settings.py`` deliberately disables


### PR DESCRIPTION
The shebang was indented four spaces (`    #!/usr/bin/env python`), making it inert, a shebang only takes effect at column 0, so `./make_migrations.py` fell back to the default interpreter instead of the declared one. Dedented to column 0 and set the executable bit.

Verified: `python make_migrations.py --check` reports "No changes detected in app 'django_waf'" (exit 0).

The ecosystem-pattern part of the issue is already satisfied (both django-waf and icv-webhooks ship a `make_migrations.py`, each reusing its own test-settings source). The stale `icv_waf_*.pyc` for the renamed management commands were local, gitignored build artefacts (never tracked) and were cleared locally.

Closes #8

https://claude.ai/code/session_017zBPdvprwKiWKZJE5eyJTn