### PR TITLE
1.6.0: P1 defect wave (#24 #25 #26 #27 #30 #34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-08-01
+
+A defect wave from the 2026-08-01 issue triage. Each of these was latent since
+the feature that introduced it, not a regression: the fixes below correct
+behaviour that was wrong from first release (the one exception is noted under
+rule expiry). All 929 tests pass.
+
+### Fixed
+
+- **Cloud-spray detection was blind to botnets that spoof a referer (#24).**
+  `detect_cloud_spray` only counted requests with an empty or missing referer,
+  so a botnet that stamped every request with a static referer was invisible.
+  Observed in production (2026-08-01): a distributed click-fraud flood of
+  131,293 distinct IPs in one day, a rotated pool of plausible Chrome/Edge user
+  agents, every request carrying a bare-origin `Referer` header, reported as
+  zero cloud-spray while roughly 95% of the flood was allowed. A referer that
+  is a bare origin with no path (matching `^https?://[^/]+$`) is now treated
+  the same as a missing referer in both detector queries, because genuine
+  browser navigation always serialises at least a trailing slash after the host
+  (including `Referrer-Policy: origin`), so a path-less referer cannot come from
+  real traffic. Referers with a real path, and trailing-slash origins, are
+  unaffected.
+- **Proof-of-work pass cookies could not round-trip an IPv6 address (#26).** The
+  cookie payload was colon-joined (`token:ip:expiry:signature`) and validation
+  split on colons, so an IPv6 client's address (which contains colons)
+  mis-parsed and every solved IPv6 client was re-challenged on every request.
+  The payload is now a versioned, pipe-delimited format (`v2|token|ip|expiry|
+  signature`) and IPs are normalised through the `ipaddress` module, so
+  compressed and expanded IPv6 forms validate interchangeably. Cookies in the
+  old format are rejected without special-casing: a client holding one is
+  re-challenged once after upgrade, then behaves normally. Cookie name, TTL, and
+  IP binding are unchanged.
+- **Rule expiry was not enforced during evaluation, and AllowRules never
+  expired (#25).** Active-rule queries filtered only on `is_active`, so the
+  cache could serve a rule past its `expires_at` until the housekeeping task
+  ran, and that task deactivated only BlockRules. An expired feed or crawler
+  AllowRule therefore bypassed every WAF check indefinitely. (The AllowRule half
+  became possible in 1.4.0, which first gave AllowRules an `expires_at`.) Both
+  `active()` querysets now exclude passed expiry, the rule cache carries
+  `expires_at` per entry and rejects expired entries at match time, and the
+  `expire_rules` task deactivates expired AllowRules as well as BlockRules and
+  invalidates the cache when either model had an expired row.
+- **Unsolved-challenge escalation was unreachable (#27).** The escalation check
+  sat after the rule-driven, no-referer, and score-driven challenge verdicts had
+  already returned, so an IP that repeatedly ignored challenges never reached
+  auto-block. Escalation is now gated before every challenge-verdict return
+  point: once the unsolved-challenge count reaches the threshold, the request is
+  blocked with a single TTL-bound auto rule instead of challenged again. A
+  successful solve resets the counter, as before.
+- **Rate limiting returned an inaccurate `Retry-After` (#30).** The retry
+  calculation always collapsed to one second and the value was then dropped
+  because `EvaluationResult` carried no rate-limit metadata, so the middleware
+  sent a fixed 60 seconds. The sliding-window limiter now returns the true
+  seconds until the oldest event ages out (computed atomically in the same Redis
+  pipeline), `EvaluationResult` carries `retry_after`, and both the main WAF
+  throttle and the site-password guess-throttle emit accurate headers.
+- **Verified-crawler allow rules trusted an unconfirmed PTR record (#34).**
+  Crawler verification accepted a reverse-DNS hostname whose suffix matched an
+  approved pattern without forward-resolving it, so anyone controlling the PTR
+  record for their own IP (any cloud host with settable reverse DNS) could pass
+  as Googlebot or Bingbot. Verification now performs forward-confirmed reverse
+  DNS: after the PTR suffix matches, the hostname is forward-resolved and the
+  original IP must appear among the results. Any DNS failure fails closed.
+
+### Added
+
+- `DJANGO_WAF_RDNS_FAILURE_CACHE_TTL` (default 300): negative reverse-DNS
+  verdicts are now cached briefly, rather than for the 24 hours a positive
+  verdict is cached, so a transient resolver outage no longer suppresses a
+  crawler allow rule for a full day.
+
+### Changed
+
+- `EvaluationResult` gained a `retry_after` field (keyword default `None`);
+  positional 5-argument constructions are unaffected.
+- The `expire_rules` task result gained `expired_block_count` and
+  `expired_allow_count` alongside the existing `expired_count`.
+
 ## [1.5.2] - 2026-07-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "1.5.2"
+version = "1.6.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -215,6 +215,17 @@ DJANGO_WAF_EXEMPT_HOSTS: list[str] = getattr(
 # opt out, or deactivate the seeded AllowRule rows directly.
 DJANGO_WAF_ALLOW_VERIFIED_CRAWLERS: bool = getattr(settings, "DJANGO_WAF_ALLOW_VERIFIED_CRAWLERS", True)
 
+# TTL in seconds for a NEGATIVE forward-confirmed reverse DNS (FCrDNS)
+# verification result — a PTR/hostname pattern match that then failed the
+# forward-resolution check, or any DNS error on either lookup (#34). Kept
+# short (5 minutes) rather than the 24-hour positive-result TTL, because a
+# negative result can come from a transient resolver outage, and a long
+# negative cache would suppress a legitimate crawler's AllowRule match for
+# a full day per IP on every hiccup. A positive FCrDNS verification is
+# always cached for 24 hours, unaffected by this setting — legitimate
+# crawler infrastructure's DNS records change rarely.
+DJANGO_WAF_RDNS_FAILURE_CACHE_TTL: int = getattr(settings, "DJANGO_WAF_RDNS_FAILURE_CACHE_TTL", 300)
+
 # Trust the X-Forwarded-For header when extracting the real client IP.
 DJANGO_WAF_TRUST_X_FORWARDED_FOR: bool = getattr(settings, "DJANGO_WAF_TRUST_X_FORWARDED_FOR", False)
 

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -272,10 +272,13 @@ class WafMiddleware:
 
         ip_address = _extract_ip(request) or "0.0.0.0"
         redis_client = _get_redis_client()
-        throttled = sp.record_guess_throttle_hit(ip_address, redis_client)
-        if throttled:
+        throttle_result = sp.record_guess_throttle_hit_detailed(ip_address, redis_client)
+        if throttle_result.exceeded:
             response = HttpResponse("Too many attempts. Please retry later.", status=429)
-            response["Retry-After"] = "60"
+            # Accurate sliding-window value (#30) — falls back to 60 only
+            # when the limiter genuinely returned none (fail-open path).
+            retry_after = throttle_result.retry_after
+            response["Retry-After"] = str(retry_after) if retry_after is not None else "60"
             response["X-Robots-Tag"] = _SITE_PASSWORD_NOINDEX_HEADER
             return response
 
@@ -355,11 +358,14 @@ class WafMiddleware:
         if verdict == Verdict.THROTTLED:
             _emit_request_throttled(result, ip_address)
             response = HttpResponse("Too many requests. Please retry later.", status=429)
-            if result.action and hasattr(result, "retry_after"):
-                response["Retry-After"] = str(result.retry_after)
-            else:
-                # Default Retry-After — 60 seconds
-                response["Retry-After"] = "60"
+            # hasattr() was always True for the real EvaluationResult
+            # NamedTuple even before it carried a real retry_after value, so
+            # this always sent the fixed fallback (#30). Use the accurate
+            # sliding-window value when present; only fall back to a fixed
+            # 60 seconds when the result genuinely carries none (e.g. a
+            # test double or a pre-#30 caller).
+            retry_after = getattr(result, "retry_after", None)
+            response["Retry-After"] = str(retry_after) if retry_after is not None else "60"
             return response
 
         if verdict == Verdict.CHALLENGED:

--- a/src/django_waf/models.py
+++ b/src/django_waf/models.py
@@ -49,8 +49,15 @@ class BlockRuleManager(models.Manager):
     """Custom manager for BlockRule with convenience querysets."""
 
     def active(self) -> models.QuerySet:
-        """Return all active rules ordered by priority."""
-        return self.filter(is_active=True).order_by("priority")
+        """Return all active, non-expired rules ordered by priority.
+
+        Excludes rules whose expires_at has passed even when is_active is
+        still True — the periodic expire_rules task deactivates those, but
+        evaluation must not enforce a rule that has expired in the gap
+        before that task next runs (#25).
+        """
+        not_expired = Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now())
+        return self.filter(is_active=True).filter(not_expired).order_by("priority")
 
     def for_nginx(self) -> models.QuerySet:
         """Return active IP/CIDR/UA block or throttle rules suitable for nginx export."""
@@ -193,8 +200,15 @@ class AllowRuleManager(models.Manager):
     """Custom manager for AllowRule with convenience querysets."""
 
     def active(self) -> models.QuerySet:
-        """Return all active allow rules."""
-        return self.filter(is_active=True)
+        """Return all active, non-expired allow rules.
+
+        Excludes rules whose expires_at has passed even when is_active is
+        still True — mirrors BlockRuleManager.active() (#25). Without this,
+        an expired feed or crawler AllowRule keeps bypassing every WAF
+        check until the periodic expire_rules task next deactivates it.
+        """
+        not_expired = Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now())
+        return self.filter(is_active=True).filter(not_expired)
 
     def requiring_rdns(self) -> models.QuerySet:
         """Return active rules that require reverse-DNS verification."""
@@ -203,6 +217,14 @@ class AllowRuleManager(models.Manager):
     def feed_sourced(self) -> models.QuerySet:
         """Return active rules sourced from the collective threat feed."""
         return self.active().filter(source=RuleSource.FEED)
+
+    def expired(self) -> models.QuerySet:
+        """Return active rules whose expiry time has passed.
+
+        Mirrors BlockRuleManager.expired() so the expire_rules task can
+        deactivate AllowRules using the same shape (#25).
+        """
+        return self.filter(is_active=True, expires_at__lte=timezone.now())
 
 
 class AllowRule(BaseModel):

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -16,6 +16,13 @@ from django.utils import timezone
 
 logger = logging.getLogger("django_waf.anomaly_detector")
 
+# A referer that is a bare origin with no path (e.g. "https://host") cannot be
+# produced by genuine browser navigation: even Referrer-Policy: origin always
+# serialises at least a trailing slash after the host ("https://host/"). A
+# botnet that spoofs a static bare-origin referer to defeat the missing-referer
+# check must therefore be treated the same as a missing referer (issue #24).
+BARE_ORIGIN_REFERER_RE = r"^https?://[^/]+$"
+
 
 def detect_ua_rotation(
     window_minutes: int = 5,
@@ -330,6 +337,12 @@ def detect_cloud_spray(window_minutes: int = 30) -> list:
     where each IP makes only 1-3 requests with no referer. This pattern is
     characteristic of cloud-hosted bot farms that evade per-IP rate limits.
 
+    A referer that is a bare origin with no path (``BARE_ORIGIN_REFERER_RE``,
+    e.g. "https://example.com") is treated the same as a missing referer:
+    genuine browser navigation always serialises at least a trailing slash
+    after the host, so a spoofed static bare-origin referer is otherwise
+    invisible to this detector (issue #24).
+
     Flags subnets rather than individual IPs — cloud providers allocate
     contiguous blocks, so a single CIDR catches the cluster efficiently.
     Aggregation uses ``_get_subnet_prefix`` (the /24 network for IPv4, the
@@ -351,12 +364,13 @@ def detect_cloud_spray(window_minutes: int = 30) -> list:
     min_ips = conf.DJANGO_WAF_CLOUD_SPRAY_MIN_IPS
     max_per_ip = conf.DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP
 
-    # Step 1: Find UAs used by many distinct IPs with no referer
+    # Step 1: Find UAs used by many distinct IPs with no referer (or a
+    # spoofed bare-origin referer, which is indistinguishable from missing).
     spray_uas = (
         RequestLog.objects.filter(
             timestamp__gte=cutoff,
         )
-        .filter(Q(referer="") | Q(referer__isnull=True))
+        .filter(Q(referer="") | Q(referer__isnull=True) | Q(referer__regex=BARE_ORIGIN_REFERER_RE))
         .exclude(user_agent="")
         .values("user_agent")
         .annotate(distinct_ips=Count("ip_address", distinct=True))
@@ -371,12 +385,13 @@ def detect_cloud_spray(window_minutes: int = 30) -> list:
         ua = ua_row["user_agent"]
 
         # Step 2: Get IPs using this UA with low request counts and no referer
+        # (or a spoofed bare-origin referer — same treatment as Step 1).
         ip_counts = (
             RequestLog.objects.filter(
                 timestamp__gte=cutoff,
                 user_agent=ua,
             )
-            .filter(Q(referer="") | Q(referer__isnull=True))
+            .filter(Q(referer="") | Q(referer__isnull=True) | Q(referer__regex=BARE_ORIGIN_REFERER_RE))
             .values("ip_address")
             .annotate(req_count=Count("id"))
             .filter(req_count__lte=max_per_ip)

--- a/src/django_waf/services/challenge_service.py
+++ b/src/django_waf/services/challenge_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import secrets
@@ -18,6 +19,17 @@ from django.conf import settings
 from django.utils import timezone
 
 logger = logging.getLogger("django_waf.challenge_service")
+
+# ---------------------------------------------------------------------------
+# Pass-cookie payload format
+# ---------------------------------------------------------------------------
+
+# "|" cannot appear in a hex token, an IP address, or a decimal timestamp, so
+# it is an unambiguous delimiter, unlike ":", which IPv6 addresses contain.
+# The "v2" tag lets validation reject anything issued by the old colon-joined
+# format outright rather than mis-parsing it (see GH #26).
+_PASS_COOKIE_VERSION = "v2"
+_PASS_COOKIE_DELIMITER = "|"
 
 # ---------------------------------------------------------------------------
 # Custom exceptions
@@ -265,6 +277,21 @@ def verify_challenge_solution(
     return True
 
 
+def _normalise_ip(ip_address: str) -> str:
+    """Return the compressed canonical form of an IP address.
+
+    Ensures compressed and expanded forms of the same IPv6 address (e.g.
+    ``2001:db8::1`` and ``2001:0db8:0000:...:0001``) compare equal both when
+    a cookie is issued and when it is later validated. Falls back to the raw
+    input for anything ``ipaddress`` cannot parse, so an invalid value still
+    reaches the normal reject-and-return-False path rather than raising here.
+    """
+    try:
+        return ipaddress.ip_address(ip_address).compressed
+    except ValueError:
+        return ip_address
+
+
 def issue_pass_cookie(
     response,
     token: str,
@@ -273,8 +300,12 @@ def issue_pass_cookie(
 ) -> None:
     """Set the waf_pass cookie on the response to mark successful challenge completion.
 
-    Cookie value format: ``{token}:{ip_address}:{expiry_timestamp}:{signature}``
-    where signature is HMAC-SHA256 of the value prefix.
+    Cookie value format: ``v2|{token}|{ip_address}|{expiry_timestamp}|{signature}``
+    where signature is HMAC-SHA256 of the ``v2|token|ip|expiry`` prefix. The
+    "|" delimiter is unambiguous for IPv6 addresses, which contain ":" and
+    broke the previous colon-joined format (GH #26). ``ip_address`` is stored
+    in its compressed canonical form so validation can compare like for like
+    regardless of which form the client's IP is seen in.
 
     Per BR-CHAL-005 and BR-CHAL-007.
 
@@ -288,10 +319,11 @@ def issue_pass_cookie(
 
     ttl = conf.DJANGO_WAF_CHALLENGE_COOKIE_TTL
     expiry_ts = int(time.time()) + ttl
+    normalised_ip = _normalise_ip(ip_address)
 
-    value_prefix = f"{token}:{ip_address}:{expiry_ts}"
+    value_prefix = _PASS_COOKIE_DELIMITER.join([_PASS_COOKIE_VERSION, token, normalised_ip, str(expiry_ts)])
     signature = _hmac_sign(value_prefix)
-    cookie_value = f"{value_prefix}:{signature}"
+    cookie_value = f"{value_prefix}{_PASS_COOKIE_DELIMITER}{signature}"
 
     response.set_cookie(
         "waf_pass",
@@ -308,6 +340,11 @@ def validate_pass_cookie(cookie_value: str, ip_address: str) -> bool:
 
     Pure function — no DB or Redis access.
 
+    Only understands the versioned "v2|token|ip|expiry|signature" format
+    (see ``issue_pass_cookie``). A cookie issued by the pre-fix colon-joined
+    format simply fails to parse and returns False: the client re-solves the
+    challenge once, there is no legacy-format fallback (GH #26).
+
     Per BR-CHAL-006.
 
     Args:
@@ -318,29 +355,26 @@ def validate_pass_cookie(cookie_value: str, ip_address: str) -> bool:
         True if the cookie is valid (HMAC verifies, not expired, IP matches).
     """
     try:
-        parts = cookie_value.rsplit(":", 1)
-        if len(parts) != 2:
-            return False
-        value_prefix, signature = parts
+        value_prefix, signature = cookie_value.rsplit(_PASS_COOKIE_DELIMITER, 1)
 
-        # Verify HMAC
+        # Verify HMAC before trusting anything else in the payload.
         expected_sig = _hmac_sign(value_prefix)
         if not hmac.compare_digest(expected_sig, signature):
             return False
 
-        # Parse value prefix: token:ip:expiry
-        prefix_parts = value_prefix.split(":", 2)
-        if len(prefix_parts) != 3:
+        # Parse value prefix: v2|token|ip|expiry
+        version, _token, cookie_ip, expiry_str = value_prefix.split(_PASS_COOKIE_DELIMITER, 3)
+        if version != _PASS_COOKIE_VERSION:
             return False
-        _token, cookie_ip, expiry_str = prefix_parts
 
         # Check expiry
         expiry_ts = int(expiry_str)
         if time.time() > expiry_ts:
             return False
 
-        # Check IP binding
-        return cookie_ip == ip_address
+        # Check IP binding: normalise both sides so a compressed cookie IP
+        # matches an expanded request IP (or vice versa).
+        return cookie_ip == _normalise_ip(ip_address)
 
     except (ValueError, AttributeError, TypeError):
         return False

--- a/src/django_waf/services/rate_limiter.py
+++ b/src/django_waf/services/rate_limiter.py
@@ -31,6 +31,31 @@ _WINDOWS: list[tuple[str, int]] = [
 ]
 
 
+def _retry_after_from_oldest(oldest_in_window: list, window_seconds: int, now: float) -> int:
+    """Return the true seconds-until-retry from a ZRANGE(0, 0, withscores=True) result.
+
+    ``oldest_in_window`` is the pipeline's ZRANGE result for the surviving
+    (post-ZREMRANGEBYSCORE) entry with the lowest score — the oldest event
+    still counted in the window. The client may retry once that event ages
+    out of the window, at ``oldest_timestamp + window_seconds``. Previously
+    this was computed as ``window_seconds - (now - cutoff)`` where
+    ``cutoff = now - window_seconds``, which algebraically collapses to a
+    constant ``0`` every time regardless of actual window occupancy — hence
+    the fixed 1-second floor always winning (#30).
+
+    Falls back to the full window_seconds (floored at 1) if the ZRANGE
+    result is empty — this should not happen in practice (the event that
+    just triggered the breach is always in the set), but a fake/incomplete
+    Redis client in tests may return an empty list.
+    """
+    if not oldest_in_window:
+        return max(1, window_seconds)
+
+    _member, oldest_timestamp = oldest_in_window[0]
+    retry_after = int(float(oldest_timestamp) + window_seconds - now)
+    return max(1, retry_after)
+
+
 def _check_path_rate_limit(
     ip_address: str,
     path: str,
@@ -82,14 +107,15 @@ def _check_path_rate_limit(
     pipe.zadd(key, {str(now): now})
     pipe.zremrangebyscore(key, 0, cutoff)
     pipe.zcard(key)
+    pipe.zrange(key, 0, 0, withscores=True)
     pipe.expire(key, window_seconds + 10)
     results = pipe.execute()
 
     count = results[2]
+    oldest_in_window = results[3]
 
     if count > max_requests:
-        retry_after = int(window_seconds - (now - cutoff))
-        retry_after = max(1, retry_after)
+        retry_after = _retry_after_from_oldest(oldest_in_window, window_seconds, now)
         return RateLimitResult(exceeded=True, window="path", retry_after=retry_after)
 
     return None
@@ -156,14 +182,15 @@ def check_rate_limit(
         pipe.zadd(key, {str(now): now})
         pipe.zremrangebyscore(key, 0, cutoff)
         pipe.zcard(key)
+        pipe.zrange(key, 0, 0, withscores=True)
         pipe.expire(key, ttl)
         results = pipe.execute()
 
         count = results[2]
+        oldest_in_window = results[3]
 
         if count > threshold:
-            retry_after = int(window_seconds - (now - cutoff))
-            retry_after = max(1, retry_after)
+            retry_after = _retry_after_from_oldest(oldest_in_window, window_seconds, now)
             return RateLimitResult(exceeded=True, window=window_name, retry_after=retry_after)
 
     return RateLimitResult(exceeded=False, window=None, retry_after=None)

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -31,6 +31,11 @@ class EvaluationResult(NamedTuple):
     matched_rule_id: UUID | None
     matched_rule_type: str  # "" when no rule matched; RequestLog.matched_rule_type is NOT NULL
     anomaly_score: float | None
+    # Populated only on THROTTLED verdicts (#30) — the true seconds until the
+    # sliding window's oldest counted event ages out. None for every other
+    # verdict. Defaulted so existing positional/keyword construction sites
+    # that predate this field keep working unchanged.
+    retry_after: int | None = None
 
 
 class RuleCache(NamedTuple):
@@ -375,6 +380,7 @@ def evaluate_request(
             matched_rule_id=None,
             matched_rule_type="",
             anomaly_score=None,
+            retry_after=rate_result.retry_after,
         )
 
     # Step 8: No-referer challenge (moved from middleware for proper logging)

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -188,6 +188,7 @@ def _rebuild_rule_cache_from_db(redis_client, version: int, cache_key: str) -> R
         "pattern",
         "action",
         "priority",
+        "expires_at",
     )
 
     block_rules = [
@@ -198,6 +199,7 @@ def _rebuild_rule_cache_from_db(redis_client, version: int, cache_key: str) -> R
             "pattern": r["pattern"],
             "action": r["action"],
             "priority": r["priority"],
+            "expires_at": r["expires_at"].isoformat() if r["expires_at"] else None,
         }
         for r in block_qs
     ]
@@ -209,6 +211,7 @@ def _rebuild_rule_cache_from_db(redis_client, version: int, cache_key: str) -> R
         "pattern",
         "verify_rdns",
         "rdns_pattern",
+        "expires_at",
     )
     allow_rules = [
         {
@@ -218,6 +221,7 @@ def _rebuild_rule_cache_from_db(redis_client, version: int, cache_key: str) -> R
             "pattern": r["pattern"],
             "verify_rdns": r["verify_rdns"],
             "rdns_pattern": r["rdns_pattern"],
+            "expires_at": r["expires_at"].isoformat() if r["expires_at"] else None,
         }
         for r in allow_qs
     ]
@@ -450,6 +454,26 @@ def evaluate_request(
 # ---------------------------------------------------------------------------
 
 
+def _is_cached_rule_expired(rule: dict) -> bool:
+    """Return True if a cached rule dict's expires_at has passed.
+
+    The rule cache can lag the database by up to _CACHE_TTL seconds (or
+    longer if expire_rules hasn't run yet), so a rule that expired after
+    the cache was built must still be rejected at match time rather than
+    waiting for the next cache rebuild (#25).
+    """
+    expires_at = rule.get("expires_at")
+    if not expires_at:
+        return False
+
+    from datetime import datetime
+
+    from django.utils import timezone
+
+    expiry = datetime.fromisoformat(expires_at)
+    return expiry <= timezone.now()
+
+
 def _check_allow_rules(
     ip_address: str,
     user_agent: str,
@@ -458,6 +482,8 @@ def _check_allow_rules(
 ) -> tuple[str, dict] | None:
     """Return (rule_id, rule_dict) if an AllowRule matches, else None."""
     for rule in cache.allow_rules:
+        if _is_cached_rule_expired(rule):
+            continue  # expired since the cache was built (#25) — not a match
         if _rule_matches(rule, ip_address, user_agent):
             if (
                 rule.get("verify_rdns")
@@ -481,6 +507,8 @@ def _check_block_rules(
     (flushed to DB by the update_rule_hit_counts task).
     """
     for rule in cache.block_rules:
+        if _is_cached_rule_expired(rule):
+            continue  # expired since the cache was built (#25) — not a match
         if _rule_matches(rule, ip_address, user_agent):
             if redis_client is not None:
                 _record_rule_hit(rule["id"], redis_client)

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -54,9 +54,18 @@ class RuleCache(NamedTuple):
 _RULES_VERSION_KEY = "waf:rules:version"
 _RULES_CACHE_KEY = "waf:rules:cache:{version}"
 _BLOCKED_IP_KEY = "waf:blocked:{ip}"
-_BOT_RDNS_KEY = "waf:bot_rdns:{ip}"
+# Forward-confirmed rDNS (FCrDNS) verified-verdict cache (#34). Keyed on both
+# ip and rdns_pattern_hash: a single IP can legitimately be checked against
+# more than one AllowRule's rdns_pattern (e.g. a Googlebot pattern and a
+# Bingbot pattern both tried against the same request), and the verdict is a
+# function of both. The pattern is hashed (not embedded raw) so the key
+# stays a bounded length regardless of pattern content.
+_BOT_FCRDNS_KEY = "waf:bot_fcrdns:{ip}:{pattern_hash}"
 _STATS_KEY = "waf:stats:today"
 _CACHE_TTL = 600  # 10 minutes
+# Positive FCrDNS verifications are cached for 24 hours — PTR/forward DNS
+# records for legitimate crawler infrastructure change rarely.
+_FCRDNS_POSITIVE_CACHE_TTL = 86400
 
 _REBUILD_LOCK_KEY = "waf:rule_cache:lock"
 _REBUILD_LOCK_TTL = 5  # seconds
@@ -592,37 +601,108 @@ def _match_cidr(ip_address: str, cidr_pattern: str) -> bool:
 
 
 def _verify_rdns(ip_address: str, rdns_pattern: str, redis_client) -> bool:
-    """Verify that the IP's reverse DNS hostname matches rdns_pattern.
+    """Verify the IP via forward-confirmed reverse DNS (FCrDNS) (#34).
 
-    Results are cached in Redis for 24 hours (BR-EVAL-004).
+    A bare PTR (reverse-DNS) lookup is not proof of identity: an attacker
+    who controls the PTR record of their own IP (any cloud VM with settable
+    rDNS) can make ``socket.gethostbyaddr`` return a hostname that matches
+    ``rdns_pattern`` (e.g. anything ending ``.googlebot.com``) without being
+    Google at all. Forward confirmation closes that gap: after the PTR
+    hostname matches the pattern, the hostname is forward-resolved
+    (``socket.getaddrinfo``, both address families) and the check only
+    passes if the *original* IP appears among the forward-resolved
+    addresses — proving whoever controls ``rdns_pattern``'s DNS zone (e.g.
+    Google, for ``*.googlebot.com``) also vouches for this IP, not just
+    whoever controls the PTR record of the IP itself.
+
+    The final verified verdict (not the raw hostname) is cached in Redis,
+    keyed on both ip and rdns_pattern (hashed) since a single IP can
+    legitimately be checked against more than one AllowRule's pattern.
+    Positive verdicts cache for 24 hours; negative verdicts (pattern
+    mismatch, forward-resolution mismatch, or any DNS error on either
+    lookup) cache for DJANGO_WAF_RDNS_FAILURE_CACHE_TTL (default 5 minutes)
+    so a transient resolver outage does not suppress a legitimate crawler's
+    AllowRule match for a full day per IP.
+
+    Any DNS error — on the reverse lookup or the forward lookup — fails
+    closed (returns False).
 
     Args:
-        ip_address: IP to reverse-lookup.
-        rdns_pattern: Regex the resolved hostname must match.
+        ip_address: IP to reverse-lookup and confirm.
+        rdns_pattern: Regex the resolved PTR hostname must match.
         redis_client: Redis client for caching.
 
     Returns:
-        True if rDNS resolves and hostname matches the pattern.
+        True only if the PTR hostname matches rdns_pattern AND the
+        hostname's forward DNS resolution includes ip_address.
     """
-    cache_key = _BOT_RDNS_KEY.format(ip=ip_address)
-    cached_hostname = redis_client.get(cache_key)
+    from django_waf import conf
 
-    if cached_hostname is None:
-        try:
-            hostname = socket.gethostbyaddr(ip_address)[0]
-        except (socket.herror, socket.gaierror, OSError):
-            hostname = ""
-        redis_client.setex(cache_key, 86400, hostname)
-    else:
-        hostname = cached_hostname if isinstance(cached_hostname, str) else cached_hostname.decode()
+    cache_key = _fcrdns_cache_key(ip_address, rdns_pattern)
+    cached_verdict = redis_client.get(cache_key)
+    if cached_verdict is not None:
+        verdict_str = cached_verdict if isinstance(cached_verdict, str) else cached_verdict.decode()
+        return verdict_str == "1"
+
+    verdict = _resolve_and_confirm_rdns(ip_address, rdns_pattern)
+
+    ttl = _FCRDNS_POSITIVE_CACHE_TTL if verdict else conf.DJANGO_WAF_RDNS_FAILURE_CACHE_TTL
+    redis_client.setex(cache_key, ttl, "1" if verdict else "0")
+    return verdict
+
+
+def _fcrdns_cache_key(ip_address: str, rdns_pattern: str) -> str:
+    """Return the FCrDNS verdict cache key for an (ip, pattern) pair.
+
+    Not a security use — just a stable, bounded-length key fragment derived
+    from the pattern string, mirroring the same hashing approach used for
+    per-path rate-limit keys in rate_limiter.py.
+    """
+    import hashlib
+
+    pattern_hash = hashlib.sha1(rdns_pattern.encode(), usedforsecurity=False).hexdigest()[:12]
+    return _BOT_FCRDNS_KEY.format(ip=ip_address, pattern_hash=pattern_hash)
+
+
+def _resolve_and_confirm_rdns(ip_address: str, rdns_pattern: str) -> bool:
+    """Perform the actual reverse + forward DNS resolution and comparison.
+
+    No caching here — callers (``_verify_rdns``) own the cache. Split out
+    so the two concerns (DNS resolution vs. verdict caching) can be tested
+    independently.
+    """
+    try:
+        hostname = socket.gethostbyaddr(ip_address)[0]
+    except (socket.herror, socket.gaierror, OSError):
+        return False  # reverse lookup failed — fail closed
 
     if not hostname:
         return False
 
     try:
-        return bool(re.search(rdns_pattern, hostname, re.IGNORECASE))
+        if not re.search(rdns_pattern, hostname, re.IGNORECASE):
+            return False
     except re.error:
         return False
+
+    try:
+        forward_addresses = {info[4][0] for info in socket.getaddrinfo(hostname, None)}
+    except (socket.gaierror, OSError):
+        return False  # forward lookup failed — fail closed
+
+    try:
+        target = ipaddress.ip_address(ip_address)
+    except ValueError:
+        return False
+
+    for candidate in forward_addresses:
+        try:
+            if ipaddress.ip_address(candidate) == target:
+                return True
+        except ValueError:
+            continue
+
+    return False
 
 
 def _action_to_verdict(action: str) -> str:

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -288,6 +288,14 @@ def evaluate_request(
     7. Rate limits
     8. UA anomaly score (if IP has >10 recent requests)
 
+    Every point below that would return a CHALLENGED verdict (a rule-driven
+    BlockRule challenge, the no-referer challenge, or a score-driven
+    challenge) is routed through ``_gate_challenge_or_escalate`` first (#27).
+    Without that gate, an IP that keeps ignoring challenges never revisits
+    the threshold check that would otherwise auto-block it, because each
+    new request returns its own challenge verdict before evaluation ever
+    reaches the old end-of-function escalation check.
+
     Args:
         ip_address: Client IP address string.
         user_agent: Raw User-Agent header string.
@@ -347,13 +355,16 @@ def evaluate_request(
         matched_id, rule = block_result
         action = rule["action"]
         verdict = _action_to_verdict(action)
-        return EvaluationResult(
+        block_eval_result = EvaluationResult(
             verdict=verdict,
             action=action,
             matched_rule_id=UUID(matched_id),
             matched_rule_type="block",
             anomaly_score=None,
         )
+        if verdict == Verdict.CHALLENGED:
+            return _gate_challenge_or_escalate(ip_address, redis_client, block_eval_result)
+        return block_eval_result
 
     # Step 7: Rate limits
     rate_result = check_rate_limit(ip_address, redis_client, path=path)
@@ -370,12 +381,16 @@ def evaluate_request(
     if conf.DJANGO_WAF_CHALLENGE_NO_REFERER and not referer:
         exempt = any(path == p or path.startswith(p) for p in conf.DJANGO_WAF_NO_REFERER_EXEMPT_PATHS)
         if not exempt:
-            return EvaluationResult(
-                verdict=Verdict.CHALLENGED,
-                action=RuleAction.CHALLENGE,
-                matched_rule_id=None,
-                matched_rule_type="",
-                anomaly_score=None,
+            return _gate_challenge_or_escalate(
+                ip_address,
+                redis_client,
+                EvaluationResult(
+                    verdict=Verdict.CHALLENGED,
+                    action=RuleAction.CHALLENGE,
+                    matched_rule_id=None,
+                    matched_rule_type="",
+                    anomaly_score=None,
+                ),
             )
 
     # Step 9: Path scoring — always evaluated (no volume threshold).
@@ -405,39 +420,24 @@ def evaluate_request(
     total_score = ua_score + path_score + fp_score
     if total_score > 0:
         verdict, action = _score_to_verdict(total_score)
-        if verdict != Verdict.ALLOWED:
-            return EvaluationResult(
-                verdict=verdict,
-                action=action,
-                matched_rule_id=None,
-                matched_rule_type="",
-                anomaly_score=total_score,
+        if verdict == Verdict.CHALLENGED:
+            return _gate_challenge_or_escalate(
+                ip_address,
+                redis_client,
+                EvaluationResult(
+                    verdict=verdict,
+                    action=action,
+                    matched_rule_id=None,
+                    matched_rule_type="",
+                    anomaly_score=total_score,
+                ),
             )
         return EvaluationResult(
-            verdict=Verdict.ALLOWED,
-            action=None,
+            verdict=verdict,
+            action=action,
             matched_rule_id=None,
             matched_rule_type="",
             anomaly_score=total_score,
-        )
-
-    # Step 10: Challenge escalation — auto-block IPs that ignore challenges.
-    # Creates a persistent auto BlockRule + Redis fast-path with configurable TTL.
-    challenged_count = _get_unsolved_challenge_count(ip_address, redis_client)
-    if challenged_count >= conf.DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD:
-        escalation_rule = _create_escalation_rule(ip_address)
-        record_block_verdict(
-            ip_address,
-            redis_client,
-            ttl=conf.DJANGO_WAF_ESCALATION_BLOCK_TTL,
-            rule_id=str(escalation_rule.id) if escalation_rule else None,
-        )
-        return EvaluationResult(
-            verdict=Verdict.BLOCKED,
-            action=RuleAction.BLOCK,
-            matched_rule_id=None,
-            matched_rule_type="",
-            anomaly_score=None,
         )
 
     return EvaluationResult(
@@ -672,6 +672,61 @@ def _score_path(path: str) -> float:
         except re.error:
             continue
     return score
+
+
+def _gate_challenge_or_escalate(
+    ip_address: str,
+    redis_client,
+    challenge_result: EvaluationResult,
+) -> EvaluationResult:
+    """Single escalation gate — called before returning ANY challenge verdict.
+
+    Fixes #27: evaluate_request has three places that can produce a
+    CHALLENGED verdict (a rule-driven BlockRule challenge, the no-referer
+    challenge, and a score-driven challenge). The escalation check used to
+    live only at the very end of evaluate_request, after all three of
+    those early returns — so a repeatedly-challenged IP never reached it
+    and auto-block-on-ignored-challenges was dead code. Routing every
+    challenge verdict through this one gate first makes escalation reachable
+    regardless of which path produced the challenge.
+
+    If the IP's unsolved-challenge count has reached
+    DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD, creates (or reuses) a
+    persistent auto BlockRule and returns a BLOCKED verdict referencing it
+    instead of the challenge verdict. Otherwise returns challenge_result
+    unchanged.
+
+    Args:
+        ip_address: Client IP address string.
+        redis_client: Configured Redis client instance.
+        challenge_result: The CHALLENGED EvaluationResult that would
+            otherwise be returned.
+
+    Returns:
+        A BLOCKED EvaluationResult when escalation triggers, else
+        challenge_result unchanged.
+    """
+    from django_waf import conf
+    from django_waf.enums import RuleAction, Verdict
+
+    challenged_count = _get_unsolved_challenge_count(ip_address, redis_client)
+    if challenged_count < conf.DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD:
+        return challenge_result
+
+    escalation_rule = _create_escalation_rule(ip_address)
+    record_block_verdict(
+        ip_address,
+        redis_client,
+        ttl=conf.DJANGO_WAF_ESCALATION_BLOCK_TTL,
+        rule_id=str(escalation_rule.id) if escalation_rule else None,
+    )
+    return EvaluationResult(
+        verdict=Verdict.BLOCKED,
+        action=RuleAction.BLOCK,
+        matched_rule_id=None,
+        matched_rule_type="",
+        anomaly_score=None,
+    )
 
 
 def _get_unsolved_challenge_count(ip_address: str, redis_client) -> int:

--- a/src/django_waf/services/site_password_service.py
+++ b/src/django_waf/services/site_password_service.py
@@ -181,16 +181,32 @@ def record_guess_throttle_hit(ip_address: str, redis_client) -> bool:
     False) on any Redis error, matching the WAF's existing fail-open policy
     for infrastructure failures — a throttling outage must never turn into
     a site-wide lockout on its own.
+
+    Returns a plain bool (not the RateLimitResult) so this stays a drop-in
+    "should I throttle?" check. Callers that also need the accurate
+    Retry-After value (#30) should call
+    ``record_guess_throttle_hit_detailed`` instead — this function is kept
+    for callers that only need the boolean.
+    """
+    return record_guess_throttle_hit_detailed(ip_address, redis_client).exceeded
+
+
+def record_guess_throttle_hit_detailed(ip_address: str, redis_client):
+    """Like ``record_guess_throttle_hit``, but returns the full
+    ``RateLimitResult`` (exceeded, window, retry_after) instead of a bare
+    bool, so the caller can send an accurate Retry-After header (#30)
+    rather than a fixed fallback.
+
+    Fails open on any Redis error: returns
+    ``RateLimitResult(exceeded=False, window=None, retry_after=None)``.
     """
     from django_waf import conf
-    from django_waf.services.rate_limiter import check_rate_limit
+    from django_waf.services.rate_limiter import RateLimitResult, check_rate_limit
 
     if redis_client is None:
-        return False
+        return RateLimitResult(exceeded=False, window=None, retry_after=None)
 
     try:
-        result = check_rate_limit(ip_address, redis_client, path=conf.DJANGO_WAF_SITE_PASSWORD_VERIFY_PATH)
+        return check_rate_limit(ip_address, redis_client, path=conf.DJANGO_WAF_SITE_PASSWORD_VERIFY_PATH)
     except Exception:
-        return False
-
-    return result.exceeded
+        return RateLimitResult(exceeded=False, window=None, retry_after=None)

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -212,32 +212,44 @@ def prune_challenge_tokens(hours: int = 24) -> dict:
 
 @shared_task
 def expire_rules() -> dict:
-    """Deactivate BlockRules whose expires_at has passed.
+    """Deactivate BlockRules and AllowRules whose expires_at has passed.
 
-    Sets is_active=False. Does not delete rules (BR-LIFE-001). After bulk update,
-    manually increments the Redis rule version key to invalidate the cache since
-    bulk update() does not trigger post_save signals.
+    Sets is_active=False. Does not delete rules (BR-LIFE-001). Covers both
+    rule tables (#25) — an expired AllowRule left active would otherwise
+    keep bypassing every WAF check indefinitely. After bulk update,
+    manually increments the Redis rule version key to invalidate the cache
+    since bulk update() does not trigger post_save signals.
 
     Returns:
-        Dict with keys: expired_count.
+        Dict with keys: expired_block_count, expired_allow_count,
+        expired_count (total, kept for backwards compatibility).
 
     Scheduled: every 30 minutes (BR-LIFE-002).
     """
-    from django_waf.models import BlockRule
+    from django_waf.models import AllowRule, BlockRule
 
-    expired_qs = BlockRule.objects.expired()
-    count = expired_qs.update(is_active=False)
+    expired_block_count = BlockRule.objects.expired().update(is_active=False)
+    expired_allow_count = AllowRule.objects.expired().update(is_active=False)
+    total = expired_block_count + expired_allow_count
 
-    if count > 0:
+    if total > 0:
         # bulk update() bypasses signals — manually invalidate the rule cache
         try:
             _invalidate_rule_cache_redis()
         except Exception:
             logger.exception("django-waf: failed to invalidate rule cache after expire_rules")
 
-        logger.info("django-waf: expired %d BlockRules", count)
+        logger.info(
+            "django-waf: expired %d BlockRules, %d AllowRules",
+            expired_block_count,
+            expired_allow_count,
+        )
 
-    return {"expired_count": count}
+    return {
+        "expired_block_count": expired_block_count,
+        "expired_allow_count": expired_allow_count,
+        "expired_count": total,
+    }
 
 
 @shared_task

--- a/tests/test_cloud_spray_referer.py
+++ b/tests/test_cloud_spray_referer.py
@@ -1,0 +1,183 @@
+"""Regression tests for issue #24: detect_cloud_spray blind to spoofed bare-origin referers.
+
+A botnet that stamps every request with a static bare-origin referer (e.g.
+"https://vendably.shop", no trailing slash, no path) previously slipped past
+detect_cloud_spray entirely: both the spray-UA aggregation query and the
+per-IP counting query only matched empty or NULL referers. Genuine browser
+navigation always serialises at least a trailing slash after the host, so a
+path-less referer is impossible from real traffic and must be treated as
+equivalent to a missing referer.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from django_waf.services.anomaly_detector import detect_cloud_spray
+from django_waf.testing.factories import RequestLogFactory
+
+pytestmark = pytest.mark.django_db
+
+
+class TestDetectCloudSprayBareOriginReferer:
+    def test_bare_origin_referer_counts_as_missing(self):
+        """A shared bare-origin referer (no path) is treated as a missing referer.
+
+        Production case (VendablyCSS, 2026-08-01): every request in the flood
+        carried "Referer: https://vendably.shop" with no trailing slash, so
+        the old missing-referer-only filter reported cloud_spray=0.
+        """
+        import django_waf.conf as conf_mod
+
+        now = timezone.now()
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        for i in range(min_ips):
+            RequestLogFactory(
+                ip_address=f"203.0.113.{i}",
+                user_agent=shared_ua,
+                referer="https://vendably.shop",
+                timestamp=now,
+            )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        assert len(created) == 1
+        assert created[0].pattern == "203.0.113.0/24"
+
+    def test_bare_origin_referer_with_rotated_uas_still_detected(self):
+        """A small rotated UA pool with a shared bare-origin referer is still caught.
+
+        Mirrors the production shape more closely than a single identical UA:
+        each of the min_ips distinct IPs uses one of a handful of rotated UA
+        strings, so no single UA alone clears the distinct-IP threshold. The
+        detector must still flag the subnet once the bare-origin referer is
+        counted as missing.
+        """
+        import django_waf.conf as conf_mod
+
+        now = timezone.now()
+        min_ips = 20
+        ua_pool = [
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Edge/120.0.0.0",
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/119.0.0.0",
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/121.0.0.0",
+        ]
+
+        # Reduce the threshold so a UA pool split four ways can still clear
+        # it per-UA, while proving no single UA repeats an IP.
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 5),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            for i in range(min_ips):
+                RequestLogFactory(
+                    ip_address=f"198.51.100.{i}",
+                    user_agent=ua_pool[i % len(ua_pool)],
+                    referer="https://vendably.shop",
+                    timestamp=now,
+                )
+
+            created = detect_cloud_spray(window_minutes=30)
+
+        # Every rotated UA maps to the same subnet, and _get_or_create_auto_rule
+        # is keyed on (rule_type, pattern, source, action): only the first UA's
+        # pass creates the rule, later passes refresh the same row (created=False).
+        assert len(created) == 1
+        assert created[0].pattern == "198.51.100.0/24"
+
+    def test_real_referer_with_path_excluded(self):
+        """A referer with a real path is not treated as missing, alone.
+
+        Real navigation from a specific page must not falsely trip the
+        missing-referer bucket used for cloud-spray detection.
+        """
+        import django_waf.conf as conf_mod
+
+        now = timezone.now()
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        for i in range(min_ips):
+            RequestLogFactory(
+                ip_address=f"203.0.113.{i}",
+                user_agent=shared_ua,
+                referer="https://example.com/page",
+                timestamp=now,
+            )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        assert created == []
+
+    def test_trailing_slash_origin_referer_excluded(self):
+        """A referer that is the origin WITH a trailing slash is a real referer, not bare.
+
+        "https://example.com/" is what Referrer-Policy: origin actually
+        produces from genuine navigation; it must not be folded into the
+        missing-referer bucket.
+        """
+        import django_waf.conf as conf_mod
+
+        now = timezone.now()
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        for i in range(min_ips):
+            RequestLogFactory(
+                ip_address=f"203.0.113.{i}",
+                user_agent=shared_ua,
+                referer="https://example.com/",
+                timestamp=now,
+            )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        assert created == []
+
+    def test_empty_referer_still_detected(self):
+        """Existing missing-referer detection (empty string) still works."""
+        import django_waf.conf as conf_mod
+
+        now = timezone.now()
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        for i in range(min_ips):
+            RequestLogFactory(
+                ip_address=f"203.0.113.{i}",
+                user_agent=shared_ua,
+                referer="",
+                timestamp=now,
+            )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        assert len(created) == 1
+        assert created[0].pattern == "203.0.113.0/24"

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -130,10 +130,10 @@ class TestEscalationReachableFromScoreDrivenChallenge:
 
         redis.get.side_effect = _get
 
-        with override_settings(
-            DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD=10,
-            DJANGO_WAF_CHALLENGE_NO_REFERER=True,
-            DJANGO_WAF_NO_REFERER_EXEMPT_PATHS=[],
+        with (
+            override_settings(DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD=10),
+            patch("django_waf.conf.DJANGO_WAF_CHALLENGE_NO_REFERER", True),
+            patch("django_waf.conf.DJANGO_WAF_NO_REFERER_EXEMPT_PATHS", []),
         ):
             result = evaluate_request(
                 ip_address="13.13.13.13",

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -19,6 +19,7 @@ using unittest.mock, matching the pattern in test_services.py.
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -43,9 +44,15 @@ def _make_redis() -> MagicMock:
 
 
 def _make_pipeline_mock(zcard_return: int) -> MagicMock:
-    """Return a pipeline mock whose execute() result has zcard_return at index 2."""
+    """Return a pipeline mock for [zadd, zremrangebyscore, zcard, zrange, expire].
+
+    Matches the 5-command pipeline shape rate_limiter.py builds since #30
+    (see tests/test_retry_after.py) — zcard_return sits at index 2, and a
+    single (member, score) zrange result sits at index 3.
+    """
     pipeline = MagicMock()
-    pipeline.execute.return_value = [1, 0, zcard_return, True]
+    now = time.time()
+    pipeline.execute.return_value = [1, 0, zcard_return, [(str(now), now)], True]
     return pipeline
 
 
@@ -64,9 +71,7 @@ class TestEscalationReachableFromRuleDrivenChallenge:
         )
 
         redis = _make_redis()
-        redis.get.side_effect = lambda key: (
-            b"9" if key == "waf:challenged:11.11.11.11" else None
-        )
+        redis.get.side_effect = lambda key: b"9" if key == "waf:challenged:11.11.11.11" else None
 
         with override_settings(DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD=10):
             result = evaluate_request(
@@ -89,9 +94,7 @@ class TestEscalationReachableFromRuleDrivenChallenge:
         )
 
         redis = _make_redis()
-        redis.get.side_effect = lambda key: (
-            b"10" if key == "waf:challenged:12.12.12.12" else None
-        )
+        redis.get.side_effect = lambda key: b"10" if key == "waf:challenged:12.12.12.12" else None
 
         with override_settings(DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD=10, DJANGO_WAF_ESCALATION_BLOCK_TTL=3600):
             result = evaluate_request(

--- a/tests/test_escalation.py
+++ b/tests/test_escalation.py
@@ -1,0 +1,232 @@
+"""Tests for challenge-escalation reachability (#27).
+
+Prior to this fix, the auto-block-on-unsolved-challenges check sat at the
+very end of evaluate_request, after every branch that can return a
+CHALLENGED verdict (a rule-driven BlockRule challenge, the no-referer
+challenge, and a score-driven challenge). Because each of those branches
+returns early, the escalation check was unreachable dead code: a
+repeatedly-challenged IP just kept getting challenged forever.
+
+The fix routes every CHALLENGED verdict through a single
+``_gate_challenge_or_escalate`` gate before it is returned. These tests
+exercise that gate via both a rule-driven and a score-driven challenge
+path, confirm a solve resets the counter, and confirm below-threshold
+requests still challenge normally.
+
+Redis is not available in the test environment; all Redis calls are mocked
+using unittest.mock, matching the pattern in test_services.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import override_settings
+
+from django_waf.enums import RuleAction, RuleSource, RuleType, Verdict
+from django_waf.models import BlockRule
+from django_waf.services.rule_engine import evaluate_request
+from django_waf.testing.factories import BlockRuleFactory
+
+
+def _make_redis() -> MagicMock:
+    """Return a MagicMock configured as a minimal Redis client."""
+    redis = MagicMock()
+    redis.get.return_value = None
+    redis.set.return_value = True
+    redis.setex.return_value = True
+    redis.delete.return_value = 1
+    redis.incr.return_value = 1
+    redis.zcount.return_value = 0
+    return redis
+
+
+def _make_pipeline_mock(zcard_return: int) -> MagicMock:
+    """Return a pipeline mock whose execute() result has zcard_return at index 2."""
+    pipeline = MagicMock()
+    pipeline.execute.return_value = [1, 0, zcard_return, True]
+    return pipeline
+
+
+@pytest.mark.django_db
+class TestEscalationReachableFromRuleDrivenChallenge:
+    """A BlockRule with action=CHALLENGE must escalate to BLOCKED once the
+    unsolved-challenge threshold is reached, instead of challenging forever."""
+
+    def test_below_threshold_still_challenges(self):
+        BlockRuleFactory(
+            is_active=True,
+            rule_type=RuleType.IP,
+            match_type="exact",
+            pattern="11.11.11.11",
+            action=RuleAction.CHALLENGE,
+        )
+
+        redis = _make_redis()
+        redis.get.side_effect = lambda key: (
+            b"9" if key == "waf:challenged:11.11.11.11" else None
+        )
+
+        with override_settings(DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD=10):
+            result = evaluate_request(
+                ip_address="11.11.11.11",
+                user_agent="Mozilla/5.0",
+                path="/",
+                method="GET",
+                redis_client=redis,
+            )
+
+        assert result.verdict == Verdict.CHALLENGED
+
+    def test_at_threshold_escalates_to_blocked_with_one_auto_rule(self):
+        BlockRuleFactory(
+            is_active=True,
+            rule_type=RuleType.IP,
+            match_type="exact",
+            pattern="12.12.12.12",
+            action=RuleAction.CHALLENGE,
+        )
+
+        redis = _make_redis()
+        redis.get.side_effect = lambda key: (
+            b"10" if key == "waf:challenged:12.12.12.12" else None
+        )
+
+        with override_settings(DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD=10, DJANGO_WAF_ESCALATION_BLOCK_TTL=3600):
+            result = evaluate_request(
+                ip_address="12.12.12.12",
+                user_agent="Mozilla/5.0",
+                path="/",
+                method="GET",
+                redis_client=redis,
+            )
+
+        assert result.verdict == Verdict.BLOCKED
+        assert result.action == RuleAction.BLOCK
+        auto_rules = BlockRule.objects.filter(pattern="12.12.12.12", source=RuleSource.AUTO)
+        assert auto_rules.count() == 1
+        assert auto_rules.first().expires_at is not None
+
+
+@pytest.mark.django_db
+class TestEscalationReachableFromScoreDrivenChallenge:
+    """A score-driven CHALLENGED verdict (no matching rule at all) must also
+    escalate once the threshold is reached — the old dead-code placement
+    only ever ran after this branch, so it could never fire from here."""
+
+    def test_score_driven_challenge_escalates_at_threshold(self):
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(1)
+        redis.zcount.return_value = 5
+
+        def _get(key):
+            if key.startswith("waf:challenged:"):
+                return b"10"
+            return None
+
+        redis.get.side_effect = _get
+
+        with override_settings(
+            DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD=10,
+            DJANGO_WAF_CHALLENGE_NO_REFERER=True,
+            DJANGO_WAF_NO_REFERER_EXEMPT_PATHS=[],
+        ):
+            result = evaluate_request(
+                ip_address="13.13.13.13",
+                user_agent="Mozilla/5.0",
+                path="/some-page/",
+                method="GET",
+                redis_client=redis,
+                referer="",
+            )
+
+        assert result.verdict == Verdict.BLOCKED
+        auto_rules = BlockRule.objects.filter(pattern="13.13.13.13", source=RuleSource.AUTO)
+        assert auto_rules.count() == 1
+
+
+@pytest.mark.django_db
+class TestSolveResetsEscalationCounter:
+    """Confirm the existing solve flow (VerifyView.post, not
+    challenge_service.py) resets waf:challenged:{ip} so escalation does
+    not fire on the next request after a successful solve.
+
+    Follows the same patch targets, Client usage, and ROOT_URLCONF override
+    as tests/test_views.py::TestVerifyView, since VerifyView imports
+    verify_challenge_solution and issue_pass_cookie lazily from
+    django_waf.services.challenge_service inside the method body.
+    """
+
+    @pytest.fixture(autouse=True)
+    def waf_urls(self, settings):
+        settings.ROOT_URLCONF = "tests.urls"
+
+    def test_verify_view_deletes_challenged_counter_on_solve(self, settings):
+        """VerifyView.post clears waf:challenged:{ip} after a successful
+        proof-of-work verification (views.py, not challenge_service.py —
+        the counter reset already lives in the views layer where the solve
+        is processed, satisfying #27's second requirement without touching
+        the sibling-owned challenge_service.py)."""
+        from django.test import Client
+
+        settings.DJANGO_WAF_ENABLED = True
+
+        client = Client()
+        redis = _make_redis()
+
+        with (
+            patch("django_waf.views._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.verify_challenge_solution") as mock_verify,
+            patch("django_waf.services.challenge_service.issue_pass_cookie"),
+        ):
+            mock_redis_fn.return_value = redis
+            mock_verify.return_value = True
+
+            client.post(
+                "/waf/verify/",
+                data={"token": "sometoken", "nonce": "somenonce", "next": "/"},
+            )
+
+        redis.setex.assert_any_call("waf:solved:127.0.0.1", 86400, "1")
+        redis.delete.assert_any_call("waf:challenged:127.0.0.1")
+
+
+@pytest.mark.django_db
+class TestGateHonoursSolvedFlag:
+    def test_gate_treats_solved_ip_as_below_threshold(self):
+        """Once waf:solved:{ip} is set (by VerifyView on success), the gate's
+        own count lookup — via _get_unsolved_challenge_count — returns 0
+        even if a stale counter value is still present, so escalation does
+        not fire for an IP that has just solved a challenge."""
+        BlockRuleFactory(
+            is_active=True,
+            rule_type=RuleType.IP,
+            match_type="exact",
+            pattern="15.15.15.15",
+            action=RuleAction.CHALLENGE,
+        )
+
+        redis = _make_redis()
+
+        def _get(key):
+            if key == "waf:challenged:15.15.15.15":
+                return b"10"
+            if key == "waf:solved:15.15.15.15":
+                return b"1"
+            return None
+
+        redis.get.side_effect = _get
+
+        with override_settings(DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD=10):
+            result = evaluate_request(
+                ip_address="15.15.15.15",
+                user_agent="Mozilla/5.0",
+                path="/",
+                method="GET",
+                redis_client=redis,
+            )
+
+        assert result.verdict == Verdict.CHALLENGED
+        redis.delete.assert_any_call("waf:challenged:15.15.15.15")
+        assert not BlockRule.objects.filter(pattern="15.15.15.15", source=RuleSource.AUTO).exists()

--- a/tests/test_pass_cookie.py
+++ b/tests/test_pass_cookie.py
@@ -1,0 +1,390 @@
+"""Tests for the waf_pass cookie: issuance, validation, and IPv6 safety.
+
+Regression coverage for GH #26 (proof-of-work pass cookies were not
+IPv6-safe): the pre-fix cookie format joined ``token:ip:expiry:signature``
+with ":", which an IPv6 address also contains, so validation mis-parsed the
+payload and every solved IPv6 client was re-challenged forever despite
+holding a validly signed cookie. The fix moves to a versioned "|"-delimited
+payload (see ``django_waf.services.challenge_service.issue_pass_cookie``)
+and normalises IP addresses via the ``ipaddress`` module before comparing.
+
+Redis is not available in the test environment; the middleware integration
+test mocks it the same way tests/test_middleware.py does. validate_pass_cookie
+and issue_pass_cookie themselves are pure functions with no Redis/DB access.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+from django_waf.services.challenge_service import (
+    _hmac_sign,
+    issue_pass_cookie,
+    validate_pass_cookie,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _issued_cookie_value(token: str, ip: str, ttl: int = 3600, secure: bool = False) -> str:
+    """Issue a pass cookie and return the raw value that would be sent to the client."""
+    import django_waf.conf as conf_mod
+
+    response = MagicMock()
+    captured = {}
+
+    def capture_cookie(name, value, **kwargs):
+        captured["value"] = value
+
+    response.set_cookie.side_effect = capture_cookie
+
+    with patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_COOKIE_TTL", ttl):
+        issue_pass_cookie(response, token, ip, secure=secure)
+
+    return captured["value"]
+
+
+# ---------------------------------------------------------------------------
+# IPv4 round trip
+# ---------------------------------------------------------------------------
+
+
+class TestPassCookieIPv4:
+    def test_round_trip_valid(self):
+        """A cookie issued for an IPv4 address validates for that same address."""
+        ip = "10.0.0.1"
+        token = "abc123def456abc123def456abc123"
+
+        cookie_value = _issued_cookie_value(token, ip)
+
+        assert validate_pass_cookie(cookie_value, ip) is True
+
+    def test_wrong_ip_returns_false(self):
+        """Cookie issued for one IPv4 address does not validate for a different one."""
+        ip = "10.0.0.1"
+        other_ip = "10.0.0.2"
+        token = "some-token-value"
+
+        cookie_value = _issued_cookie_value(token, ip)
+
+        assert validate_pass_cookie(cookie_value, other_ip) is False
+
+
+# ---------------------------------------------------------------------------
+# IPv6 round trip (GH #26)
+# ---------------------------------------------------------------------------
+
+
+class TestPassCookieIPv6:
+    def test_compressed_ipv6_round_trip(self):
+        """A cookie issued and validated with the same compressed IPv6 address works."""
+        ip = "2001:db8::1"
+        token = "compressed-ipv6-token"
+
+        cookie_value = _issued_cookie_value(token, ip)
+
+        assert validate_pass_cookie(cookie_value, ip) is True
+
+    def test_expanded_ipv6_round_trip(self):
+        """A cookie issued and validated with the same expanded IPv6 address works."""
+        ip = "2001:0db8:0000:0000:0000:0000:0000:0001"
+        token = "expanded-ipv6-token"
+
+        cookie_value = _issued_cookie_value(token, ip)
+
+        assert validate_pass_cookie(cookie_value, ip) is True
+
+    def test_issued_compressed_validated_expanded(self):
+        """A cookie issued with the compressed form validates against the expanded form.
+
+        This is the exact defect from GH #26: the two forms are the same
+        address, so they must compare equal regardless of which form the
+        client is seen in on each request.
+        """
+        compressed = "2001:db8::1"
+        expanded = "2001:0db8:0000:0000:0000:0000:0000:0001"
+        token = "mixed-form-token"
+
+        cookie_value = _issued_cookie_value(token, compressed)
+
+        assert validate_pass_cookie(cookie_value, expanded) is True
+
+    def test_issued_expanded_validated_compressed(self):
+        """A cookie issued with the expanded form validates against the compressed form."""
+        compressed = "2001:db8::1"
+        expanded = "2001:0db8:0000:0000:0000:0000:0000:0001"
+        token = "mixed-form-token-2"
+
+        cookie_value = _issued_cookie_value(token, expanded)
+
+        assert validate_pass_cookie(cookie_value, compressed) is True
+
+    def test_wrong_ipv6_returns_false(self):
+        """Cookie issued for one IPv6 address does not validate for a different one."""
+        ip = "2001:db8::1"
+        other_ip = "2001:db8::2"
+        token = "some-ipv6-token"
+
+        cookie_value = _issued_cookie_value(token, ip)
+
+        assert validate_pass_cookie(cookie_value, other_ip) is False
+
+
+# ---------------------------------------------------------------------------
+# Tamper / expiry / malformed rejection
+# ---------------------------------------------------------------------------
+
+
+class TestPassCookieRejection:
+    def test_tampered_payload_returns_false(self):
+        """A cookie whose payload was altered after signing is rejected.
+
+        The signature was computed over the original IP; changing the IP in
+        the payload (while leaving the signature as-is) must not validate.
+        """
+        ip = "10.0.0.1"
+        token = "some-token"
+        cookie_value = _issued_cookie_value(token, ip)
+
+        prefix, signature = cookie_value.rsplit("|", 1)
+        version, tok, _original_ip, expiry = prefix.split("|", 3)
+        tampered_prefix = "|".join([version, tok, "10.0.0.99", expiry])
+        tampered_cookie = f"{tampered_prefix}|{signature}"
+
+        assert validate_pass_cookie(tampered_cookie, ip) is False
+        assert validate_pass_cookie(tampered_cookie, "10.0.0.99") is False
+
+    def test_tampered_signature_returns_false(self):
+        """A cookie with a modified signature is rejected."""
+        future_ts = int(time.time()) + 3600
+        bad_cookie = f"v2|some-token|10.0.0.1|{future_ts}|invalidsignature"
+
+        assert validate_pass_cookie(bad_cookie, "10.0.0.1") is False
+
+    def test_tampered_signature_returns_false_ipv6(self):
+        """A cookie with a modified signature is rejected for an IPv6 payload too.
+
+        This is the shape that previously slipped through undetected: the
+        signature check on the old format never ran because the parse step
+        after it raised first (GH #26).
+        """
+        future_ts = int(time.time()) + 3600
+        bad_cookie = f"v2|some-token|2001:db8::1|{future_ts}|invalidsignature"
+
+        assert validate_pass_cookie(bad_cookie, "2001:db8::1") is False
+
+    def test_expired_cookie_returns_false(self):
+        """A cookie with a past expiry timestamp is rejected, even with a valid signature."""
+        ip = "10.0.0.1"
+        token = "some-token"
+        expired_ts = int(time.time()) - 1
+
+        value_prefix = f"v2|{token}|{ip}|{expired_ts}"
+        sig = _hmac_sign(value_prefix)
+        bad_cookie = f"{value_prefix}|{sig}"
+
+        assert validate_pass_cookie(bad_cookie, ip) is False
+
+    def test_expired_cookie_returns_false_ipv6(self):
+        """A cookie with a past expiry timestamp is rejected for an IPv6 payload."""
+        ip = "2001:db8::1"
+        token = "some-token"
+        expired_ts = int(time.time()) - 1
+
+        value_prefix = f"v2|{token}|{ip}|{expired_ts}"
+        sig = _hmac_sign(value_prefix)
+        bad_cookie = f"{value_prefix}|{sig}"
+
+        assert validate_pass_cookie(bad_cookie, ip) is False
+
+    def test_ip_mismatch_returns_false(self):
+        """A validly signed, unexpired cookie is still rejected if the requesting IP differs."""
+        ip = "10.0.0.1"
+        token = "some-token"
+        future_ts = int(time.time()) + 3600
+
+        value_prefix = f"v2|{token}|{ip}|{future_ts}"
+        sig = _hmac_sign(value_prefix)
+        cookie_value = f"{value_prefix}|{sig}"
+
+        assert validate_pass_cookie(cookie_value, "10.0.0.2") is False
+
+    def test_malformed_cookie_returns_false(self):
+        """A cookie with the wrong shape is gracefully rejected, not raised."""
+        assert validate_pass_cookie("", "1.2.3.4") is False
+        assert validate_pass_cookie("notacookie", "1.2.3.4") is False
+        assert validate_pass_cookie("a|b", "1.2.3.4") is False
+
+    def test_old_colon_format_cookie_is_rejected(self):
+        """A cookie issued by the pre-fix colon-joined format fails validation.
+
+        No legacy parsing is added (see the module docstring): a client
+        holding an old-format cookie simply re-solves the challenge once
+        after upgrade rather than being silently trusted or crashing.
+        """
+        future_ts = int(time.time()) + 3600
+        old_format_prefix = f"some-token:10.0.0.1:{future_ts}"
+        old_format_sig = _hmac_sign(old_format_prefix)
+        old_cookie = f"{old_format_prefix}:{old_format_sig}"
+
+        assert validate_pass_cookie(old_cookie, "10.0.0.1") is False
+
+    def test_old_colon_format_cookie_is_rejected_ipv6(self):
+        """An old-format cookie for an IPv6 client also fails cleanly rather than mis-parsing.
+
+        This is the exact GH #26 failure mode: ``split(":", 2)`` on an IPv6
+        address produces more than 3 parts, so the un-fixed code raised
+        ValueError parsing the expiry and (before the try/except) could
+        return an incorrect result. The fixed parser must reject this
+        outright via the version tag, not attempt to interpret it.
+        """
+        future_ts = int(time.time()) + 3600
+        old_format_prefix = f"some-token:2001:db8::1:{future_ts}"
+        old_format_sig = _hmac_sign(old_format_prefix)
+        old_cookie = f"{old_format_prefix}:{old_format_sig}"
+
+        assert validate_pass_cookie(old_cookie, "2001:db8::1") is False
+
+
+# ---------------------------------------------------------------------------
+# issue_pass_cookie cookie attributes
+# ---------------------------------------------------------------------------
+
+
+class TestIssuePassCookieAttributes:
+    def test_sets_cookie_with_expected_attributes(self):
+        """issue_pass_cookie calls response.set_cookie with the expected flags."""
+        import django_waf.conf as conf_mod
+
+        response = MagicMock()
+
+        with patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_COOKIE_TTL", 86400):
+            issue_pass_cookie(response, "my-token", "10.0.0.1", secure=True)
+
+        response.set_cookie.assert_called_once()
+        call_kwargs = response.set_cookie.call_args
+        assert call_kwargs.args[0] == "waf_pass"
+        assert call_kwargs.kwargs.get("httponly") is True
+        assert call_kwargs.kwargs.get("samesite") == "Lax"
+        assert call_kwargs.kwargs.get("secure") is True
+
+    def test_sets_cookie_for_ipv6_client(self):
+        """issue_pass_cookie works unchanged for an IPv6 client IP."""
+        import django_waf.conf as conf_mod
+
+        response = MagicMock()
+
+        with patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_COOKIE_TTL", 86400):
+            issue_pass_cookie(response, "my-token", "2001:db8::1", secure=True)
+
+        response.set_cookie.assert_called_once()
+        call_kwargs = response.set_cookie.call_args
+        assert call_kwargs.args[0] == "waf_pass"
+        cookie_value = call_kwargs.args[1]
+        assert cookie_value.startswith("v2|my-token|2001:db8::1|")
+
+
+# ---------------------------------------------------------------------------
+# Middleware integration: a solved IPv6 client's cookie bypasses evaluation
+# ---------------------------------------------------------------------------
+
+
+def _make_middleware(get_response=None):
+    """Instantiate WafMiddleware with a trivial get_response (matches test_middleware.py)."""
+    from django_waf.middleware import WafMiddleware
+
+    if get_response is None:
+        get_response = lambda req: HttpResponse("ok")  # noqa: E731
+    return WafMiddleware(get_response)
+
+
+def _mock_redis():
+    """Return a MagicMock that behaves like a basic Redis client (matches test_middleware.py)."""
+    redis = MagicMock()
+    redis.get.return_value = None
+    return redis
+
+
+class TestMiddlewareIPv6PassCookie:
+    """A solved IPv6 client's real waf_pass cookie bypasses evaluation on later requests.
+
+    Unlike tests/test_middleware.py's TestWafPassCookie, this does not mock
+    validate_pass_cookie: it issues a real cookie via issue_pass_cookie and
+    feeds it back through the middleware as an IPv6 client would send it,
+    proving the fix end-to-end rather than at the unit level only.
+    """
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_solved_ipv6_client_cookie_bypasses_evaluation(self):
+        import importlib
+
+        import django_waf.conf as conf_mod
+
+        importlib.reload(conf_mod)
+
+        ip = "2001:db8::1"
+        cookie_value = _issued_cookie_value("ipv6-client-token", ip, secure=False)
+
+        factory = RequestFactory()
+        request = factory.get("/page/", REMOTE_ADDR=ip)
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {"waf_pass": cookie_value}
+        get_response = MagicMock(return_value=HttpResponse("ok"))
+        middleware = _make_middleware(get_response)
+
+        with (
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+
+            response = middleware(request)
+
+        # The cookie must short-circuit evaluation entirely: get_response is
+        # called directly and evaluate_request is never reached.
+        get_response.assert_called_once_with(request)
+        mock_eval.assert_not_called()
+        assert response.status_code == 200
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_solved_ipv6_client_cookie_rejected_for_different_ip(self):
+        """A pass cookie issued to one IPv6 client does not bypass evaluation for another."""
+        import importlib
+
+        import django_waf.conf as conf_mod
+
+        importlib.reload(conf_mod)
+
+        issued_ip = "2001:db8::1"
+        requesting_ip = "2001:db8::2"
+        cookie_value = _issued_cookie_value("ipv6-client-token", issued_ip, secure=False)
+
+        factory = RequestFactory()
+        request = factory.get("/page/", REMOTE_ADDR=requesting_ip)
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {"waf_pass": cookie_value}
+
+        with (
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_eval.return_value = MagicMock(
+                verdict="allowed",
+                matched_rule_id=None,
+                matched_rule_type="",
+                anomaly_score=None,
+                action=None,
+            )
+
+            middleware = _make_middleware()
+            middleware(request)
+
+        # Cookie is for a different IP, so evaluation must still run.
+        mock_eval.assert_called_once()

--- a/tests/test_rdns_fcrdns.py
+++ b/tests/test_rdns_fcrdns.py
@@ -28,6 +28,7 @@ pre-existing _verify_rdns tests there used).
 from __future__ import annotations
 
 import socket
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -45,6 +46,13 @@ def _make_redis() -> MagicMock:
     redis.delete.return_value = 1
     redis.incr.return_value = 1
     redis.zcount.return_value = 0
+    # Configure the rate-limiter pipeline shape (see test_retry_after.py)
+    # so an AllowRule miss that falls through to check_rate_limit doesn't
+    # hit a bare, unconfigured MagicMock at `count > threshold`.
+    now = time.time()
+    pipeline = MagicMock()
+    pipeline.execute.return_value = [1, 0, 1, [(str(now), now)], True]
+    redis.pipeline.return_value = pipeline
     return redis
 
 

--- a/tests/test_rdns_fcrdns.py
+++ b/tests/test_rdns_fcrdns.py
@@ -1,0 +1,373 @@
+"""Tests for forward-confirmed reverse DNS (FCrDNS) verified crawler allows (#34).
+
+Prior to this fix, ``_verify_rdns`` did a bare PTR (reverse-DNS) lookup and
+matched the resolved hostname against ``rdns_pattern`` — no forward lookup
+anywhere. An attacker who controls the PTR record of their own IP (any cloud
+VM with settable rDNS) could set a PTR record like
+``fake-crawler.googlebot.com`` and pass the check without being Google at
+all, since nothing confirmed that Google's DNS zone (the *forward* record)
+actually points back at that IP.
+
+The fix forward-resolves the PTR hostname after a pattern match and requires
+the original IP to appear among the forward-resolved addresses (both IPv4
+and IPv6 families via ``socket.getaddrinfo``). Any DNS error — reverse or
+forward — fails closed. The final verified verdict is cached per (ip,
+rdns_pattern): 24 hours for a positive verification, a short
+DJANGO_WAF_RDNS_FAILURE_CACHE_TTL (default 300s) for a negative one, so a
+transient resolver outage does not suppress a legitimate crawler's
+AllowRule match for a full day per IP.
+
+This file focuses on end-to-end/integration-flavoured scenarios (spoofed
+PTR denial, genuine FCrDNS allow via evaluate_request, IPv4 and IPv6
+address families, and the differentiated cache TTLs). Function-level unit
+coverage of ``_verify_rdns`` and ``_resolve_and_confirm_rdns`` lives in
+tests/test_services.py::TestVerifyRdns (mocking pattern matches what the
+pre-existing _verify_rdns tests there used).
+"""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from django_waf.enums import RuleType, Verdict
+from django_waf.services.rule_engine import _fcrdns_cache_key, _resolve_and_confirm_rdns, _verify_rdns, evaluate_request
+from django_waf.testing.factories import AllowRuleFactory
+
+
+def _make_redis() -> MagicMock:
+    redis = MagicMock()
+    redis.get.return_value = None
+    redis.set.return_value = True
+    redis.setex.return_value = True
+    redis.delete.return_value = 1
+    redis.incr.return_value = 1
+    redis.zcount.return_value = 0
+    return redis
+
+
+# ---------------------------------------------------------------------------
+# Spoofed PTR denial vs genuine FCrDNS allow
+# ---------------------------------------------------------------------------
+
+
+class TestSpoofedVsGenuineFCrDNS:
+    def test_spoofed_ptr_suffix_matches_but_forward_resolves_elsewhere_is_denied(self):
+        """An attacker-controlled PTR record that happens to match the
+        pattern suffix is denied when the hostname's forward resolution
+        does not include the attacker's own IP — they control the PTR of
+        their IP, but not example.com's DNS zone."""
+        redis = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("attacker-owned.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                # Forward resolution of the spoofed hostname points at
+                # Google's real infrastructure, not the attacker's IP.
+                return_value=[(socket.AF_INET, 1, 6, "", ("66.249.66.1", 0))],
+            ),
+        ):
+            result = _verify_rdns("198.51.100.7", r"\.googlebot\.com$", redis)
+
+        assert result is False
+
+    def test_genuine_fcrdns_forward_set_contains_the_ip_is_allowed(self):
+        """A real crawler IP: PTR matches the pattern AND the hostname's
+        forward resolution includes that same IP among (possibly several)
+        addresses."""
+        redis = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl-66-249-66-1.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[
+                    (socket.AF_INET, 1, 6, "", ("66.249.66.2", 0)),
+                    (socket.AF_INET, 1, 6, "", ("66.249.66.1", 0)),  # the original IP, among others
+                ],
+            ),
+        ):
+            result = _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis)
+
+        assert result is True
+
+
+# ---------------------------------------------------------------------------
+# IPv4 and IPv6
+# ---------------------------------------------------------------------------
+
+
+class TestAddressFamilies:
+    def test_ipv4_forward_confirmation(self):
+        redis = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(socket.AF_INET, 1, 6, "", ("66.249.66.1", 0))],
+            ),
+        ):
+            assert _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis) is True
+
+    def test_ipv6_forward_confirmation(self):
+        """getaddrinfo's IPv6 sockaddr tuple is (address, port, flowinfo,
+        scope_id) — address is still element 0 of the sockaddr, which is
+        info[4][0], same as IPv4."""
+        redis = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(socket.AF_INET6, 1, 6, "", ("2001:4860:4801:10::64", 0, 0, 0))],
+            ),
+        ):
+            assert _verify_rdns("2001:4860:4801:10::64", r"\.googlebot\.com$", redis) is True
+
+    def test_ipv6_forward_mismatch_is_denied(self):
+        redis = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("spoofed.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(socket.AF_INET6, 1, 6, "", ("2001:4860:4801:10::99", 0, 0, 0))],
+            ),
+        ):
+            assert _verify_rdns("2001:4860:4801:10::64", r"\.googlebot\.com$", redis) is False
+
+    def test_mixed_ipv4_and_ipv6_forward_results_confirms_ipv4_target(self):
+        """A hostname that forward-resolves to both address families
+        confirms correctly against an IPv4 target IP."""
+        redis = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[
+                    (socket.AF_INET6, 1, 6, "", ("2001:4860:4801:10::64", 0, 0, 0)),
+                    (socket.AF_INET, 1, 6, "", ("66.249.66.1", 0)),
+                ],
+            ),
+        ):
+            assert _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis) is True
+
+
+# ---------------------------------------------------------------------------
+# Both failure modes fail closed
+# ---------------------------------------------------------------------------
+
+
+class TestFailsClosedOnEitherDnsFailure:
+    def test_reverse_dns_failure_fails_closed(self):
+        redis = _make_redis()
+
+        with patch(
+            "django_waf.services.rule_engine.socket.gethostbyaddr",
+            side_effect=socket.herror("no PTR record"),
+        ):
+            assert _verify_rdns("203.0.113.5", r"\.googlebot\.com$", redis) is False
+
+    def test_forward_dns_failure_fails_closed_even_after_ptr_match(self):
+        """The PTR hostname matches the pattern, but the forward lookup
+        itself raises — must still deny, not fall back to trusting the PTR."""
+        redis = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                side_effect=socket.gaierror("resolver timeout"),
+            ),
+        ):
+            assert _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis) is False
+
+    def test_resolve_and_confirm_helper_fails_closed_on_generic_os_error(self):
+        """Non-DNS-specific OSError subclasses on the reverse lookup also fail closed."""
+        with patch(
+            "django_waf.services.rule_engine.socket.gethostbyaddr",
+            side_effect=OSError("network unreachable"),
+        ):
+            assert _resolve_and_confirm_rdns("203.0.113.5", r"\.googlebot\.com$") is False
+
+
+# ---------------------------------------------------------------------------
+# Cache TTL differentiation: 24h positive, short negative
+# ---------------------------------------------------------------------------
+
+
+class TestCacheTtlDifferentiation:
+    def test_positive_result_cached_for_24_hours(self):
+        redis = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(socket.AF_INET, 1, 6, "", ("66.249.66.1", 0))],
+            ),
+        ):
+            _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis)
+
+        redis.setex.assert_called_once()
+        cache_key, ttl, value = redis.setex.call_args.args
+        assert ttl == 86400
+        assert value == "1"
+        assert cache_key == _fcrdns_cache_key("66.249.66.1", r"\.googlebot\.com$")
+
+    def test_negative_result_cached_with_configured_failure_ttl(self):
+        redis = _make_redis()
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_RDNS_FAILURE_CACHE_TTL", 120),
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("attacker.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(socket.AF_INET, 1, 6, "", ("9.9.9.9", 0))],
+            ),
+        ):
+            _verify_rdns("198.51.100.7", r"\.googlebot\.com$", redis)
+
+        redis.setex.assert_called_once()
+        _cache_key, ttl, value = redis.setex.call_args.args
+        assert ttl == 120
+        assert value == "0"
+
+    def test_dns_failure_result_also_cached_with_short_ttl_not_24h(self):
+        """A DNS error (not just a pattern/forward mismatch) is a negative
+        verdict too, and must not get the 24-hour positive TTL — otherwise
+        a transient resolver outage would suppress a legitimate crawler's
+        AllowRule match for a full day per IP."""
+        redis = _make_redis()
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_RDNS_FAILURE_CACHE_TTL", 300),
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                side_effect=socket.herror("resolver down"),
+            ),
+        ):
+            _verify_rdns("203.0.113.5", r"\.googlebot\.com$", redis)
+
+        redis.setex.assert_called_once()
+        _cache_key, ttl, value = redis.setex.call_args.args
+        assert ttl == 300
+        assert value == "0"
+
+    def test_different_patterns_for_same_ip_cache_independently(self):
+        """The cache key includes the pattern, so checking the same IP
+        against two different AllowRule patterns doesn't collide."""
+        key_a = _fcrdns_cache_key("1.2.3.4", r"\.googlebot\.com$")
+        key_b = _fcrdns_cache_key("1.2.3.4", r"\.search\.msn\.com$")
+
+        assert key_a != key_b
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via evaluate_request
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestEvaluateRequestFCrDNSEndToEnd:
+    def test_spoofed_crawler_ua_with_non_confirming_ptr_does_not_bypass(self):
+        """A spoofed Googlebot UA from an IP whose PTR happens to match the
+        suffix, but whose forward resolution does not confirm the IP, must
+        not be granted the AllowRule's PASSED verdict."""
+        AllowRuleFactory(
+            rule_type=RuleType.UA,
+            match_type="regex",
+            pattern="Googlebot",
+            verify_rdns=True,
+            rdns_pattern=r"\.googlebot\.com$|\.google\.com$",
+            is_active=True,
+        )
+
+        redis_client = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("attacker-controlled.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(socket.AF_INET, 1, 6, "", ("8.8.8.8", 0))],  # not the attacker's IP
+            ),
+        ):
+            result = evaluate_request(
+                ip_address="198.51.100.7",
+                user_agent="Googlebot/2.1 (+http://www.google.com/bot.html)",
+                path="/",
+                method="GET",
+                redis_client=redis_client,
+            )
+
+        assert result.verdict != Verdict.PASSED
+
+    def test_genuine_crawler_with_confirming_ptr_bypasses_via_allow_rule(self):
+        """A genuine Googlebot request whose PTR both matches the pattern
+        and forward-confirms is granted PASSED via the AllowRule."""
+        AllowRuleFactory(
+            rule_type=RuleType.UA,
+            match_type="regex",
+            pattern="Googlebot",
+            verify_rdns=True,
+            rdns_pattern=r"\.googlebot\.com$|\.google\.com$",
+            is_active=True,
+        )
+
+        redis_client = _make_redis()
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl-66-249-66-1.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(socket.AF_INET, 1, 6, "", ("66.249.66.1", 0))],
+            ),
+        ):
+            result = evaluate_request(
+                ip_address="66.249.66.1",
+                user_agent="Googlebot/2.1 (+http://www.google.com/bot.html)",
+                path="/",
+                method="GET",
+                redis_client=redis_client,
+            )
+
+        assert result.verdict == Verdict.PASSED
+        assert result.matched_rule_type == "allow"

--- a/tests/test_retry_after.py
+++ b/tests/test_retry_after.py
@@ -1,0 +1,280 @@
+"""Tests for accurate Retry-After from sliding-window rate limiting (#30).
+
+Previously ``retry_after = window_seconds - (now - cutoff)`` where
+``cutoff = now - window_seconds`` algebraically collapses to a constant
+``0`` every time, so ``max(1, 0)`` always sent a fixed 1 second internally
+and the middleware sent a fixed 60-second header regardless of real state
+(EvaluationResult had no retry_after field at all, so
+``hasattr(result, "retry_after")`` was always False on the real NamedTuple
+too — a double bug).
+
+The fix makes the sliding-window limiter return
+``oldest_event_in_window + window_seconds - now``: the real number of
+seconds until the window's oldest counted event ages out, computed via a
+``ZRANGE(0, 0, withscores=True)`` in the same Redis pipeline (atomic with
+the ZADD/ZREMRANGEBYSCORE/ZCARD it already ran). ``EvaluationResult`` now
+carries a ``retry_after`` field populated on THROTTLED verdicts, and the
+middleware sends that value instead of a fixed fallback.
+
+Redis is not available in the test environment; all Redis calls are mocked
+using unittest.mock, matching the pattern in test_services.py.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.http import HttpResponse
+from django.test import RequestFactory
+
+from django_waf.enums import RuleAction, Verdict
+from django_waf.services.rate_limiter import RateLimitResult, _retry_after_from_oldest, check_rate_limit
+from django_waf.services.rule_engine import EvaluationResult
+
+
+def _make_redis() -> MagicMock:
+    redis = MagicMock()
+    redis.get.return_value = None
+    redis.set.return_value = True
+    redis.setex.return_value = True
+    redis.delete.return_value = 1
+    redis.incr.return_value = 1
+    redis.zcount.return_value = 0
+    return redis
+
+
+# ---------------------------------------------------------------------------
+# _retry_after_from_oldest — pure maths, no Redis
+# ---------------------------------------------------------------------------
+
+
+class TestRetryAfterFromOldest:
+    def test_computes_seconds_until_oldest_event_ages_out(self):
+        """retry_after is oldest_timestamp + window_seconds - now, not a constant."""
+        now = 1_000_000.0
+        oldest_timestamp = now - 45  # added 45 seconds ago
+        window_seconds = 60
+
+        retry_after = _retry_after_from_oldest([(str(oldest_timestamp), oldest_timestamp)], window_seconds, now)
+
+        # Ages out at oldest_timestamp + 60 = now + 15
+        assert retry_after == 15
+
+    def test_freshly_added_event_gives_nearly_full_window(self):
+        """An event added right now must retry after ~the full window, not 1 second."""
+        now = 1_000_000.0
+
+        retry_after = _retry_after_from_oldest([(str(now), now)], 60, now)
+
+        assert retry_after == 60
+
+    def test_floors_at_one_second(self):
+        """A window boundary computed as <=0 (clock skew, rounding) floors at 1."""
+        now = 1_000_000.0
+        oldest_timestamp = now - 61  # already past a 60s window
+
+        retry_after = _retry_after_from_oldest([(str(oldest_timestamp), oldest_timestamp)], 60, now)
+
+        assert retry_after == 1
+
+    def test_empty_oldest_falls_back_to_full_window(self):
+        """No ZRANGE result (should not happen with a real Redis, but a
+        stub might) falls back to the full window rather than raising."""
+        retry_after = _retry_after_from_oldest([], 60, time.time())
+
+        assert retry_after == 60
+
+
+# ---------------------------------------------------------------------------
+# check_rate_limit — concrete Retry-After values via the pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRateLimitConcreteRetryAfter:
+    def test_global_window_retry_after_matches_oldest_event_age(self):
+        """When the 1s burst window is breached, retry_after reflects the
+        oldest surviving event's age, not a fixed 1."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        now = time.time()
+        oldest = now - 0.4  # added 0.4s ago, inside the 1s window
+
+        pipeline = MagicMock()
+        pipeline.execute.return_value = [1, 0, 6, [(str(oldest), oldest)], True]
+        redis.pipeline.return_value = pipeline
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_BURST", 5),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_MINUTE", 120),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_5MIN", 600),
+            patch("django_waf.services.rate_limiter.time.time", return_value=now),
+        ):
+            result = check_rate_limit("1.2.3.4", redis)
+
+        assert result.exceeded is True
+        assert result.window == "1s"
+        # Ages out at oldest + 1s = now + 0.6s → rounds down to 0? No: int()
+        # truncates toward zero, and 0 would violate the floor, so this
+        # must be at least 1.
+        assert result.retry_after >= 1
+        # The oldest event is 0.4s old in a 1s window, so ~0.6s remain —
+        # truncated to 0 by int(), then floored to 1. Assert the exact
+        # floored value to catch a regression to the old constant-0 maths.
+        assert result.retry_after == 1
+
+    def test_retry_after_scales_with_window_occupancy(self):
+        """A per-path window whose oldest event is fresher yields a longer
+        retry_after than one whose oldest event is stale — proving the
+        value tracks real occupancy rather than being a fixed constant."""
+        import django_waf.conf as conf_mod
+
+        now = 1_500_000_000.0
+        window_seconds = 60
+
+        def _run_with_oldest_age(age_seconds: float) -> int:
+            redis = _make_redis()
+            oldest = now - age_seconds
+            pipeline = MagicMock()
+            pipeline.execute.return_value = [1, 0, 11, [(str(oldest), oldest)], True]
+            redis.pipeline.return_value = pipeline
+
+            with (
+                patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (10, window_seconds)}),
+                patch("django_waf.services.rate_limiter.time.time", return_value=now),
+            ):
+                result = check_rate_limit("9.9.9.9", redis, path="/api/widgets/")
+            return result.retry_after
+
+        fresh_retry_after = _run_with_oldest_age(5)  # oldest event 5s old
+        stale_retry_after = _run_with_oldest_age(55)  # oldest event 55s old
+
+        assert fresh_retry_after == 55  # 60 - 5
+        assert stale_retry_after == 5  # 60 - 55
+        assert fresh_retry_after > stale_retry_after
+
+
+# ---------------------------------------------------------------------------
+# EvaluationResult.retry_after — populated on THROTTLED, absent elsewhere
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestEvaluationResultRetryAfter:
+    def test_throttled_verdict_carries_rate_limiter_retry_after(self):
+        from django_waf.services.rule_engine import evaluate_request
+
+        redis = _make_redis()
+        with patch(
+            "django_waf.services.rate_limiter.check_rate_limit",
+            return_value=RateLimitResult(exceeded=True, window="1m", retry_after=37),
+        ):
+            result = evaluate_request(
+                ip_address="16.16.16.16",
+                user_agent="Mozilla/5.0",
+                path="/",
+                method="GET",
+                redis_client=redis,
+            )
+
+        assert result.verdict == Verdict.THROTTLED
+        assert result.retry_after == 37
+
+    def test_non_throttled_verdict_has_no_retry_after(self):
+        """Every other verdict path leaves retry_after at its None default."""
+        redis = _make_redis()
+        pipeline = MagicMock()
+        now = time.time()
+        pipeline.execute.return_value = [1, 0, 1, [(str(now), now)], True]
+        redis.pipeline.return_value = pipeline
+        redis.zcount.return_value = 5
+
+        from django_waf.services.rule_engine import evaluate_request
+
+        result = evaluate_request(
+            ip_address="17.17.17.17",
+            user_agent="Mozilla/5.0",
+            path="/",
+            method="GET",
+            redis_client=redis,
+        )
+
+        assert result.verdict == Verdict.ALLOWED
+        assert result.retry_after is None
+
+    def test_evaluation_result_default_retry_after_is_none(self):
+        """Construction sites that predate #30 (positional/keyword without
+        retry_after) still work, defaulting to None."""
+        result = EvaluationResult(
+            verdict=Verdict.BLOCKED,
+            action=RuleAction.BLOCK,
+            matched_rule_id=None,
+            matched_rule_type="",
+            anomaly_score=None,
+        )
+
+        assert result.retry_after is None
+
+
+# ---------------------------------------------------------------------------
+# Middleware — sends the real Retry-After header, not a fixed fallback
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareSendsAccurateRetryAfter:
+    def _run_with_result(self, result: EvaluationResult) -> HttpResponse:
+        from django_waf.middleware import WafMiddleware
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("view response"))
+
+        with (
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+            patch("django_waf.middleware._emit_request_throttled"),
+        ):
+            mock_redis_fn.return_value = _make_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = result
+
+            middleware = WafMiddleware(get_response)
+            with patch("django_waf.conf.DJANGO_WAF_ENABLED", True):
+                response = middleware(request)
+
+        return response
+
+    def test_sends_real_retry_after_value(self):
+        result = EvaluationResult(
+            verdict=Verdict.THROTTLED,
+            action=RuleAction.THROTTLE,
+            matched_rule_id=None,
+            matched_rule_type="",
+            anomaly_score=None,
+            retry_after=23,
+        )
+
+        response = self._run_with_result(result)
+
+        assert response.status_code == 429
+        assert response["Retry-After"] == "23"
+
+    def test_falls_back_to_60_when_retry_after_is_none(self):
+        result = EvaluationResult(
+            verdict=Verdict.THROTTLED,
+            action=RuleAction.THROTTLE,
+            matched_rule_id=None,
+            matched_rule_type="",
+            anomaly_score=None,
+            retry_after=None,
+        )
+
+        response = self._run_with_result(result)
+
+        assert response.status_code == 429
+        assert response["Retry-After"] == "60"

--- a/tests/test_rule_expiry.py
+++ b/tests/test_rule_expiry.py
@@ -14,6 +14,7 @@ using unittest.mock, matching the pattern in test_services.py and test_tasks.py.
 
 from __future__ import annotations
 
+import time
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
@@ -39,9 +40,15 @@ def _make_redis() -> MagicMock:
 
 
 def _make_pipeline_mock(zcard_return: int) -> MagicMock:
-    """Return a pipeline mock whose execute() result has zcard_return at index 2."""
+    """Return a pipeline mock for [zadd, zremrangebyscore, zcard, zrange, expire].
+
+    Matches the 5-command pipeline shape rate_limiter.py builds since #30
+    (see tests/test_retry_after.py) — zcard_return sits at index 2, and a
+    single (member, score) zrange result sits at index 3.
+    """
     pipeline = MagicMock()
-    pipeline.execute.return_value = [1, 0, zcard_return, True]
+    now = time.time()
+    pipeline.execute.return_value = [1, 0, zcard_return, [(str(now), now)], True]
     return pipeline
 
 

--- a/tests/test_rule_expiry.py
+++ b/tests/test_rule_expiry.py
@@ -1,0 +1,348 @@
+"""Tests for rule expiry enforcement (#25).
+
+Covers three layers:
+  - Manager querysets (BlockRuleManager.active/expired, AllowRuleManager.active/expired)
+    exclude/include passed expires_at correctly.
+  - Rule-cache evaluation (_check_block_rules/_check_allow_rules) rejects an
+    expired rule even when served from a cache built before the rule expired.
+  - The expire_rules task deactivates both BlockRules and AllowRules and
+    invalidates the rule cache.
+
+Redis is not available in the test environment; all Redis calls are mocked
+using unittest.mock, matching the pattern in test_services.py and test_tasks.py.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.utils import timezone
+
+from django_waf.enums import RuleAction, RuleType, Verdict
+from django_waf.models import AllowRule, BlockRule
+from django_waf.services.rule_engine import RuleCache, _check_allow_rules, _check_block_rules, evaluate_request
+from django_waf.testing.factories import AllowRuleFactory, BlockRuleFactory
+
+
+def _make_redis() -> MagicMock:
+    """Return a MagicMock configured as a minimal Redis client."""
+    redis = MagicMock()
+    redis.get.return_value = None
+    redis.set.return_value = True
+    redis.setex.return_value = True
+    redis.delete.return_value = 1
+    redis.incr.return_value = 1
+    redis.zcount.return_value = 0
+    return redis
+
+
+def _make_pipeline_mock(zcard_return: int) -> MagicMock:
+    """Return a pipeline mock whose execute() result has zcard_return at index 2."""
+    pipeline = MagicMock()
+    pipeline.execute.return_value = [1, 0, zcard_return, True]
+    return pipeline
+
+
+# ---------------------------------------------------------------------------
+# BlockRuleManager.active() / .expired()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestBlockRuleManagerExpiry:
+    def test_active_excludes_expired_rule(self):
+        """An active=True BlockRule with a passed expires_at is excluded from .active()."""
+        BlockRuleFactory(is_active=True, expires_at=timezone.now() - timedelta(hours=1))
+
+        assert BlockRule.objects.active().count() == 0
+
+    def test_active_includes_rule_with_no_expiry(self):
+        """A BlockRule with expires_at=None is never excluded by expiry."""
+        rule = BlockRuleFactory(is_active=True, expires_at=None)
+
+        assert list(BlockRule.objects.active()) == [rule]
+
+    def test_active_includes_rule_with_future_expiry(self):
+        """A BlockRule whose expires_at is still in the future remains active."""
+        rule = BlockRuleFactory(is_active=True, expires_at=timezone.now() + timedelta(days=1))
+
+        assert list(BlockRule.objects.active()) == [rule]
+
+    def test_expired_returns_only_passed_expiry(self):
+        """.expired() returns only active rules whose expires_at has passed."""
+        expired = BlockRuleFactory(is_active=True, expires_at=timezone.now() - timedelta(minutes=1))
+        BlockRuleFactory(is_active=True, expires_at=timezone.now() + timedelta(days=1))
+        BlockRuleFactory(is_active=True, expires_at=None)
+
+        assert list(BlockRule.objects.expired()) == [expired]
+
+
+# ---------------------------------------------------------------------------
+# AllowRuleManager.active() / .expired()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestAllowRuleManagerExpiry:
+    def test_active_excludes_expired_rule(self):
+        """An active=True AllowRule with a passed expires_at is excluded from .active()."""
+        AllowRuleFactory(is_active=True, expires_at=timezone.now() - timedelta(hours=1))
+
+        assert AllowRule.objects.active().count() == 0
+
+    def test_active_includes_rule_with_no_expiry(self):
+        """An AllowRule with expires_at=None is never excluded by expiry."""
+        rule = AllowRuleFactory(is_active=True, expires_at=None)
+
+        assert list(AllowRule.objects.active()) == [rule]
+
+    def test_active_includes_rule_with_future_expiry(self):
+        """An AllowRule whose expires_at is still in the future remains active."""
+        rule = AllowRuleFactory(is_active=True, expires_at=timezone.now() + timedelta(days=1))
+
+        assert list(AllowRule.objects.active()) == [rule]
+
+    def test_expired_returns_only_passed_expiry(self):
+        """.expired() returns only active AllowRules whose expires_at has passed."""
+        expired = AllowRuleFactory(is_active=True, expires_at=timezone.now() - timedelta(minutes=1))
+        AllowRuleFactory(is_active=True, expires_at=timezone.now() + timedelta(days=1))
+        AllowRuleFactory(is_active=True, expires_at=None)
+
+        assert list(AllowRule.objects.expired()) == [expired]
+
+    def test_inactive_expired_rule_not_returned(self):
+        """.expired() only returns rules that are still is_active=True."""
+        AllowRuleFactory(is_active=False, expires_at=timezone.now() - timedelta(hours=1))
+
+        assert AllowRule.objects.expired().count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Cache-level enforcement — a rule that expired after the cache was built
+# must never match, even without a cache rebuild (#25).
+# ---------------------------------------------------------------------------
+
+
+class TestExpiredRuleRejectedAtCacheEvaluation:
+    def test_expired_block_rule_in_stale_cache_does_not_match(self):
+        """A BlockRule cached before it expired is rejected at match time."""
+        expired_dict = {
+            "id": "00000000-0000-0000-0000-000000000010",
+            "rule_type": RuleType.IP,
+            "match_type": "exact",
+            "pattern": "9.9.9.9",
+            "action": RuleAction.BLOCK,
+            "priority": 100,
+            "expires_at": (timezone.now() - timedelta(minutes=5)).isoformat(),
+        }
+        cache = RuleCache(version=1, allow_rules=[], block_rules=[expired_dict], ua_regex_set=[])
+
+        result = _check_block_rules("9.9.9.9", "Mozilla/5.0", cache)
+
+        assert result is None
+
+    def test_non_expired_block_rule_in_cache_still_matches(self):
+        """A BlockRule with a future expires_at still matches normally."""
+        future_dict = {
+            "id": "00000000-0000-0000-0000-000000000011",
+            "rule_type": RuleType.IP,
+            "match_type": "exact",
+            "pattern": "9.9.9.8",
+            "action": RuleAction.BLOCK,
+            "priority": 100,
+            "expires_at": (timezone.now() + timedelta(hours=1)).isoformat(),
+        }
+        cache = RuleCache(version=1, allow_rules=[], block_rules=[future_dict], ua_regex_set=[])
+
+        result = _check_block_rules("9.9.9.8", "Mozilla/5.0", cache)
+
+        assert result is not None
+        assert result[0] == future_dict["id"]
+
+    def test_block_rule_without_expires_at_key_still_matches(self):
+        """A cached rule dict with no expires_at key (old cache payload) is never treated as expired."""
+        no_expiry_dict = {
+            "id": "00000000-0000-0000-0000-000000000012",
+            "rule_type": RuleType.IP,
+            "match_type": "exact",
+            "pattern": "9.9.9.7",
+            "action": RuleAction.BLOCK,
+            "priority": 100,
+        }
+        cache = RuleCache(version=1, allow_rules=[], block_rules=[no_expiry_dict], ua_regex_set=[])
+
+        result = _check_block_rules("9.9.9.7", "Mozilla/5.0", cache)
+
+        assert result is not None
+
+    def test_expired_allow_rule_in_stale_cache_does_not_match(self):
+        """An AllowRule cached before it expired is rejected at match time."""
+        expired_dict = {
+            "id": "00000000-0000-0000-0000-000000000020",
+            "rule_type": RuleType.IP,
+            "match_type": "exact",
+            "pattern": "8.8.8.8",
+            "verify_rdns": False,
+            "rdns_pattern": "",
+            "expires_at": (timezone.now() - timedelta(minutes=5)).isoformat(),
+        }
+        cache = RuleCache(version=1, allow_rules=[expired_dict], block_rules=[], ua_regex_set=[])
+        redis = _make_redis()
+
+        result = _check_allow_rules("8.8.8.8", "Mozilla/5.0", cache, redis)
+
+        assert result is None
+
+    def test_non_expired_allow_rule_in_cache_still_matches(self):
+        """An AllowRule with a future expires_at still matches normally."""
+        future_dict = {
+            "id": "00000000-0000-0000-0000-000000000021",
+            "rule_type": RuleType.IP,
+            "match_type": "exact",
+            "pattern": "8.8.8.7",
+            "verify_rdns": False,
+            "rdns_pattern": "",
+            "expires_at": (timezone.now() + timedelta(hours=1)).isoformat(),
+        }
+        cache = RuleCache(version=1, allow_rules=[future_dict], block_rules=[], ua_regex_set=[])
+        redis = _make_redis()
+
+        result = _check_allow_rules("8.8.8.7", "Mozilla/5.0", cache, redis)
+
+        assert result is not None
+        assert result[0] == future_dict["id"]
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via evaluate_request — an expired crawler AllowRule must not
+# bypass evaluation, and an expired BlockRule must not be enforced.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestEvaluateRequestExpiryEndToEnd:
+    def test_expired_allow_rule_does_not_bypass_evaluation(self):
+        """An expired AllowRule is excluded from the rebuilt cache, so the
+        request falls through to normal (allowed) evaluation rather than
+        an automatic PASSED verdict."""
+        AllowRuleFactory(
+            is_active=True,
+            rule_type=RuleType.IP,
+            match_type="exact",
+            pattern="7.7.7.7",
+            expires_at=timezone.now() - timedelta(hours=1),
+        )
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(1)
+        redis.zcount.return_value = 5
+
+        result = evaluate_request(
+            ip_address="7.7.7.7",
+            user_agent="Mozilla/5.0",
+            path="/",
+            method="GET",
+            redis_client=redis,
+        )
+
+        assert result.verdict != Verdict.PASSED
+
+    def test_expired_block_rule_does_not_block(self):
+        """An expired BlockRule is excluded from the rebuilt cache, so the
+        request is not blocked by it."""
+        BlockRuleFactory(
+            is_active=True,
+            rule_type=RuleType.IP,
+            match_type="exact",
+            pattern="6.6.6.6",
+            action=RuleAction.BLOCK,
+            expires_at=timezone.now() - timedelta(hours=1),
+        )
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(1)
+        redis.zcount.return_value = 5
+
+        result = evaluate_request(
+            ip_address="6.6.6.6",
+            user_agent="Mozilla/5.0",
+            path="/",
+            method="GET",
+            redis_client=redis,
+        )
+
+        assert result.verdict != Verdict.BLOCKED
+
+
+# ---------------------------------------------------------------------------
+# expire_rules task — deactivates both models, invalidates the cache.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestExpireRulesDeactivatesBothModels:
+    def test_deactivates_expired_block_and_allow_rules(self):
+        """expire_rules deactivates expired rows in both BlockRule and AllowRule."""
+        expired_block = BlockRuleFactory(is_active=True, expires_at=timezone.now() - timedelta(hours=1))
+        expired_allow = AllowRuleFactory(is_active=True, expires_at=timezone.now() - timedelta(hours=1))
+        active_block = BlockRuleFactory(is_active=True, expires_at=timezone.now() + timedelta(days=1))
+        active_allow = AllowRuleFactory(is_active=True, expires_at=None)
+
+        with patch("django_waf.tasks._invalidate_rule_cache_redis"):
+            from django_waf.tasks import expire_rules
+
+            result = expire_rules()
+
+        expired_block.refresh_from_db()
+        expired_allow.refresh_from_db()
+        active_block.refresh_from_db()
+        active_allow.refresh_from_db()
+
+        assert expired_block.is_active is False
+        assert expired_allow.is_active is False
+        assert active_block.is_active is True
+        assert active_allow.is_active is True
+        assert result["expired_block_count"] == 1
+        assert result["expired_allow_count"] == 1
+        assert result["expired_count"] == 2
+
+    def test_invalidates_cache_when_only_allow_rule_expires(self):
+        """Cache invalidation fires even when only an AllowRule (no BlockRule) expired."""
+        AllowRuleFactory(is_active=True, expires_at=timezone.now() - timedelta(minutes=1))
+
+        with patch("django_waf.tasks._invalidate_rule_cache_redis") as mock_inval:
+            from django_waf.tasks import expire_rules
+
+            expire_rules()
+
+        mock_inval.assert_called_once()
+
+    def test_no_invalidation_when_nothing_expired(self):
+        """Cache invalidation is skipped when neither model has an expired row."""
+        BlockRuleFactory(is_active=True, expires_at=None)
+        AllowRuleFactory(is_active=True, expires_at=None)
+
+        with patch("django_waf.tasks._invalidate_rule_cache_redis") as mock_inval:
+            from django_waf.tasks import expire_rules
+
+            result = expire_rules()
+
+        mock_inval.assert_not_called()
+        assert result["expired_count"] == 0
+
+    def test_non_expiring_rules_unaffected(self):
+        """Rules with expires_at=None are never touched by expire_rules."""
+        block = BlockRuleFactory(is_active=True, expires_at=None)
+        allow = AllowRuleFactory(is_active=True, expires_at=None)
+
+        with patch("django_waf.tasks._invalidate_rule_cache_redis"):
+            from django_waf.tasks import expire_rules
+
+            expire_rules()
+
+        block.refresh_from_db()
+        allow.refresh_from_db()
+        assert block.is_active is True
+        assert allow.is_active is True

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,8 +25,6 @@ from django_waf.services.challenge_service import (
     ChallengeInvalidError,
     ChallengeMismatchError,
     issue_challenge,
-    issue_pass_cookie,
-    validate_pass_cookie,
     verify_challenge_solution,
 )
 from django_waf.services.fingerprint import (
@@ -1355,95 +1352,10 @@ class TestVerifyChallengeService:
 
 # ---------------------------------------------------------------------------
 # validate_pass_cookie / issue_pass_cookie
+#
+# Covered in tests/test_pass_cookie.py, including the IPv6-safety fix for
+# GH #26 (the versioned "|"-delimited payload format).
 # ---------------------------------------------------------------------------
-
-
-class TestPassCookie:
-    def test_round_trip_valid(self):
-        """A cookie issued by issue_pass_cookie passes validate_pass_cookie."""
-        import django_waf.conf as conf_mod
-
-        ip = "10.0.0.1"
-        token = "abc123def456abc123def456abc123"
-
-        response = MagicMock()
-        cookie_value_captured = {}
-
-        def capture_cookie(name, value, **kwargs):
-            cookie_value_captured["value"] = value
-
-        response.set_cookie.side_effect = capture_cookie
-
-        with patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_COOKIE_TTL", 3600):
-            issue_pass_cookie(response, token, ip, secure=False)
-
-        assert cookie_value_captured["value"] is not None
-        assert validate_pass_cookie(cookie_value_captured["value"], ip) is True
-
-    def test_wrong_ip_returns_false(self):
-        """Cookie issued for one IP does not validate for a different IP."""
-        import django_waf.conf as conf_mod
-
-        ip = "10.0.0.1"
-        other_ip = "10.0.0.2"
-        token = "some-token-value"
-
-        response = MagicMock()
-        cookie_value_captured = {}
-
-        def capture_cookie(name, value, **kwargs):
-            cookie_value_captured["value"] = value
-
-        response.set_cookie.side_effect = capture_cookie
-
-        with patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_COOKIE_TTL", 3600):
-            issue_pass_cookie(response, token, ip, secure=False)
-
-        assert validate_pass_cookie(cookie_value_captured["value"], other_ip) is False
-
-    def test_tampered_signature_returns_false(self):
-        """A cookie with a modified signature is rejected."""
-        future_ts = int(time.time()) + 3600
-        # Construct a cookie value with a bogus signature
-        bad_cookie = f"some-token:10.0.0.1:{future_ts}:invalidsignature"
-
-        assert validate_pass_cookie(bad_cookie, "10.0.0.1") is False
-
-    def test_expired_cookie_returns_false(self):
-        """A cookie with a past expiry timestamp is rejected."""
-        from django_waf.services.challenge_service import _hmac_sign
-
-        ip = "10.0.0.1"
-        token = "some-token"
-        expired_ts = int(time.time()) - 1  # Already in the past
-
-        value_prefix = f"{token}:{ip}:{expired_ts}"
-        sig = _hmac_sign(value_prefix)
-        bad_cookie = f"{value_prefix}:{sig}"
-
-        assert validate_pass_cookie(bad_cookie, ip) is False
-
-    def test_malformed_cookie_returns_false(self):
-        """A cookie with wrong format is gracefully rejected."""
-        assert validate_pass_cookie("", "1.2.3.4") is False
-        assert validate_pass_cookie("notacookie", "1.2.3.4") is False
-        assert validate_pass_cookie("a:b", "1.2.3.4") is False
-
-    def test_issue_pass_cookie_sets_cookie_on_response(self):
-        """issue_pass_cookie calls response.set_cookie with correct parameters."""
-        import django_waf.conf as conf_mod
-
-        response = MagicMock()
-
-        with patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_COOKIE_TTL", 86400):
-            issue_pass_cookie(response, "my-token", "10.0.0.1", secure=True)
-
-        response.set_cookie.assert_called_once()
-        call_kwargs = response.set_cookie.call_args
-        assert call_kwargs.args[0] == "waf_pass"
-        assert call_kwargs.kwargs.get("httponly") is True
-        assert call_kwargs.kwargs.get("samesite") == "Lax"
-        assert call_kwargs.kwargs.get("secure") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -67,9 +68,17 @@ def _make_redis() -> MagicMock:
 
 
 def _make_pipeline_mock(zcard_return: int) -> MagicMock:
-    """Return a pipeline mock whose execute() result has zcard_return at index 2."""
+    """Return a pipeline mock for [zadd, zremrangebyscore, zcard, zrange, expire].
+
+    zcard_return sits at index 2, matching every existing call site. The
+    zrange(0, 0, withscores=True) result at index 3 is a single (member,
+    score) pair scored "now", enough for _retry_after_from_oldest to
+    compute a real value in tests that don't care about the exact number
+    (see test_retry_after.py for tests pinning an exact Retry-After value).
+    """
     pipeline = MagicMock()
-    pipeline.execute.return_value = [1, 0, zcard_return, True]
+    now = time.time()
+    pipeline.execute.return_value = [1, 0, zcard_return, [(str(now), now)], True]
     return pipeline
 
 
@@ -223,8 +232,17 @@ class TestCheckRateLimit:
     """
 
     def _pipeline_returning(self, zcard_value: int) -> MagicMock:
+        """Pipeline mock for [zadd, zremrangebyscore, zcard, zrange, expire].
+
+        The zrange(0, 0, withscores=True) result is a single (member, score)
+        pair with score=time.time() (i.e. "just added now") — enough for
+        _retry_after_from_oldest to compute a real value without pinning an
+        exact number (tests assert retry_after >= 1, not an exact value; the
+        exact-value assertions live in test_retry_after.py).
+        """
         pipeline = MagicMock()
-        pipeline.execute.return_value = [1, 0, zcard_value, True]
+        now = time.time()
+        pipeline.execute.return_value = [1, 0, zcard_value, [(str(now), now)], True]
         return pipeline
 
     def test_within_limits_returns_not_exceeded(self):
@@ -316,7 +334,8 @@ class TestCheckRateLimit:
 
         redis = _make_redis()
         pipeline = MagicMock()
-        pipeline.execute.return_value = [1, 0, 1, True]
+        now = time.time()
+        pipeline.execute.return_value = [1, 0, 1, [(str(now), now)], True]
         redis.pipeline.return_value = pipeline
 
         ip = "5.5.5.5"

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2978,35 +2978,76 @@ class TestReloadNginx:
 
 
 class TestVerifyRdns:
-    def test_returns_true_when_hostname_matches_pattern(self):
-        """_verify_rdns returns True when the resolved hostname matches the pattern."""
+    """_verify_rdns is forward-confirmed reverse DNS (FCrDNS) since #34 — see
+    tests/test_rdns_fcrdns.py for the full FCrDNS-specific coverage (spoofed
+    PTR denial, genuine FCrDNS allow, IPv4/IPv6, failure-cache TTLs). These
+    tests keep the lighter-weight "does the wiring still work" coverage in
+    this shared file."""
+
+    def test_returns_true_when_ptr_matches_and_forward_confirms(self):
+        """_verify_rdns returns True when the PTR hostname matches the pattern
+        AND the hostname forward-resolves back to the original IP."""
         from django_waf.services.rule_engine import _verify_rdns
 
         redis = _make_redis()
-        redis.get.return_value = None  # No cached value
+        redis.get.return_value = None  # No cached verdict
 
-        with patch(
-            "django_waf.services.rule_engine.socket.gethostbyaddr",
-            return_value=("crawl.googlebot.com", [], []),
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("66.249.66.1", 0))],
+            ),
         ):
             result = _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis)
 
         assert result is True
 
-    def test_returns_false_when_hostname_does_not_match(self):
-        """_verify_rdns returns False when the hostname does not match the pattern."""
+    def test_returns_false_when_hostname_does_not_match_pattern(self):
+        """A PTR hostname that doesn't match the pattern fails before any forward lookup."""
         from django_waf.services.rule_engine import _verify_rdns
 
         redis = _make_redis()
         redis.get.return_value = None
 
-        with patch("django_waf.services.rule_engine.socket.gethostbyaddr", return_value=("evil.example.com", [], [])):
+        with (
+            patch("django_waf.services.rule_engine.socket.gethostbyaddr", return_value=("evil.example.com", [], [])),
+            patch("django_waf.services.rule_engine.socket.getaddrinfo") as mock_forward,
+        ):
+            result = _verify_rdns("1.2.3.4", r"\.googlebot\.com$", redis)
+
+        assert result is False
+        mock_forward.assert_not_called()
+
+    def test_returns_false_when_forward_resolution_does_not_confirm(self):
+        """Spoofed PTR: the hostname matches the pattern, but forward
+        resolution of that hostname does not include the original IP —
+        the attacker controls the PTR record but not the pattern's DNS
+        zone (#34's core fix)."""
+        from django_waf.services.rule_engine import _verify_rdns
+
+        redis = _make_redis()
+        redis.get.return_value = None
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("spoofed.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("9.9.9.9", 0))],  # not the original IP
+            ),
+        ):
             result = _verify_rdns("1.2.3.4", r"\.googlebot\.com$", redis)
 
         assert result is False
 
-    def test_returns_false_on_dns_failure(self):
-        """_verify_rdns returns False when DNS lookup fails."""
+    def test_returns_false_on_reverse_dns_failure(self):
+        """_verify_rdns returns False when the reverse (PTR) lookup fails."""
         import socket
 
         from django_waf.services.rule_engine import _verify_rdns
@@ -3019,53 +3060,131 @@ class TestVerifyRdns:
 
         assert result is False
 
-    def test_uses_cached_hostname_from_redis(self):
-        """_verify_rdns uses the cached hostname from Redis without a DNS lookup."""
-        from django_waf.services.rule_engine import _verify_rdns
+    def test_returns_false_on_forward_dns_failure(self):
+        """_verify_rdns returns False when the forward lookup fails, even
+        though the PTR hostname matched the pattern (fails closed)."""
+        import socket
 
-        redis = _make_redis()
-        redis.get.return_value = b"crawl.googlebot.com"
-
-        with patch("django_waf.services.rule_engine.socket.gethostbyaddr") as mock_dns:
-            result = _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis)
-
-        mock_dns.assert_not_called()
-        assert result is True
-
-    def test_stores_resolved_hostname_in_redis(self):
-        """_verify_rdns caches the resolved hostname in Redis with a 24-hour TTL."""
         from django_waf.services.rule_engine import _verify_rdns
 
         redis = _make_redis()
         redis.get.return_value = None
 
-        with patch("django_waf.services.rule_engine.socket.gethostbyaddr", return_value=("host.example.com", [], [])):
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                side_effect=socket.gaierror,
+            ),
+        ):
+            result = _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis)
+
+        assert result is False
+
+    def test_uses_cached_positive_verdict_without_dns_lookup(self):
+        """_verify_rdns uses a cached positive verdict from Redis without
+        performing either DNS lookup."""
+        from django_waf.services.rule_engine import _verify_rdns
+
+        redis = _make_redis()
+        redis.get.return_value = b"1"
+
+        with (
+            patch("django_waf.services.rule_engine.socket.gethostbyaddr") as mock_reverse,
+            patch("django_waf.services.rule_engine.socket.getaddrinfo") as mock_forward,
+        ):
+            result = _verify_rdns("66.249.66.1", r"\.googlebot\.com$", redis)
+
+        mock_reverse.assert_not_called()
+        mock_forward.assert_not_called()
+        assert result is True
+
+    def test_uses_cached_negative_verdict_without_dns_lookup(self):
+        """A cached negative verdict ("0") also short-circuits both lookups."""
+        from django_waf.services.rule_engine import _verify_rdns
+
+        redis = _make_redis()
+        redis.get.return_value = b"0"
+
+        with patch("django_waf.services.rule_engine.socket.gethostbyaddr") as mock_reverse:
+            result = _verify_rdns("1.2.3.4", r"\.googlebot\.com$", redis)
+
+        mock_reverse.assert_not_called()
+        assert result is False
+
+    def test_stores_positive_verdict_with_24h_ttl(self):
+        """A successful FCrDNS verification is cached for 24 hours."""
+        from django_waf.services.rule_engine import _verify_rdns
+
+        redis = _make_redis()
+        redis.get.return_value = None
+
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("host.example.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("1.2.3.4", 0))],
+            ),
+        ):
             _verify_rdns("1.2.3.4", r"example\.com$", redis)
 
         assert redis.setex.called
         call_args = redis.setex.call_args
         assert call_args.args[1] == 86400  # 24-hour TTL
-        assert call_args.args[2] == "host.example.com"
+        assert call_args.args[2] == "1"
 
-    def test_returns_false_for_empty_cached_hostname(self):
-        """_verify_rdns returns False when the cached hostname is an empty string."""
+    def test_stores_negative_verdict_with_short_failure_ttl(self):
+        """A failed verification is cached with DJANGO_WAF_RDNS_FAILURE_CACHE_TTL,
+        not the 24-hour positive TTL."""
+        import django_waf.conf as conf_mod
         from django_waf.services.rule_engine import _verify_rdns
 
         redis = _make_redis()
-        redis.get.return_value = b""  # Cached empty hostname (prior DNS failure)
+        redis.get.return_value = None
 
-        result = _verify_rdns("1.2.3.4", r"\.googlebot\.com$", redis)
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_RDNS_FAILURE_CACHE_TTL", 300),
+            patch("django_waf.services.rule_engine.socket.gethostbyaddr", return_value=("evil.example.com", [], [])),
+        ):
+            _verify_rdns("1.2.3.4", r"\.googlebot\.com$", redis)
+
+        assert redis.setex.called
+        call_args = redis.setex.call_args
+        assert call_args.args[1] == 300
+        assert call_args.args[2] == "0"
+
+    def test_returns_false_for_empty_ptr_hostname(self):
+        """An empty PTR hostname (successful lookup, empty result) fails
+        before any forward lookup."""
+        from django_waf.services.rule_engine import _verify_rdns
+
+        redis = _make_redis()
+        redis.get.return_value = None
+
+        with (
+            patch("django_waf.services.rule_engine.socket.gethostbyaddr", return_value=("", [], [])),
+            patch("django_waf.services.rule_engine.socket.getaddrinfo") as mock_forward,
+        ):
+            result = _verify_rdns("1.2.3.4", r"\.googlebot\.com$", redis)
 
         assert result is False
+        mock_forward.assert_not_called()
 
     def test_returns_false_for_invalid_rdns_regex(self):
         """_verify_rdns returns False gracefully when rdns_pattern is an invalid regex."""
         from django_waf.services.rule_engine import _verify_rdns
 
         redis = _make_redis()
-        redis.get.return_value = b"host.example.com"
+        redis.get.return_value = None
 
-        result = _verify_rdns("1.2.3.4", "[invalid(regex", redis)
+        with patch("django_waf.services.rule_engine.socket.gethostbyaddr", return_value=("host.example.com", [], [])):
+            result = _verify_rdns("1.2.3.4", "[invalid(regex", redis)
 
         assert result is False
 
@@ -3868,68 +3987,65 @@ class TestRuleEngineHelpers:
         # Must not raise
         _record_rule_hit("rule-123", redis)
 
-    # ------------------------------------------------------------------ _verify_rdns
+    # ------------------------------------------------------------------ _resolve_and_confirm_rdns
+    #
+    # _verify_rdns's own cache-hit/cache-miss/TTL behaviour is covered by
+    # TestVerifyRdns above and tests/test_rdns_fcrdns.py. These tests cover
+    # the split-out pure-resolution helper directly (no caching involved).
 
-    def test_verify_rdns_cache_miss_resolves_and_caches(self):
-        from django_waf.services.rule_engine import _verify_rdns
+    def test_resolve_and_confirm_matches_and_confirms(self):
+        from django_waf.services.rule_engine import _resolve_and_confirm_rdns
 
-        redis = MagicMock()
-        redis.get.return_value = None  # cache miss
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("crawl-1-2-3-4.googlebot.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("1.2.3.4", 0))],
+            ),
+        ):
+            assert _resolve_and_confirm_rdns("1.2.3.4", r"\.googlebot\.com$") is True
+
+    def test_resolve_and_confirm_reverse_lookup_failure(self):
+        from django_waf.services.rule_engine import _resolve_and_confirm_rdns
+
+        with patch("django_waf.services.rule_engine.socket.gethostbyaddr", side_effect=OSError("no ptr")):
+            assert _resolve_and_confirm_rdns("203.0.113.1", r"\.googlebot\.com$") is False
+
+    def test_resolve_and_confirm_empty_hostname(self):
+        from django_waf.services.rule_engine import _resolve_and_confirm_rdns
+
+        with patch("django_waf.services.rule_engine.socket.gethostbyaddr", return_value=("", [], [])):
+            assert _resolve_and_confirm_rdns("203.0.113.1", r"\.googlebot\.com$") is False
+
+    def test_resolve_and_confirm_invalid_pattern(self):
+        """An invalid rDNS regex pattern is swallowed and returns False."""
+        from django_waf.services.rule_engine import _resolve_and_confirm_rdns
 
         with patch(
             "django_waf.services.rule_engine.socket.gethostbyaddr",
-            return_value=("crawl-1-2-3-4.googlebot.com", [], []),
+            return_value=("something.example.com", [], []),
         ):
-            result = _verify_rdns("1.2.3.4", r"\.googlebot\.com$", redis)
+            assert _resolve_and_confirm_rdns("1.2.3.4", "[unclosed") is False
 
-        assert result is True
-        redis.setex.assert_called_once()
+    def test_resolve_and_confirm_forward_mismatch_fails(self):
+        """PTR matches the pattern, but the forward-resolved set does not
+        include the original IP — the spoofed-PTR case #34 exists to catch."""
+        from django_waf.services.rule_engine import _resolve_and_confirm_rdns
 
-    def test_verify_rdns_cache_hit_uses_cached_hostname(self):
-        from django_waf.services.rule_engine import _verify_rdns
-
-        redis = MagicMock()
-        redis.get.return_value = "bingbot-5-6-7-8.search.msn.com"
-
-        result = _verify_rdns("5.6.7.8", r"\.search\.msn\.com$", redis)
-
-        assert result is True
-        # No socket call — cached
-        redis.setex.assert_not_called()
-
-    def test_verify_rdns_cache_hit_bytes_value(self):
-        """A bytes-valued cache entry is decoded before matching."""
-        from django_waf.services.rule_engine import _verify_rdns
-
-        redis = MagicMock()
-        redis.get.return_value = b"crawl-1-2-3-4.googlebot.com"
-
-        assert _verify_rdns("1.2.3.4", r"\.googlebot\.com$", redis) is True
-
-    def test_verify_rdns_resolution_failure_returns_false(self):
-        from django_waf.services.rule_engine import _verify_rdns
-
-        redis = MagicMock()
-        redis.get.return_value = None
-
-        with patch("django_waf.services.rule_engine.socket.gethostbyaddr", side_effect=OSError("no ptr")):
-            assert _verify_rdns("203.0.113.1", r"\.googlebot\.com$", redis) is False
-
-    def test_verify_rdns_no_hostname_returns_false(self):
-        """Empty hostname (cached) short-circuits to False."""
-        from django_waf.services.rule_engine import _verify_rdns
-
-        redis = MagicMock()
-        redis.get.return_value = ""
-        assert _verify_rdns("203.0.113.1", r"\.googlebot\.com$", redis) is False
-
-    def test_verify_rdns_invalid_pattern_returns_false(self):
-        """An invalid rDNS regex pattern is swallowed and returns False."""
-        from django_waf.services.rule_engine import _verify_rdns
-
-        redis = MagicMock()
-        redis.get.return_value = "something.example.com"
-        assert _verify_rdns("1.2.3.4", "[unclosed", redis) is False
+        with (
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                return_value=("bingbot-5-6-7-8.search.msn.com", [], []),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.getaddrinfo",
+                return_value=[(2, 1, 6, "", ("203.0.113.99", 0))],
+            ),
+        ):
+            assert _resolve_and_confirm_rdns("5.6.7.8", r"\.search\.msn\.com$") is False
 
     # ------------------------------------------------------------------ _action_to_verdict
 

--- a/tests/test_site_password.py
+++ b/tests/test_site_password.py
@@ -397,6 +397,7 @@ class TestGuessThrottling:
         mock_check.assert_called_once()
 
     def test_throttle_exceeded_returns_429(self):
+        """#30: the 429 carries the limiter's real retry_after, not a fixed 60."""
         with (
             _enable_gate(password="correct-horse"),
             patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
@@ -412,7 +413,7 @@ class TestGuessThrottling:
             )
 
         assert response.status_code == 429
-        assert "Retry-After" in response
+        assert response["Retry-After"] == "42"
 
     def test_throttle_check_reuses_rate_limiter_module_not_a_new_limiter(self):
         """BR-SP-007: guess throttling must go through


### PR DESCRIPTION
The 1.6.0 defect wave from the 2026-08-01 issue triage. Six verified defects, each latent since the feature that introduced it (not regressions), fixed with tests. Full suite green: **929 passed, 0 failed**; CI ruff gate (0.15.22) clean.

## Fixes

- **#24** cloud-spray detection now counts a bare-origin referer (`^https?://[^/]+$`) as missing, closing the blind spot a live 131k-IP/day click-fraud botnet on VendablyCSS exploited by stamping a static `Referer: https://vendably.shop` on every request.
- **#25** rule expiry is enforced at evaluation time (cache carries `expires_at`, expired entries never match), and the housekeeping task now deactivates expired AllowRules as well as BlockRules. The AllowRule-bypass half became possible in 1.4.0, which first gave AllowRules an `expires_at`.
- **#26** the proof-of-work pass cookie moved from a colon-joined payload to a versioned pipe-delimited one (`v2|token|ip|expiry|signature`) with `ipaddress`-normalised IPs, so IPv6 clients validate instead of being re-challenged every request. Old-format cookies re-solve once after upgrade.
- **#27** unsolved-challenge escalation is now gated before every challenge-verdict return point, so a persistently-abusive IP actually reaches auto-block (previously dead code).
- **#30** rate limiting returns an accurate `Retry-After` (true seconds until the oldest event ages out, computed atomically), carried on `EvaluationResult`, for both the WAF throttle and the site-password guess-throttle.
- **#34** verified-crawler allow rules now require forward-confirmed reverse DNS: a matched PTR hostname must forward-resolve back to the source IP, defeating PTR spoofing from cloud hosts. Any DNS failure fails closed.

## Notes for the reviewer

- New setting `DJANGO_WAF_RDNS_FAILURE_CACHE_TTL` (default 300): negative rDNS verdicts cache briefly instead of the 24h positive TTL, so a transient resolver outage no longer suppresses a crawler allow for a day.
- `EvaluationResult` gained a keyword-default `retry_after` field (positional 5-arg constructions unaffected); `expire_rules` result gained `expired_block_count`/`expired_allow_count`.
- Behaviour change to flag on upgrade: an existing rDNS-gated crawler AllowRule stops matching if its forward DNS does not point back at the IP whose PTR was configured. That is the intended hardening.
- Provenance was traced by git archaeology: #26/#30/#25(BlockRule)/#34 date to the founding commit (v0.1.0), #27 to v0.5.0, #24 to v0.7.0; #25's AllowRule bypass opened at v1.4.0. None are regressions.

Closes #24, #25, #26, #27, #30, #34.

Spec sync (`docs/specs/django-waf/`) rides on a companion umbrella PR.