### PR TITLE
1.8.0: signed trusted-user cookie (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-01
+
+A single opt-in feature closing the last item from the 2026-08-01 triage: the
+WAF can now recognise staff without depending on `AuthenticationMiddleware`
+order, dissolving the W004 tension. Off by default, so existing sites are
+unaffected. All 1058 tests pass.
+
 ### Added
 
 - **Signed trusted-user cookie so the staff bypass works before
   `AuthenticationMiddleware` (#23).** The staff/superuser rate-limit bypass
   (BR-RATE-003) read `request.user`, which is only populated once
-  `AuthenticationMiddleware` has run — so the bypass silently failed on any
+  `AuthenticationMiddleware` has run, so the bypass silently failed on any
   deployment that (correctly, for security-first ordering) placed
   `WafMiddleware` before auth, and `django_waf.W004` warned about the
   ordering with no fix beyond moving the WAF later, which trades away its
@@ -25,13 +32,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`django_waf.receivers.set_trusted_cookie_flag_on_login`, wired from
   `DjangoWafConfig.ready()`). `_is_staff_user` now checks this cookie
   first, falling back to `request.user` unchanged. When the feature is
-  enabled, `django_waf.W004` is no longer raised — the bypass no longer
-  depends on middleware order. A new setting,
-  `DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL` (default `"staff"`, or
-  `"authenticated"`), controls which logged-in users receive the cookie;
-  an invalid value is warned about by the new `django_waf.W006` check and
-  falls back to `"staff"`. Feature is off by default: existing sites see
-  no behaviour change. See `docs/DESIGN-trusted-user-cookie.md`.
+  enabled, `django_waf.W004` is no longer raised: the bypass no longer
+  depends on middleware order. The cookie is bound to the client IP via the
+  hardened `resolve_client_ip` resolver (#29) and carries a short TTL, so a
+  stolen cookie grants the bypass only briefly and only from the same
+  address.
+- `DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL` (default `"staff"`, or
+  `"authenticated"`): which logged-in users receive the cookie. An invalid
+  value is warned about by the new `django_waf.W006` system check and falls
+  back to `"staff"`.
+- `DJANGO_WAF_TRUSTED_COOKIE_TTL` (default `3600` seconds) and
+  `DJANGO_WAF_TRUSTED_COOKIE_DOMAIN` (default `None`, falling back to
+  `SESSION_COOKIE_DOMAIN`): the cookie's lifetime and cross-subdomain scope,
+  mirroring the site-password settings.
+
+### Changed
+
+- `django_waf.W004` (middleware ordering) is suppressed when
+  `DJANGO_WAF_TRUSTED_COOKIE_ENABLED` is `True`, and still raised as before
+  when the feature is off and the WAF sits before auth.
 
 ## [1.7.0] - 2026-08-01
 
@@ -332,10 +351,10 @@ rule expiry). All 929 tests pass.
   via the new `IsWafAdmin` permission), and read-only `RequestLogViewSet`
   (`?verdict=`, `?ip_address=`, `?from_ts=` filters) and `IPReputationViewSet`
   (`?min_threat_score=` filter), both restricted to Django admin users. Off by
-  default — set `DJANGO_WAF_API_ENABLED = True` to mount the routes, and every
+  default, set `DJANGO_WAF_API_ENABLED = True` to mount the routes, and every
   endpoint returns `503` while disabled. Requires the new `django-waf[api]`
   extra (`djangorestframework>=3.14`); `djangorestframework` stays fully
-  optional otherwise — the package imports and every existing test passes
+  optional otherwise, the package imports and every existing test passes
   with it absent from the environment.
 - System check `django_waf.W005`: warns when `DJANGO_WAF_FEED_ENABLED` is
   true but `DJANGO_WAF_FEED_URL` is not `https://`. Feed responses become
@@ -359,7 +378,7 @@ rule expiry). All 929 tests pass.
   yet in that ordering, so the staff/superuser bypass silently fails and
   staff accounts get blocked/challenged like anonymous traffic.
 - `django_waf.testing.fixtures`: pytest fixtures for consuming-project test
-  suites — `disable_waf`, `waf_redis_mock` (requires `fakeredis`),
+  suites, `disable_waf`, `waf_redis_mock` (requires `fakeredis`),
   `block_rule`, `allow_rule`, `challenge_token`. Re-exported from
   `django_waf.testing`.
 - `django_waf.testing.helpers`: `create_blocked_request()` and
@@ -367,7 +386,7 @@ rule expiry). All 929 tests pass.
   `BlockRule` and issue a request through the Django test client.
   Re-exported from `django_waf.testing`.
 - `django_waf.logging.WafStructuredFormatter`: a JSON logging formatter for
-  the `django_waf` logger hierarchy — one object per line with timestamp,
+  the `django_waf` logger hierarchy, one object per line with timestamp,
   level, logger, message, and (when present on the record) ip, verdict,
   rule_id, anomaly_score, latency_ms, path, method, and user_agent
   (truncated to 200 characters).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Signed trusted-user cookie so the staff bypass works before
+  `AuthenticationMiddleware` (#23).** The staff/superuser rate-limit bypass
+  (BR-RATE-003) read `request.user`, which is only populated once
+  `AuthenticationMiddleware` has run — so the bypass silently failed on any
+  deployment that (correctly, for security-first ordering) placed
+  `WafMiddleware` before auth, and `django_waf.W004` warned about the
+  ordering with no fix beyond moving the WAF later, which trades away its
+  early-rejection value. New opt-in setting
+  `DJANGO_WAF_TRUSTED_COOKIE_ENABLED` (default `False`) turns on a
+  WAF-owned, IP-bound, short-TTL signed cookie
+  (`django_waf.services.trusted_user_service`, mirroring the existing
+  site-password cookie's `TimestampSigner` pattern) set on login via a new
+  opt-in `user_logged_in` receiver
+  (`django_waf.receivers.set_trusted_cookie_flag_on_login`, wired from
+  `DjangoWafConfig.ready()`). `_is_staff_user` now checks this cookie
+  first, falling back to `request.user` unchanged. When the feature is
+  enabled, `django_waf.W004` is no longer raised — the bypass no longer
+  depends on middleware order. A new setting,
+  `DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL` (default `"staff"`, or
+  `"authenticated"`), controls which logged-in users receive the cookie;
+  an invalid value is warned about by the new `django_waf.W006` check and
+  falls back to `"staff"`. Feature is off by default: existing sites see
+  no behaviour change. See `docs/DESIGN-trusted-user-cookie.md`.
+
 ## [1.7.0] - 2026-08-01
 
 The P2/P3 hardening pass from the 2026-08-01 issue triage: six defects and

--- a/docs/DESIGN-trusted-user-cookie.md
+++ b/docs/DESIGN-trusted-user-cookie.md
@@ -1,6 +1,6 @@
 # Design proposal: signed trusted-user cookie so the WAF recognises staff without AuthenticationMiddleware
 
-Status: proposed (2026-07-29). Owner-requested from an icvlocal/vendablyconnect
+Status: implemented in 1.8.0 (2026-08-01). Owner-requested from an icvlocal/vendablyconnect
 integration finding. This is the durable brief; file it as an issue with the
 `gh` command at the bottom.
 
@@ -116,6 +116,28 @@ cookie, exactly mirroring `site_password_service`:
 - **Setting names** follow the existing `DJANGO_WAF_*` conf convention
   (`conf.py`); mirror the site-password settings (enable flag, TTL, cookie
   domain, cookie name).
+
+Decisions taken (1.8.0):
+
+- Staff-only by default: `DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL` defaults to
+  `"staff"` (`is_staff` or `is_superuser`); `"authenticated"` is available as an
+  explicit opt-in broadening. An unrecognised value fails closed to `"staff"`
+  rather than raising, and is flagged by system check `django_waf.W006`.
+- The feature is off by default: `DJANGO_WAF_TRUSTED_COOKIE_ENABLED = False`, so
+  no behaviour changes for a site that does not opt in, and the `user_logged_in`
+  receiver is only connected in `DjangoWafConfig.ready()` when the setting is
+  `True` at process startup (a restart is required to pick up a later change).
+- Setting names mirror the site-password convention exactly:
+  `DJANGO_WAF_TRUSTED_COOKIE_ENABLED`, `DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL`,
+  `DJANGO_WAF_TRUSTED_COOKIE_TTL` (default 3600s), and
+  `DJANGO_WAF_TRUSTED_COOKIE_DOMAIN` (default `None`, falling back to
+  `SESSION_COOKIE_DOMAIN`).
+- IP binding uses `django_waf.services.client_ip.resolve_client_ip`, the same
+  hardened, trust-boundary-aware resolver the rest of the WAF now uses (#29),
+  rather than reading `REMOTE_ADDR` directly.
+- The TTL is deliberately short (3600s default) as the primary mitigation
+  against a stolen cookie; the IP binding is a secondary control, not a
+  complete one on shared or NAT'd networks.
 
 ## Acceptance criteria
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "1.7.0"
+version = "1.8.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/django_waf/apps.py
+++ b/src/django_waf/apps.py
@@ -12,7 +12,7 @@ class DjangoWafConfig(AppConfig):
         # #23: connect the trusted-user-cookie login receiver only when the
         # feature is enabled at process startup. ready() runs once, so
         # toggling DJANGO_WAF_TRUSTED_COOKIE_ENABLED needs a restart to take
-        # effect — the standard Django app-loading contract, and consistent
+        # effect, the standard Django app-loading contract, and consistent
         # with every other opt-in wiring in this method.
         from django_waf import conf
 

--- a/src/django_waf/apps.py
+++ b/src/django_waf/apps.py
@@ -10,3 +10,15 @@ class DjangoWafConfig(AppConfig):
 
     def ready(self) -> None:
         from . import checks, handlers  # noqa: F401 — register handlers & system checks
+
+        # #23: connect the trusted-user-cookie login receiver only when the
+        # feature is enabled at process startup. ready() runs once, so
+        # toggling DJANGO_WAF_TRUSTED_COOKIE_ENABLED needs a restart to take
+        # effect — the standard Django app-loading contract, and consistent
+        # with every other opt-in wiring in this method.
+        from django_waf import conf
+
+        if conf.DJANGO_WAF_TRUSTED_COOKIE_ENABLED:
+            from . import receivers
+
+            receivers.connect()

--- a/src/django_waf/apps.py
+++ b/src/django_waf/apps.py
@@ -9,14 +9,14 @@ class DjangoWafConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
 
     def ready(self) -> None:
-        from . import checks, handlers  # noqa: F401 — register handlers & system checks
-
         # #23: connect the trusted-user-cookie login receiver only when the
         # feature is enabled at process startup. ready() runs once, so
         # toggling DJANGO_WAF_TRUSTED_COOKIE_ENABLED needs a restart to take
         # effect — the standard Django app-loading contract, and consistent
         # with every other opt-in wiring in this method.
         from django_waf import conf
+
+        from . import checks, handlers  # noqa: F401 — register handlers & system checks
 
         if conf.DJANGO_WAF_TRUSTED_COOKIE_ENABLED:
             from . import receivers

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -199,7 +199,7 @@ def check_middleware_ordering(app_configs, **kwargs):
     WAF-owned cookie (``django_waf.services.trusted_user_service``) that
     does not depend on ``request.user`` at all, so the WAF can stay
     security-first (before auth) without losing the bypass. When that
-    setting is True, this check no longer fires — the ordering it warns
+    setting is True, this check no longer fires: the ordering it warns
     about is no longer a defect for that site. It is unchanged, and still
     fires exactly as before, when the feature is off.
     """
@@ -302,7 +302,7 @@ def check_trusted_cookie_trust_level(app_configs, **kwargs):
     return [
         Warning(
             f"DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL={level!r} is not "
-            '"staff" or "authenticated" — the trusted-user-cookie login '
+            '"staff" or "authenticated"; the trusted-user-cookie login '
             'receiver is falling back to "staff" (the narrower, safer '
             "population) rather than honouring this value.",
             hint='Set DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL to "staff" or "authenticated".',

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -36,6 +36,14 @@ The site-password check (``django_waf.E003``) errors when
 at runtime in this state (every request is denied), so this is an Error
 rather than a Warning -- it flags an operator's site as permanently locked
 rather than a soft misconfiguration.
+
+The trust-level check (``django_waf.W006``) warns when
+``DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL`` is set to anything other than
+``"staff"`` or ``"authenticated"`` while the trusted-user-cookie feature
+(#23) is enabled. The service layer already fails safe on this
+(``django_waf.services.trusted_user_service.get_trust_level`` coerces an
+unrecognised value to ``"staff"``), so this is a Warning about an
+ineffective setting, not an Error about a lockout.
 """
 
 from __future__ import annotations
@@ -185,8 +193,22 @@ def check_middleware_ordering(app_configs, **kwargs):
     independent of the session framework). This check's remedy therefore
     stays "move WafMiddleware after AuthenticationMiddleware", not "resolve
     the user yourself" -- see the v1.5.1 CHANGELOG entry for the precedent.
+
+    #23 dissolves this tension for sites that opt in:
+    ``DJANGO_WAF_TRUSTED_COOKIE_ENABLED`` gives the staff bypass a signed,
+    WAF-owned cookie (``django_waf.services.trusted_user_service``) that
+    does not depend on ``request.user`` at all, so the WAF can stay
+    security-first (before auth) without losing the bypass. When that
+    setting is True, this check no longer fires — the ordering it warns
+    about is no longer a defect for that site. It is unchanged, and still
+    fires exactly as before, when the feature is off.
     """
     from django.conf import settings
+
+    from django_waf import conf
+
+    if conf.DJANGO_WAF_TRUSTED_COOKIE_ENABLED:
+        return []
 
     middleware = list(getattr(settings, "MIDDLEWARE", []))
     waf_name = "django_waf.middleware.WafMiddleware"
@@ -210,7 +232,10 @@ def check_middleware_ordering(app_configs, **kwargs):
                 hint=(
                     "Place django_waf.middleware.WafMiddleware after "
                     "django.contrib.auth.middleware.AuthenticationMiddleware "
-                    "in MIDDLEWARE."
+                    "in MIDDLEWARE, or set DJANGO_WAF_TRUSTED_COOKIE_ENABLED "
+                    "= True and wire the login receiver (see "
+                    "docs/DESIGN-trusted-user-cookie.md) so the staff bypass "
+                    "no longer depends on middleware order."
                 ),
                 id="django_waf.W004",
             )
@@ -248,5 +273,39 @@ def check_site_password_configured(app_configs, **kwargs):
                 "DJANGO_WAF_SITE_PASSWORD_ENABLED = False to disable the gate."
             ),
             id="django_waf.E003",
+        )
+    ]
+
+
+@register()
+def check_trusted_cookie_trust_level(app_configs, **kwargs):
+    """Warn (``django_waf.W006``) when ``DJANGO_WAF_TRUSTED_COOKIE_ENABLED``
+    is True and ``DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL`` is set to
+    anything other than ``"staff"`` or ``"authenticated"``.
+
+    Not an Error: ``django_waf.services.trusted_user_service.get_trust_level``
+    already fails safe, coercing an unrecognised value to ``"staff"`` (the
+    narrower, safer population) rather than raising or silently widening
+    the bypass. This check exists so the misconfiguration is visible at
+    boot rather than only discoverable by noticing the setting has no
+    effect.
+    """
+    from django_waf import conf
+
+    if not conf.DJANGO_WAF_TRUSTED_COOKIE_ENABLED:
+        return []
+
+    level = conf.DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL
+    if level in ("staff", "authenticated"):
+        return []
+
+    return [
+        Warning(
+            f"DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL={level!r} is not "
+            '"staff" or "authenticated" — the trusted-user-cookie login '
+            'receiver is falling back to "staff" (the narrower, safer '
+            "population) rather than honouring this value.",
+            hint='Set DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL to "staff" or "authenticated".',
+            id="django_waf.W006",
         )
     ]

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -588,3 +588,53 @@ DJANGO_WAF_NGINX_VALIDATE: bool = getattr(settings, "DJANGO_WAF_NGINX_VALIDATE",
 # plain syntax check; override if nginx is not on PATH or needs a specific
 # prefix (e.g. ["sudo", "nginx", "-t"]).
 DJANGO_WAF_NGINX_TEST_COMMAND: list[str] = getattr(settings, "DJANGO_WAF_NGINX_TEST_COMMAND", ["nginx", "-t"])
+
+# ---------------------------------------------------------------------------
+# Trusted-user cookie (#23)
+# ---------------------------------------------------------------------------
+# A signed, WAF-owned cookie that carries "this request is from a trusted
+# (staff) user" independently of request.user, so the staff/superuser bypass
+# (BR-RATE-003, django_waf.middleware._is_staff_user) works even when
+# WafMiddleware runs before django.contrib.auth.middleware.AuthenticationMiddleware
+# -- the security-first ordering the WAF's own README recommends, and the
+# ordering django_waf.checks.check_middleware_ordering (django_waf.W004) has
+# historically warned against. See docs/DESIGN-trusted-user-cookie.md and
+# django_waf.services.trusted_user_service, which mirrors
+# django_waf.services.site_password_service's TimestampSigner pattern.
+
+# Master switch. Off by default (opt-in): existing sites see no behaviour
+# change, and no stray cookie can grant the bypass, until a project both
+# enables this setting and wires the login receiver (see
+# django_waf.receivers / DjangoWafConfig.ready()). Read live (not cached) by
+# django_waf.services.trusted_user_service.is_feature_enabled() so tests can
+# toggle it with patch.object without a module reload.
+DJANGO_WAF_TRUSTED_COOKIE_ENABLED: bool = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", False)
+
+# Which users the login receiver issues the cookie to. "staff" (default)
+# limits the bypass to the same population the pre-existing request.user
+# check already trusted (is_staff or is_superuser); "authenticated" widens
+# it to any logged-in user, which broadens the bypass and weakens the WAF
+# for that population, so it is an explicit opt-in, not the default. Any
+# other value is treated as "staff" by the receiver (fails to the narrower,
+# safer population) and is flagged by a system check
+# (django_waf.checks.check_trusted_cookie_trust_level, django_waf.W006).
+DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL: str = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL", "staff")
+
+# Cookie lifetime in seconds. Default 3600 (1 hour) -- deliberately SHORT.
+# Unlike the site-password verified cookie (a low-value "is this visitor
+# allowed to see the site at all" flag with a 12-hour default), this cookie
+# grants a security-relevant bypass of WAF evaluation, so a stolen cookie is
+# more valuable to an attacker and the exposure window is kept tight. The
+# cookie also binds to the client IP (see trusted_user_service), which
+# further limits a stolen cookie's value but does not eliminate it entirely
+# on shared/NAT'd networks, hence the short TTL as the primary control.
+DJANGO_WAF_TRUSTED_COOKIE_TTL: int = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_TTL", 3600)
+
+# Domain for the trusted-user cookie. Defaults to None, which means
+# trusted_user_service.set_trusted_cookie() falls back to
+# settings.SESSION_COOKIE_DOMAIN at call time -- the same fallback
+# convention as DJANGO_WAF_SITE_PASSWORD_COOKIE_DOMAIN, so a site that
+# already sets SESSION_COOKIE_DOMAIN for subdomain coverage gets the same
+# coverage on this cookie without configuring it twice. Set explicitly only
+# when this cookie's subdomain scope must differ from the session cookie's.
+DJANGO_WAF_TRUSTED_COOKIE_DOMAIN: str | None = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_DOMAIN", None)

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -182,7 +182,7 @@ class WafMiddleware:
         response the view produced, wherever in ``__call__`` that happened.
 
         A no-op when the flag is absent (the overwhelming majority of
-        requests, and every request when the feature is disabled — the
+        requests, and every request when the feature is disabled: the
         receiver that sets the flag is itself only connected when
         ``DJANGO_WAF_TRUSTED_COOKIE_ENABLED`` is True, see
         ``DjangoWafConfig.ready()``), so this changes nothing about the
@@ -547,7 +547,7 @@ def _is_staff_user(request) -> bool:
     ``request.user`` check so the bypass keeps working unchanged when the
     WAF *is* placed after auth, or when the cookie feature is disabled
     (``has_valid_trusted_cookie`` is then a guaranteed no-op, so this
-    fallback is the only path exercised — behaviour is unchanged from
+    fallback is the only path exercised, behaviour is unchanged from
     before #23).
     """
     from django_waf.services.trusted_user_service import has_valid_trusted_cookie

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -66,18 +66,18 @@ class WafMiddleware:
 
         # BR-EVAL-002: master kill switch
         if not conf.DJANGO_WAF_ENABLED:
-            return self.get_response(request)
+            return self._get_response(request)
 
         # BR-EVAL-001: exempt paths — prefix match
         path = request.path_info
 
         for prefix in conf.DJANGO_WAF_EXEMPT_PATHS:
             if path.startswith(prefix):
-                return self.get_response(request)
+                return self._get_response(request)
 
         # BR-EVAL-001: exempt hosts — exact or subdomain match
         if conf.DJANGO_WAF_EXEMPT_HOSTS and _is_exempt_host(request, conf.DJANGO_WAF_EXEMPT_HOSTS):
-            return self.get_response(request)
+            return self._get_response(request)
 
         # BR-SP-008: site password gate — after the enabled/exempt/health
         # short-circuits above, before country-block/threat evaluation
@@ -98,7 +98,7 @@ class WafMiddleware:
         # Extract client IP — fail-open if unavailable
         ip_address = _extract_ip(request)
         if not ip_address:
-            return self.get_response(request)
+            return self._get_response(request)
         user_agent = request.META.get("HTTP_USER_AGENT", "")
 
         # Country blocking — fail-open on any GeoIP error or missing database.
@@ -109,12 +109,12 @@ class WafMiddleware:
 
         # BR-RATE-003: staff/superuser bypass — skip WAF entirely
         if _is_staff_user(request):
-            return self.get_response(request)
+            return self._get_response(request)
 
         # Get Redis connection — fail-open if unavailable
         redis_client = _get_redis_client()
         if redis_client is None:
-            return self.get_response(request)
+            return self._get_response(request)
 
         # BR-CHAL-006: check for valid waf_pass cookie before evaluation
         try:
@@ -123,8 +123,7 @@ class WafMiddleware:
             cookie_value = request.COOKIES.get("waf_pass", "")
             if cookie_value and validate_pass_cookie(cookie_value, ip_address):
                 # Cookie is valid — pass through
-                response = self.get_response(request)
-                return response
+                return self._get_response(request)
         except Exception:
             logger.exception("django-waf: error validating waf_pass cookie")
 
@@ -144,7 +143,7 @@ class WafMiddleware:
         except Exception:
             # Fail-open: if evaluation raises, pass the request through
             logger.exception("django-waf: evaluation error — failing open")
-            return self.get_response(request)
+            return self._get_response(request)
 
         # Build and return verdict-specific response
         response = self._handle_verdict(
@@ -165,6 +164,36 @@ class WafMiddleware:
             path=path,
             response_code=response.status_code,
         )
+
+        return response
+
+    def _get_response(self, request):
+        """Call ``get_response(request)`` and apply the trusted-user-cookie
+        response hook (#23) before returning.
+
+        ``django.contrib.auth.signals.user_logged_in`` fires during login
+        processing and only gives us ``request``, not the response the
+        login view is about to return -- so the cookie cannot be set from
+        the signal receiver directly. Instead, the receiver
+        (``django_waf.receivers.set_trusted_cookie_flag_on_login``) stashes
+        a flag on the request (``request._waf_set_trusted_cookie``); every
+        call to ``get_response`` in this middleware routes through this
+        method so that flag is checked and the cookie is set on whatever
+        response the view produced, wherever in ``__call__`` that happened.
+
+        A no-op when the flag is absent (the overwhelming majority of
+        requests, and every request when the feature is disabled — the
+        receiver that sets the flag is itself only connected when
+        ``DJANGO_WAF_TRUSTED_COOKIE_ENABLED`` is True, see
+        ``DjangoWafConfig.ready()``), so this changes nothing about the
+        response path for sites that don't use the feature.
+        """
+        response = self.get_response(request)
+
+        if getattr(request, "_waf_set_trusted_cookie", False):
+            from django_waf.services.trusted_user_service import set_trusted_cookie
+
+            set_trusted_cookie(response, request)
 
         return response
 
@@ -375,7 +404,7 @@ class WafMiddleware:
             # path to prevent infinite redirect loops. BLOCKED and THROTTLED
             # verdicts still apply — only the redirect is suppressed.
             if path.startswith(challenge_path) or path.startswith(verify_path):
-                return self.get_response(request)
+                return self._get_response(request)
 
             # Increment unsolved-challenge counter for escalation tracking
             try:
@@ -388,7 +417,7 @@ class WafMiddleware:
             return HttpResponseRedirect(challenge_url)
 
         # ALLOWED, PASSED, LOGGED — pass through to the view
-        return self.get_response(request)
+        return self._get_response(request)
 
     def _log_request(self, request, result, ip_address, user_agent, path, response_code):
         from django_waf import conf
@@ -508,10 +537,24 @@ def _is_exempt_host(request, exempt_hosts) -> bool:
 
 
 def _is_staff_user(request) -> bool:
-    """Return True if the request is from an authenticated staff or superuser.
+    """Return True if the request is from a trusted staff or superuser.
 
-    Per BR-RATE-003.
+    Per BR-RATE-003. Prefers the signed trusted-user cookie (#23,
+    ``django_waf.services.trusted_user_service.has_valid_trusted_cookie``)
+    so the bypass works even when ``WafMiddleware`` runs before
+    ``django.contrib.auth.middleware.AuthenticationMiddleware`` and
+    ``request.user`` is not yet available. Falls back to the original
+    ``request.user`` check so the bypass keeps working unchanged when the
+    WAF *is* placed after auth, or when the cookie feature is disabled
+    (``has_valid_trusted_cookie`` is then a guaranteed no-op, so this
+    fallback is the only path exercised — behaviour is unchanged from
+    before #23).
     """
+    from django_waf.services.trusted_user_service import has_valid_trusted_cookie
+
+    if has_valid_trusted_cookie(request):
+        return True
+
     return (
         hasattr(request, "user")
         and request.user.is_authenticated

--- a/src/django_waf/receivers.py
+++ b/src/django_waf/receivers.py
@@ -1,0 +1,72 @@
+"""
+Auth-signal receivers for django-waf.
+
+Currently home to the trusted-user-cookie login receiver (#23, see
+docs/DESIGN-trusted-user-cookie.md). Connected opt-in from
+``DjangoWafConfig.ready()``, gated on ``DJANGO_WAF_TRUSTED_COOKIE_ENABLED``
+-- see that module for why this is opt-in rather than always connected, and
+why toggling the setting needs a process restart to take effect (``ready()``
+runs once at process startup, the standard Django app-loading contract).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.contrib.auth.signals import user_logged_in
+
+logger = logging.getLogger("django_waf.receivers")
+
+
+def set_trusted_cookie_flag_on_login(sender, request, user, **kwargs) -> None:
+    """Flag the request so the WAF middleware sets the trusted-user cookie
+    on the login response.
+
+    ``user_logged_in`` fires during login processing and only provides
+    ``sender``, ``request``, and ``user`` -- not the response the login view
+    is about to build, so the cookie cannot be signed and set here directly.
+    Instead this stashes ``request._waf_set_trusted_cookie = True``, and
+    ``django_waf.middleware.WafMiddleware._get_response`` checks that flag
+    against the response once the view has produced one (see that method's
+    docstring for the full flow).
+
+    Only flags the request when both the feature is enabled and ``user``
+    meets the configured trust level
+    (``django_waf.services.trusted_user_service.user_meets_trust_level``,
+    governed by ``DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL``) -- a non-staff
+    user under the default "staff" trust level never gets the cookie.
+
+    Never raises: an error here must not break login. Any exception is
+    logged and swallowed, matching the fail-open posture the rest of the
+    WAF's signal handling already uses (see ``django_waf.middleware``'s
+    ``_emit_request_blocked`` / ``_emit_request_throttled``).
+    """
+    try:
+        from django_waf.services.trusted_user_service import (
+            is_feature_enabled,
+            user_meets_trust_level,
+        )
+
+        if not is_feature_enabled():
+            return
+
+        if not user_meets_trust_level(user):
+            return
+
+        request._waf_set_trusted_cookie = True
+    except Exception:
+        logger.exception("django-waf: error flagging request for trusted-user cookie on login")
+
+
+def connect() -> None:
+    """Connect the login receiver to ``user_logged_in``.
+
+    Called from ``DjangoWafConfig.ready()`` only when
+    ``DJANGO_WAF_TRUSTED_COOKIE_ENABLED`` is True at process startup, so a
+    site that never enables the feature never connects this receiver --
+    the feature is fully opt-in wiring, not just an opt-in runtime check.
+    """
+    user_logged_in.connect(
+        set_trusted_cookie_flag_on_login,
+        dispatch_uid="django_waf.receivers.set_trusted_cookie_flag_on_login",
+    )

--- a/src/django_waf/services/trusted_user_service.py
+++ b/src/django_waf/services/trusted_user_service.py
@@ -1,0 +1,204 @@
+"""
+Trusted-user cookie service for django-waf.
+
+Implements #23 (see docs/DESIGN-trusted-user-cookie.md): a signed,
+WAF-owned cookie that lets ``WafMiddleware`` recognise a trusted (staff)
+user without reading ``request.user``, so the staff/superuser bypass
+(BR-RATE-003, ``django_waf.middleware._is_staff_user``) works even when
+``WafMiddleware`` runs before
+``django.contrib.auth.middleware.AuthenticationMiddleware`` — the
+security-first ordering the package's own README recommends, and the
+ordering ``django_waf.checks.check_middleware_ordering`` (``django_waf.W004``)
+has historically warned against.
+
+This mirrors ``django_waf.services.site_password_service`` exactly: a
+``django.core.signing.TimestampSigner`` keyed with the package's own
+signing key (``django_waf.forms.services.tokens.get_signing_key``), a
+distinct salt, and a fixed marker payload rather than a JSON blob (the
+signer's own timestamp already gives the age used for the TTL check). The
+TTL is enforced live by passing ``max_age`` to ``TimestampSigner.unsign``
+on every request, so a ``DJANGO_WAF_TRUSTED_COOKIE_TTL`` change takes
+effect immediately without needing every existing cookie re-issued.
+
+Unlike the site-password cookie, this cookie also binds to the client IP
+(the same ``resolve_client_ip`` the rest of the WAF uses, see
+``django_waf.services.client_ip``) as part of the signed payload. A signed
+cookie is unforgeable but a *stolen* one grants the bypass until expiry;
+binding it to the issuing IP means a copy used from a different address is
+rejected, and the deliberately short default TTL
+(``DJANGO_WAF_TRUSTED_COOKIE_TTL``) bounds the remaining exposure. Neither
+control makes a stolen cookie harmless on a shared/NAT'd network, so the
+short TTL is the primary control, not the IP binding.
+
+This module is DB-free, session-free, and auth-free by design — it must be
+safe to call from ``WafMiddleware`` at a point in the stack before
+``SessionMiddleware`` and ``AuthenticationMiddleware`` have run.
+"""
+
+from __future__ import annotations
+
+from django.core import signing
+from django.http import HttpRequest, HttpResponse
+
+# Name of the trusted-user cookie. Distinct from the site-password gate's
+# cookie (django_waf.services.site_password_service.SITE_PASSWORD_COOKIE)
+# and from the challenge-pass cookie ("waf_pass") — each signed artefact
+# the WAF issues owns its own cookie name and salt.
+TRUSTED_USER_COOKIE = "waf_trusted"
+
+# Salt namespacing this cookie's signatures from any other
+# django.core.signing use in the project.
+_SIGNING_SALT = "django_waf.trusted_user"
+
+# The cookie proves "a trusted user issued this cookie from this IP"; the
+# TimestampSigner's own timestamp gives the age used for the TTL check, so
+# the payload is a fixed marker plus the bound IP rather than a JSON blob.
+_TRUSTED_MARKER = "trusted"
+
+
+def is_feature_enabled() -> bool:
+    """Return True if the trusted-user cookie feature is switched on.
+
+    Read live (not cached) so tests can toggle it with ``patch.object``
+    without a module reload, and so a disabled feature is a true no-op:
+    ``has_valid_trusted_cookie`` short-circuits on this before touching any
+    cookie, meaning a stray cookie left over from the feature previously
+    being enabled grants nothing while it is off.
+    """
+    from django_waf import conf
+
+    return bool(conf.DJANGO_WAF_TRUSTED_COOKIE_ENABLED)
+
+
+def get_trust_level() -> str:
+    """Return the configured trust level, coerced to a known value.
+
+    ``DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL`` should be "staff" or
+    "authenticated" (see conf.py). Any other configured value fails to the
+    narrower, safer population ("staff") rather than raising — a typo in
+    settings must never silently widen the bypass to every authenticated
+    user. ``django_waf.checks.check_trusted_cookie_trust_level``
+    (``django_waf.W006``) surfaces the misconfiguration at boot.
+    """
+    from django_waf import conf
+
+    level = conf.DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL
+    if level == "authenticated":
+        return "authenticated"
+    return "staff"
+
+
+def user_meets_trust_level(user) -> bool:
+    """Return True if ``user`` meets the configured trust level.
+
+    "staff" (default): ``is_staff`` or ``is_superuser`` — the same
+    population ``django_waf.middleware._is_staff_user`` already trusted via
+    ``request.user`` before this feature existed. "authenticated": any
+    ``is_authenticated`` user, an explicit opt-in broadening of the bypass.
+    """
+    if not getattr(user, "is_authenticated", False):
+        return False
+
+    if get_trust_level() == "authenticated":
+        return True
+
+    return bool(getattr(user, "is_staff", False) or getattr(user, "is_superuser", False))
+
+
+def _get_signer() -> signing.TimestampSigner:
+    """Return a TimestampSigner keyed with the package's own signing key.
+
+    Uses ``django_waf.forms.services.tokens.get_signing_key`` (the same key
+    convention as ``site_password_service._get_signer``), independent of
+    Django's session/cookie signer.
+    """
+    from django_waf.forms.services.tokens import get_signing_key
+
+    return signing.TimestampSigner(key=get_signing_key(), salt=_SIGNING_SALT)
+
+
+def _build_payload(ip_address: str) -> str:
+    """Build the signed payload: the fixed marker bound to the issuing IP."""
+    return f"{_TRUSTED_MARKER}:{ip_address}"
+
+
+def set_trusted_cookie(response: HttpResponse, request: HttpRequest) -> None:
+    """Set the signed trusted-user cookie on the response.
+
+    Binds the cookie to the client IP resolved via
+    ``django_waf.services.client_ip.resolve_client_ip`` — the same hardened
+    resolver the rest of the WAF uses (#29) — rather than
+    ``request.META["REMOTE_ADDR"]`` directly, so the binding matches
+    whatever IP the WAF itself treats as authoritative for this request
+    (trusted-proxy chains, ``X-Forwarded-For`` handling, and so on).
+
+    Set on the *response*, not the request: this is normally called from
+    the login receiver via the middleware's response-side hook (see
+    ``django_waf.middleware.WafMiddleware`` and ``django_waf.receivers``),
+    because the cookie can only be written once the login response exists.
+
+    ``domain`` defaults to ``DJANGO_WAF_TRUSTED_COOKIE_DOMAIN`` if set, else
+    ``settings.SESSION_COOKIE_DOMAIN`` — mirrors
+    ``site_password_service.set_verified_cookie``.
+    """
+    from django.conf import settings
+
+    from django_waf import conf
+    from django_waf.services.client_ip import resolve_client_ip
+
+    ttl = conf.DJANGO_WAF_TRUSTED_COOKIE_TTL
+    cookie_domain = conf.DJANGO_WAF_TRUSTED_COOKIE_DOMAIN
+    if cookie_domain is None:
+        cookie_domain = getattr(settings, "SESSION_COOKIE_DOMAIN", None)
+
+    ip_address = resolve_client_ip(request)
+    signed_value = _get_signer().sign(_build_payload(ip_address))
+    response.set_cookie(
+        TRUSTED_USER_COOKIE,
+        signed_value,
+        max_age=ttl,
+        domain=cookie_domain,
+        httponly=True,
+        secure=request.is_secure(),
+        samesite="Lax",
+    )
+
+
+def has_valid_trusted_cookie(request: HttpRequest) -> bool:
+    """Return True if the request carries an unexpired, correctly signed
+    trusted-user cookie issued to the request's own client IP.
+
+    Returns False (never raises) when: the feature is disabled (so a stray
+    cookie left over from the feature previously being enabled grants
+    nothing); the cookie is missing; the signature is tampered or expired
+    (``signing.BadSignature`` covers both — ``SignatureExpired`` is a
+    subclass); or the bound IP does not match
+    ``django_waf.services.client_ip.resolve_client_ip(request)`` for this
+    request (rejects a cookie replayed from a different address).
+
+    Reads ``DJANGO_WAF_TRUSTED_COOKIE_TTL`` live via the ``max_age`` passed
+    to ``unsign`` so a TTL change takes effect immediately, mirroring
+    ``site_password_service.has_valid_cookie``.
+    """
+    if not is_feature_enabled():
+        return False
+
+    from django_waf import conf
+    from django_waf.services.client_ip import resolve_client_ip
+
+    cookie_value = request.COOKIES.get(TRUSTED_USER_COOKIE)
+    if not cookie_value:
+        return False
+
+    ttl = conf.DJANGO_WAF_TRUSTED_COOKIE_TTL
+    try:
+        payload = _get_signer().unsign(cookie_value, max_age=ttl)
+    except signing.BadSignature:
+        return False
+
+    marker, _, bound_ip = payload.partition(":")
+    if marker != _TRUSTED_MARKER:
+        return False
+
+    return bound_ip == resolve_client_ip(request)
+

--- a/src/django_waf/services/trusted_user_service.py
+++ b/src/django_waf/services/trusted_user_service.py
@@ -6,7 +6,7 @@ WAF-owned cookie that lets ``WafMiddleware`` recognise a trusted (staff)
 user without reading ``request.user``, so the staff/superuser bypass
 (BR-RATE-003, ``django_waf.middleware._is_staff_user``) works even when
 ``WafMiddleware`` runs before
-``django.contrib.auth.middleware.AuthenticationMiddleware`` — the
+``django.contrib.auth.middleware.AuthenticationMiddleware``, the
 security-first ordering the package's own README recommends, and the
 ordering ``django_waf.checks.check_middleware_ordering`` (``django_waf.W004``)
 has historically warned against.
@@ -30,7 +30,7 @@ rejected, and the deliberately short default TTL
 control makes a stolen cookie harmless on a shared/NAT'd network, so the
 short TTL is the primary control, not the IP binding.
 
-This module is DB-free, session-free, and auth-free by design — it must be
+This module is DB-free, session-free, and auth-free by design, it must be
 safe to call from ``WafMiddleware`` at a point in the stack before
 ``SessionMiddleware`` and ``AuthenticationMiddleware`` have run.
 """
@@ -42,7 +42,7 @@ from django.http import HttpRequest, HttpResponse
 
 # Name of the trusted-user cookie. Distinct from the site-password gate's
 # cookie (django_waf.services.site_password_service.SITE_PASSWORD_COOKIE)
-# and from the challenge-pass cookie ("waf_pass") — each signed artefact
+# and from the challenge-pass cookie ("waf_pass"), each signed artefact
 # the WAF issues owns its own cookie name and salt.
 TRUSTED_USER_COOKIE = "waf_trusted"
 
@@ -75,7 +75,7 @@ def get_trust_level() -> str:
 
     ``DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL`` should be "staff" or
     "authenticated" (see conf.py). Any other configured value fails to the
-    narrower, safer population ("staff") rather than raising — a typo in
+    narrower, safer population ("staff") rather than raising, a typo in
     settings must never silently widen the bypass to every authenticated
     user. ``django_waf.checks.check_trusted_cookie_trust_level``
     (``django_waf.W006``) surfaces the misconfiguration at boot.
@@ -91,7 +91,7 @@ def get_trust_level() -> str:
 def user_meets_trust_level(user) -> bool:
     """Return True if ``user`` meets the configured trust level.
 
-    "staff" (default): ``is_staff`` or ``is_superuser`` — the same
+    "staff" (default): ``is_staff`` or ``is_superuser``, the same
     population ``django_waf.middleware._is_staff_user`` already trusted via
     ``request.user`` before this feature existed. "authenticated": any
     ``is_authenticated`` user, an explicit opt-in broadening of the bypass.
@@ -126,8 +126,8 @@ def set_trusted_cookie(response: HttpResponse, request: HttpRequest) -> None:
     """Set the signed trusted-user cookie on the response.
 
     Binds the cookie to the client IP resolved via
-    ``django_waf.services.client_ip.resolve_client_ip`` — the same hardened
-    resolver the rest of the WAF uses (#29) — rather than
+    ``django_waf.services.client_ip.resolve_client_ip``, the same hardened
+    resolver the rest of the WAF uses (#29), rather than
     ``request.META["REMOTE_ADDR"]`` directly, so the binding matches
     whatever IP the WAF itself treats as authoritative for this request
     (trusted-proxy chains, ``X-Forwarded-For`` handling, and so on).
@@ -138,7 +138,7 @@ def set_trusted_cookie(response: HttpResponse, request: HttpRequest) -> None:
     because the cookie can only be written once the login response exists.
 
     ``domain`` defaults to ``DJANGO_WAF_TRUSTED_COOKIE_DOMAIN`` if set, else
-    ``settings.SESSION_COOKIE_DOMAIN`` — mirrors
+    ``settings.SESSION_COOKIE_DOMAIN``, mirrors
     ``site_password_service.set_verified_cookie``.
     """
     from django.conf import settings
@@ -171,7 +171,7 @@ def has_valid_trusted_cookie(request: HttpRequest) -> bool:
     Returns False (never raises) when: the feature is disabled (so a stray
     cookie left over from the feature previously being enabled grants
     nothing); the cookie is missing; the signature is tampered or expired
-    (``signing.BadSignature`` covers both — ``SignatureExpired`` is a
+    (``signing.BadSignature`` covers both, ``SignatureExpired`` is a
     subclass); or the bound IP does not match
     ``django_waf.services.client_ip.resolve_client_ip(request)`` for this
     request (rejects a cookie replayed from a different address).

--- a/src/django_waf/services/trusted_user_service.py
+++ b/src/django_waf/services/trusted_user_service.py
@@ -201,4 +201,3 @@ def has_valid_trusted_cookie(request: HttpRequest) -> bool:
         return False
 
     return bound_ip == resolve_client_ip(request)
-

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -37,6 +37,12 @@ def _run_feed_url_scheme_check():
     return check_feed_url_scheme(app_configs=None)
 
 
+def _run_trusted_cookie_trust_level_check():
+    from django_waf.checks import check_trusted_cookie_trust_level
+
+    return check_trusted_cookie_trust_level(app_configs=None)
+
+
 class TestChallengeDifficultyCheck:
     def test_recommended_defaults_produce_no_messages(self):
         import django_waf.conf as conf_mod
@@ -236,3 +242,87 @@ class TestMiddlewareOrderingCheck:
 
         assert len(messages) == 1
         assert messages[0].id == "django_waf.W004"
+
+    def test_suppressed_when_trusted_cookie_feature_enabled(self):
+        """#23: with DJANGO_WAF_TRUSTED_COOKIE_ENABLED True, the staff
+        bypass no longer depends on middleware order, so W004 must not
+        fire even for the exact bad ordering that triggers it above."""
+        import django_waf.conf as conf_mod
+
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django_waf.middleware.WafMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+        ]
+
+        with (
+            override_settings(MIDDLEWARE=middleware),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", True),
+        ):
+            assert _run_middleware_ordering_check() == []
+
+    def test_still_warns_when_feature_off_and_order_wrong(self):
+        """Unchanged behaviour when the feature is off (the default)."""
+        import django_waf.conf as conf_mod
+
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django_waf.middleware.WafMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+        ]
+
+        with (
+            override_settings(MIDDLEWARE=middleware),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", False),
+        ):
+            messages = _run_middleware_ordering_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W004"
+
+
+class TestTrustedCookieTrustLevelCheck:
+    """W006 — warns when DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL is neither
+    "staff" nor "authenticated" while the feature is enabled."""
+
+    def test_staff_produces_no_messages(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL", "staff"),
+        ):
+            assert _run_trusted_cookie_trust_level_check() == []
+
+    def test_authenticated_produces_no_messages(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL", "authenticated"),
+        ):
+            assert _run_trusted_cookie_trust_level_check() == []
+
+    def test_invalid_value_emits_w006_warning(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL", "everyone"),
+        ):
+            messages = _run_trusted_cookie_trust_level_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W006"
+        assert "everyone" in messages[0].message
+
+    def test_invalid_value_silent_when_feature_disabled(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", False),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL", "everyone"),
+        ):
+            assert _run_trusted_cookie_trust_level_check() == []

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -284,7 +284,7 @@ class TestMiddlewareOrderingCheck:
 
 
 class TestTrustedCookieTrustLevelCheck:
-    """W006 — warns when DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL is neither
+    """W006 warns when DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL is neither
     "staff" nor "authenticated" while the feature is enabled."""
 
     def test_staff_produces_no_messages(self):

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -316,7 +316,7 @@ class TestTrustedCookieTrustLevelCheck:
 
         assert len(messages) == 1
         assert messages[0].id == "django_waf.W006"
-        assert "everyone" in messages[0].message
+        assert "everyone" in messages[0].msg
 
     def test_invalid_value_silent_when_feature_disabled(self):
         import django_waf.conf as conf_mod

--- a/tests/test_trusted_user_cookie.py
+++ b/tests/test_trusted_user_cookie.py
@@ -1,0 +1,464 @@
+"""Tests for the trusted-user cookie (#23,
+docs/DESIGN-trusted-user-cookie.md).
+
+Covers django_waf.services.trusted_user_service (signing/verification),
+django_waf.middleware._is_staff_user's cookie-first preference,
+django_waf.receivers.set_trusted_cookie_flag_on_login, and the
+WafMiddleware response-side hook that actually writes the cookie
+(WafMiddleware._get_response).
+
+Mirrors tests/test_site_password.py's patterns: django_waf.conf reads
+settings at call time via a local import, so patch.object(conf_mod, ...)
+toggles behaviour without importlib.reload. The feature defaults off
+(DJANGO_WAF_TRUSTED_COOKIE_ENABLED=False in tests/settings.py), so every
+test that needs it on enables it explicitly.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.http import HttpResponse
+from django.test import RequestFactory, override_settings
+
+pytestmark = pytest.mark.django_db
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _enable_feature(trust_level="staff", **extra):
+    """Context manager patching django_waf.conf so the feature is on.
+
+    Mirrors tests/test_site_password.py's _enable_gate helper. Use as:
+        with _enable_feature():
+            ...
+    """
+    import django_waf.conf as conf_mod
+
+    defaults = {
+        "DJANGO_WAF_TRUSTED_COOKIE_ENABLED": True,
+        "DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL": trust_level,
+        "DJANGO_WAF_TRUSTED_COOKIE_TTL": 3600,
+        "DJANGO_WAF_TRUSTED_COOKIE_DOMAIN": None,
+    }
+    defaults.update(extra)
+    return patch.multiple(conf_mod, **defaults)
+
+
+def _make_user(*, is_staff=False, is_superuser=False, username="alice"):
+    return User.objects.create_user(
+        username=username,
+        email=f"{username}@example.com",
+        password="irrelevant",  # noqa: S106
+        is_staff=is_staff,
+        is_superuser=is_superuser,
+    )
+
+
+def _make_middleware(get_response=None):
+    from django_waf.middleware import WafMiddleware
+
+    if get_response is None:
+        get_response = MagicMock(return_value=HttpResponse("ok"))
+    return WafMiddleware(get_response)
+
+
+# ---------------------------------------------------------------------------
+# django_waf.services.trusted_user_service — signing/verification
+# ---------------------------------------------------------------------------
+
+
+class TestSetAndReadTrustedCookie:
+    def test_set_trusted_cookie_sets_signed_value(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature():
+            request = RequestFactory().get("/", REMOTE_ADDR="203.0.113.9")
+            response = HttpResponse()
+            set_trusted_cookie(response, request)
+
+        assert TRUSTED_USER_COOKIE in response.cookies
+        raw_value = response.cookies[TRUSTED_USER_COOKIE].value
+        # The cookie value is opaque signed data, not the plain marker/IP.
+        assert raw_value != "trusted:203.0.113.9"
+
+    def test_has_valid_trusted_cookie_true_for_freshly_set_cookie(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            has_valid_trusted_cookie,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature():
+            factory = RequestFactory()
+            response = HttpResponse()
+            set_trusted_cookie(response, factory.get("/", REMOTE_ADDR="203.0.113.9"))
+            signed_value = response.cookies[TRUSTED_USER_COOKIE].value
+
+            request = factory.get("/", REMOTE_ADDR="203.0.113.9")
+            request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
+
+            assert has_valid_trusted_cookie(request) is True
+
+    def test_has_valid_trusted_cookie_false_when_missing(self):
+        from django_waf.services.trusted_user_service import has_valid_trusted_cookie
+
+        with _enable_feature():
+            request = RequestFactory().get("/")
+            assert has_valid_trusted_cookie(request) is False
+
+    def test_has_valid_trusted_cookie_false_when_tampered(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            has_valid_trusted_cookie,
+        )
+
+        with _enable_feature():
+            request = RequestFactory().get("/", REMOTE_ADDR="203.0.113.9")
+            request.COOKIES[TRUSTED_USER_COOKIE] = "not-a-real-signed-value"
+            assert has_valid_trusted_cookie(request) is False
+
+    def test_has_valid_trusted_cookie_false_when_expired(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            has_valid_trusted_cookie,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature(DJANGO_WAF_TRUSTED_COOKIE_TTL=1):
+            factory = RequestFactory()
+            response = HttpResponse()
+            set_trusted_cookie(response, factory.get("/", REMOTE_ADDR="203.0.113.9"))
+            signed_value = response.cookies[TRUSTED_USER_COOKIE].value
+
+            time.sleep(1.1)
+
+            request = factory.get("/", REMOTE_ADDR="203.0.113.9")
+            request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
+
+            assert has_valid_trusted_cookie(request) is False
+
+    def test_has_valid_trusted_cookie_false_on_ip_mismatch(self):
+        """A cookie issued to one IP must not validate from another."""
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            has_valid_trusted_cookie,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature():
+            factory = RequestFactory()
+            response = HttpResponse()
+            set_trusted_cookie(response, factory.get("/", REMOTE_ADDR="203.0.113.9"))
+            signed_value = response.cookies[TRUSTED_USER_COOKIE].value
+
+            request = factory.get("/", REMOTE_ADDR="198.51.100.4")
+            request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
+
+            assert has_valid_trusted_cookie(request) is False
+
+    def test_cookie_flags_httponly_samesite_secure(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature():
+            request = RequestFactory().get("/", REMOTE_ADDR="203.0.113.9", secure=True)
+            response = HttpResponse()
+            set_trusted_cookie(response, request)
+
+        morsel = response.cookies[TRUSTED_USER_COOKIE]
+        assert morsel["httponly"] is True
+        assert morsel["samesite"] == "Lax"
+        assert morsel["secure"] is True
+
+    def test_cookie_secure_flag_false_over_plain_http(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature():
+            request = RequestFactory().get("/", REMOTE_ADDR="203.0.113.9")
+            response = HttpResponse()
+            set_trusted_cookie(response, request)
+
+        assert response.cookies[TRUSTED_USER_COOKIE]["secure"] is False
+
+    def test_cookie_scoped_to_session_cookie_domain_by_default(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            set_trusted_cookie,
+        )
+
+        with (
+            _enable_feature(),
+            override_settings(SESSION_COOKIE_DOMAIN=".example.com"),
+        ):
+            response = HttpResponse()
+            set_trusted_cookie(response, RequestFactory().get("/", REMOTE_ADDR="203.0.113.9"))
+
+        assert response.cookies[TRUSTED_USER_COOKIE]["domain"] == ".example.com"
+
+    def test_cookie_domain_setting_overrides_session_cookie_domain(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            set_trusted_cookie,
+        )
+
+        with (
+            _enable_feature(DJANGO_WAF_TRUSTED_COOKIE_DOMAIN=".waf-only.example.com"),
+            override_settings(SESSION_COOKIE_DOMAIN=".example.com"),
+        ):
+            response = HttpResponse()
+            set_trusted_cookie(response, RequestFactory().get("/", REMOTE_ADDR="203.0.113.9"))
+
+        assert response.cookies[TRUSTED_USER_COOKIE]["domain"] == ".waf-only.example.com"
+
+    def test_cookie_binds_to_resolve_client_ip_not_raw_remote_addr(self):
+        """The cookie must bind to django_waf.services.client_ip.resolve_client_ip's
+        result, not request.META["REMOTE_ADDR"] directly, so it matches
+        whatever IP the rest of the WAF treats as authoritative."""
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            has_valid_trusted_cookie,
+            set_trusted_cookie,
+        )
+
+        with (
+            _enable_feature(),
+            patch("django_waf.services.client_ip.resolve_client_ip", return_value="203.0.113.9"),
+        ):
+            factory = RequestFactory()
+            response = HttpResponse()
+            set_trusted_cookie(response, factory.get("/", REMOTE_ADDR="10.0.0.1"))
+            signed_value = response.cookies[TRUSTED_USER_COOKIE].value
+
+            request = factory.get("/", REMOTE_ADDR="10.0.0.1")
+            request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
+
+            assert has_valid_trusted_cookie(request) is True
+
+
+class TestFeatureOffIsANoOp:
+    """DJANGO_WAF_TRUSTED_COOKIE_ENABLED=False (the default) — a stray,
+    otherwise-valid-looking cookie must never grant the bypass."""
+
+    def test_has_valid_trusted_cookie_false_even_with_freshly_signed_cookie(self):
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            has_valid_trusted_cookie,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature():
+            factory = RequestFactory()
+            response = HttpResponse()
+            set_trusted_cookie(response, factory.get("/", REMOTE_ADDR="203.0.113.9"))
+            signed_value = response.cookies[TRUSTED_USER_COOKIE].value
+
+        # Feature now off — the cookie above is real and unexpired.
+        request = factory.get("/", REMOTE_ADDR="203.0.113.9")
+        request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
+
+        assert has_valid_trusted_cookie(request) is False
+
+
+# ---------------------------------------------------------------------------
+# django_waf.middleware._is_staff_user — cookie-first, request.user fallback
+# ---------------------------------------------------------------------------
+
+
+class TestIsStaffUserPrefersTrustedCookie:
+    def test_valid_trusted_cookie_returns_true_with_no_request_user(self):
+        """Simulates WafMiddleware running before AuthenticationMiddleware:
+        request.user is absent entirely, yet the cookie alone must make
+        _is_staff_user return True."""
+        from django_waf.middleware import _is_staff_user
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature():
+            factory = RequestFactory()
+            response = HttpResponse()
+            set_trusted_cookie(response, factory.get("/", REMOTE_ADDR="203.0.113.9"))
+            signed_value = response.cookies[TRUSTED_USER_COOKIE].value
+
+            request = factory.get("/", REMOTE_ADDR="203.0.113.9")
+            request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
+            # No request.user attribute at all — pre-AuthenticationMiddleware.
+            assert not hasattr(request, "user")
+
+            assert _is_staff_user(request) is True
+
+    def test_falls_back_to_request_user_when_no_cookie(self):
+        """Feature-off / no-cookie behaviour is unchanged: still driven by
+        request.user, exactly as before #23."""
+        from django_waf.middleware import _is_staff_user
+
+        request = RequestFactory().get("/")
+        request.user = MagicMock(is_authenticated=True, is_staff=True, is_superuser=False)
+
+        assert _is_staff_user(request) is True
+
+    def test_feature_off_falls_back_to_request_user_only(self):
+        """With the feature off, behaviour must be byte-identical to
+        pre-#23: driven purely by request.user, cookie ignored entirely."""
+        from django_waf.middleware import _is_staff_user
+        from django_waf.services.trusted_user_service import TRUSTED_USER_COOKIE
+
+        request = RequestFactory().get("/")
+        request.COOKIES[TRUSTED_USER_COOKIE] = "irrelevant-value"
+        request.user = MagicMock(is_authenticated=False)
+
+        assert _is_staff_user(request) is False
+
+    def test_no_cookie_no_user_attribute_returns_false(self):
+        from django_waf.middleware import _is_staff_user
+
+        request = RequestFactory().get("/")
+        assert _is_staff_user(request) is False
+
+
+# ---------------------------------------------------------------------------
+# django_waf.receivers.set_trusted_cookie_flag_on_login
+# ---------------------------------------------------------------------------
+
+
+class TestLoginReceiverFlagsRequest:
+    def test_staff_user_login_flags_request_under_staff_trust_level(self):
+        from django_waf.receivers import set_trusted_cookie_flag_on_login
+
+        with _enable_feature(trust_level="staff"):
+            user = _make_user(is_staff=True)
+            request = RequestFactory().get("/accounts/login/")
+
+            set_trusted_cookie_flag_on_login(sender=User, request=request, user=user)
+
+        assert getattr(request, "_waf_set_trusted_cookie", False) is True
+
+    def test_superuser_login_flags_request_under_staff_trust_level(self):
+        from django_waf.receivers import set_trusted_cookie_flag_on_login
+
+        with _enable_feature(trust_level="staff"):
+            user = _make_user(is_superuser=True)
+            request = RequestFactory().get("/accounts/login/")
+
+            set_trusted_cookie_flag_on_login(sender=User, request=request, user=user)
+
+        assert getattr(request, "_waf_set_trusted_cookie", False) is True
+
+    def test_non_staff_user_never_flagged_under_staff_trust_level(self):
+        from django_waf.receivers import set_trusted_cookie_flag_on_login
+
+        with _enable_feature(trust_level="staff"):
+            user = _make_user()
+            request = RequestFactory().get("/accounts/login/")
+
+            set_trusted_cookie_flag_on_login(sender=User, request=request, user=user)
+
+        assert getattr(request, "_waf_set_trusted_cookie", False) is False
+
+    def test_non_staff_user_flagged_under_authenticated_trust_level(self):
+        from django_waf.receivers import set_trusted_cookie_flag_on_login
+
+        with _enable_feature(trust_level="authenticated"):
+            user = _make_user()
+            request = RequestFactory().get("/accounts/login/")
+
+            set_trusted_cookie_flag_on_login(sender=User, request=request, user=user)
+
+        assert getattr(request, "_waf_set_trusted_cookie", False) is True
+
+    def test_receiver_no_op_when_feature_disabled(self):
+        from django_waf.receivers import set_trusted_cookie_flag_on_login
+
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", False):
+            user = _make_user(is_staff=True)
+            request = RequestFactory().get("/accounts/login/")
+
+            set_trusted_cookie_flag_on_login(sender=User, request=request, user=user)
+
+        assert getattr(request, "_waf_set_trusted_cookie", False) is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: login receiver -> middleware response hook -> cookie set
+# ---------------------------------------------------------------------------
+
+
+class TestLoginToResponseCookieFlow:
+    def test_flagged_request_gets_cookie_set_by_middleware_response_hook(self):
+        """The receiver only stashes a flag; WafMiddleware._get_response is
+        what actually writes the cookie onto whatever response the view
+        produced. This is the full receiver-flag-to-cookie wiring."""
+        from django_waf.services.trusted_user_service import TRUSTED_USER_COOKIE
+
+        with _enable_feature():
+            get_response = MagicMock(return_value=HttpResponse("logged in"))
+            middleware = _make_middleware(get_response)
+
+            request = RequestFactory().get("/dashboard/", REMOTE_ADDR="203.0.113.9")
+            request.user = MagicMock(is_authenticated=True, is_staff=True, is_superuser=False)
+            request._waf_set_trusted_cookie = True
+
+            with patch("django_waf.middleware._get_redis_client") as mock_redis_fn:
+                mock_redis_fn.return_value = None
+                response = middleware(request)
+
+        assert TRUSTED_USER_COOKIE in response.cookies
+
+    def test_unflagged_request_gets_no_cookie(self):
+        from django_waf.services.trusted_user_service import TRUSTED_USER_COOKIE
+
+        with _enable_feature():
+            get_response = MagicMock(return_value=HttpResponse("ok"))
+            middleware = _make_middleware(get_response)
+
+            request = RequestFactory().get("/dashboard/", REMOTE_ADDR="203.0.113.9")
+            request.user = MagicMock(is_authenticated=True, is_staff=True, is_superuser=False)
+            # No _waf_set_trusted_cookie flag set.
+
+            with patch("django_waf.middleware._get_redis_client") as mock_redis_fn:
+                mock_redis_fn.return_value = None
+                response = middleware(request)
+
+        assert TRUSTED_USER_COOKIE not in response.cookies
+
+    def test_subsequent_request_with_resulting_cookie_bypasses_before_auth(self):
+        """Full acceptance-criteria round trip: sign a cookie via
+        set_trusted_cookie (as the middleware response hook would), then a
+        fresh request carrying only that cookie -- no request.user at all --
+        must make _is_staff_user (and therefore the WAF bypass) return True."""
+        from django_waf.middleware import _is_staff_user
+        from django_waf.services.trusted_user_service import (
+            TRUSTED_USER_COOKIE,
+            set_trusted_cookie,
+        )
+
+        with _enable_feature():
+            factory = RequestFactory()
+            login_response = HttpResponse("logged in")
+            set_trusted_cookie(login_response, factory.get("/", REMOTE_ADDR="203.0.113.9"))
+            signed_value = login_response.cookies[TRUSTED_USER_COOKIE].value
+
+            next_request = factory.get("/dashboard/", REMOTE_ADDR="203.0.113.9")
+            next_request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
+
+            assert _is_staff_user(next_request) is True

--- a/tests/test_trusted_user_cookie.py
+++ b/tests/test_trusted_user_cookie.py
@@ -195,7 +195,7 @@ class TestSetAndReadTrustedCookie:
             response = HttpResponse()
             set_trusted_cookie(response, request)
 
-        assert response.cookies[TRUSTED_USER_COOKIE]["secure"] is False
+        assert not response.cookies[TRUSTED_USER_COOKIE]["secure"]
 
     def test_cookie_scoped_to_session_cookie_domain_by_default(self):
         from django_waf.services.trusted_user_service import (
@@ -385,9 +385,8 @@ class TestLoginReceiverFlagsRequest:
         assert getattr(request, "_waf_set_trusted_cookie", False) is True
 
     def test_receiver_no_op_when_feature_disabled(self):
-        from django_waf.receivers import set_trusted_cookie_flag_on_login
-
         import django_waf.conf as conf_mod
+        from django_waf.receivers import set_trusted_cookie_flag_on_login
 
         with patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", False):
             user = _make_user(is_staff=True)

--- a/tests/test_trusted_user_cookie.py
+++ b/tests/test_trusted_user_cookie.py
@@ -72,7 +72,7 @@ def _make_middleware(get_response=None):
 
 
 # ---------------------------------------------------------------------------
-# django_waf.services.trusted_user_service — signing/verification
+# django_waf.services.trusted_user_service, signing/verification
 # ---------------------------------------------------------------------------
 
 
@@ -253,7 +253,7 @@ class TestSetAndReadTrustedCookie:
 
 
 class TestFeatureOffIsANoOp:
-    """DJANGO_WAF_TRUSTED_COOKIE_ENABLED=False (the default) — a stray,
+    """DJANGO_WAF_TRUSTED_COOKIE_ENABLED=False (the default), a stray,
     otherwise-valid-looking cookie must never grant the bypass."""
 
     def test_has_valid_trusted_cookie_false_even_with_freshly_signed_cookie(self):
@@ -269,7 +269,7 @@ class TestFeatureOffIsANoOp:
             set_trusted_cookie(response, factory.get("/", REMOTE_ADDR="203.0.113.9"))
             signed_value = response.cookies[TRUSTED_USER_COOKIE].value
 
-        # Feature now off — the cookie above is real and unexpired.
+        # Feature now off, the cookie above is real and unexpired.
         request = factory.get("/", REMOTE_ADDR="203.0.113.9")
         request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
 
@@ -277,7 +277,7 @@ class TestFeatureOffIsANoOp:
 
 
 # ---------------------------------------------------------------------------
-# django_waf.middleware._is_staff_user — cookie-first, request.user fallback
+# django_waf.middleware._is_staff_user, cookie-first, request.user fallback
 # ---------------------------------------------------------------------------
 
 
@@ -300,7 +300,7 @@ class TestIsStaffUserPrefersTrustedCookie:
 
             request = factory.get("/", REMOTE_ADDR="203.0.113.9")
             request.COOKIES[TRUSTED_USER_COOKIE] = signed_value
-            # No request.user attribute at all — pre-AuthenticationMiddleware.
+            # No request.user attribute at all, pre-AuthenticationMiddleware.
             assert not hasattr(request, "user")
 
             assert _is_staff_user(request) is True


### PR DESCRIPTION
Closes #23. The last item from the 2026-08-01 triage: the WAF can now recognise staff without depending on `AuthenticationMiddleware` order, dissolving the W004 ordering tension. Opt-in, off by default, so existing sites are unaffected. Full suite green: **1058 passed, 0 failed**; `makemigrations --check` clean (no model changes); CI ruff gate (0.15.22) clean.

## What it does
A staff/superuser logging in with the feature enabled receives a WAF-owned, IP-bound, short-TTL signed cookie (`trusted_user_service`, mirroring the site-password cookie's `TimestampSigner` pattern). `_is_staff_user` checks that cookie first, so the staff bypass fires even when `WafMiddleware` sits before auth (the security-first ordering every real deployment uses). Falls back to `request.user` unchanged when the WAF is after auth. When enabled, `django_waf.W004` no longer fires.

## Design decisions (from the brief's recommended defaults)
- Off by default (`DJANGO_WAF_TRUSTED_COOKIE_ENABLED=False`); existing behaviour byte-identical until opted in.
- Staff-only by default (`DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL="staff"`, or `"authenticated"`); an invalid value warns via the new `django_waf.W006` and falls back to `"staff"`.
- Short TTL (`DJANGO_WAF_TRUSTED_COOKIE_TTL=3600`) and IP binding via the hardened `resolve_client_ip` resolver (#29), so a stolen cookie grants the bypass only briefly and only from the same address.
- Cross-subdomain via `DJANGO_WAF_TRUSTED_COOKIE_DOMAIN` (falls back to `SESSION_COOKIE_DOMAIN`).

## Wiring notes for the reviewer
- The `user_logged_in` receiver (`receivers.set_trusted_cookie_flag_on_login`) sets a request flag; a new `_get_response` wrapper in `WafMiddleware` writes the cookie on the response. Every internal `get_response` call site routes through it. Verified a no-op for every request that did not log in with the feature enabled (the entire existing suite passes unchanged).
- The receiver is connected in `apps.ready()` only when the feature is enabled at startup (toggling the setting needs a restart, standard Django).

New settings, all in `conf.py`. New service `trusted_user_service.py`, new `receivers.py`. `docs/DESIGN-trusted-user-cookie.md` is the design brief this implements.

Spec sync (`docs/specs/django-waf/`) rides on a companion umbrella PR.