### PR TITLE
fix: non-Redis cache fail-open (#44), leftmost-XFF check (#42), threat model docs (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The non-Redis cache fallback was broken: six Redis-only calls raised on
+  `LocMemCache` and the WAF silently failed open (#44).** Three
+  near-identical `_get_redis_client()`/`_default_redis_factory()`
+  implementations (`middleware.py`, `views.py`,
+  `forms/protection.py`) caught `django_redis.get_redis_connection()`
+  raising `NotImplementedError` (the configured cache alias is not a
+  django-redis backend, the common case for `LocMemCache` under
+  `DEBUG=True`) and fell back to returning `django.core.cache.cache`
+  itself. That object has no `setex`, no incr-with-init, no pipeline, and
+  no sorted-set support, so Redis-only calls in `rule_engine.py`,
+  `rate_limiter.py`, and elsewhere raised `AttributeError` several frames
+  later, caught by the middleware's outermost handler, which failed the
+  whole WAF open per BR-EVAL-007: it evaluated no rules at all, on any
+  project whose cache backend was not Redis, while looking from a plain
+  200 response exactly like a healthy pass. New
+  `django_waf.services.redis_client.get_redis_client()` is now the single
+  resolution point: it returns a real Redis client or `None`, never a
+  non-Redis object standing in for one. BR-EVAL-007's existing fail-open
+  policy for a genuine runtime Redis outage is unchanged and still applies;
+  what changes is that a *misconfigured* backend (the wrong kind of cache
+  configured, not a working Redis that is merely unreachable right now) is
+  now surfaced.
+- New system check **`django_waf.E004`** (Error): fires at boot when
+  `DJANGO_WAF_REDIS_ALIAS` is not configured as a `django_redis.cache.RedisCache`
+  backend, since rule evaluation, rate limiting, and challenge state have
+  no safe equivalent on a generic Django cache backend. A security control
+  that reports healthy while blocking nothing is worse than one that
+  refuses to start; this check exists so an operator catches the
+  misconfiguration at `manage.py check` rather than only discovering it
+  from a stream of per-request log lines.
+
 ## [1.8.0] - 2026-08-01
 
 A single opt-in feature closing the last item from the 2026-08-01 triage: the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documentation
+
+- **New `docs/THREAT-MODEL.md` (#36).** django-waf is marketed and packaged
+  as a WAF; read literally that implies payload inspection (SQLi, XSS,
+  OWASP Core Rule Set-class coverage), which this package does not do. The
+  new document is a verified capability matrix (in scope: bot detection,
+  rate limiting, PoW challenges, reputation scoring, the form-defence
+  chain; out of scope: payload inspection, upload scanning, volumetric
+  DDoS), the trust boundaries (Redis, the opt-in threat feed, middleware
+  ordering), and an honest accounting of the automatic-enforcement safety
+  controls: what the schema already supports (provenance, confidence, TTL
+  fields; a post-hoc dashboard review path; a per-invocation dry-run mode)
+  against what it does not (no detector runs observe-only by default,
+  auto-generated rules carry no evidence in their `confidence`/`notes`
+  fields, review happens after enforcement rather than before it, no
+  aggregate false-positive-proxy metric exists). Four follow-on
+  implementation issues (#45, #46, #47, #48) are filed for the gaps this
+  document identifies rather than folded into this documentation pass. The
+  README now links to it and states the payload-inspection boundary
+  up front.
+
 ### Fixed
 
 - **The non-Redis cache fallback was broken: six Redis-only calls raised on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   misconfiguration at `manage.py check` rather than only discovering it
   from a stream of per-request log lines.
 
+### Added
+
+- New system check **`django_waf.W007`** (#42): warns at boot when
+  `DJANGO_WAF_TRUST_X_FORWARDED_FOR` is enabled and
+  `DJANGO_WAF_TRUSTED_PROXIES` is empty, the configuration under which
+  `client_ip.resolve_client_ip` (BR-EVAL-008) falls back to trusting the
+  leftmost `X-Forwarded-For` entry unconditionally: exactly the hop a
+  client controls, and therefore spoofable by design. The resolver already
+  logged a warning on every such request; this surfaces the same risk once,
+  at boot.
+
 ## [1.8.0] - 2026-08-01
 
 A single opt-in feature closing the last item from the 2026-08-01 triage: the

--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@ user-agent anomaly scoring, JS proof-of-work challenges, path-based threat
 scoring, nginx blocklist generation, and collective threat feed integration,
 all configurable without a reverse-proxy vendor.
 
+This is bot detection and anti-abuse tooling, not a payload-inspecting
+firewall: it does not scan request bodies for SQL injection, XSS, or other
+OWASP Core Rule Set-class attacks. See [docs/THREAT-MODEL.md](docs/THREAT-MODEL.md)
+for the full capability matrix, trust boundaries, and the current state of
+automatic-enforcement safety controls (evidence, confidence, and review
+path) before relying on this package as a site's only defence layer.
+
 ## Features
 
 - **Rate limiting**: sliding-window per-IP limits (burst, per-minute, per-5-min)

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -1,0 +1,214 @@
+# django-waf: Threat Model and Operator Safety Controls
+
+Status: current as of the `Unreleased` branch (post-1.8.0). Issue: #36.
+
+Every claim below is checked against source (`file:line` or module name) as
+of this pass. Where a control does not exist yet, this document says so
+plainly rather than describing an aspiration as shipped: per ADR-021, this
+document describes the in-process, MIT-licensed package only, and must not
+promise operated-service or roadmap features that are not built.
+
+---
+
+## 1. What this document is for
+
+django-waf is marketed and packaged as a WAF. Read literally, "web
+application firewall" implies payload inspection: SQL injection, XSS,
+command injection, the OWASP Core Rule Set class of coverage. django-waf
+does not do any of that. What it does is bot detection, rate limiting,
+proof-of-work challenges, IP/UA reputation, and a form-submission defence
+chain: an anti-abuse and bot-management system, not a payload-inspecting
+firewall. This document exists so an operator (or a prospective one reading
+marketing copy) can see the real capability matrix and trust boundary
+before deploying it as their only defence layer, and so any future
+commercial claim about this package is checked against what section 2 says
+is actually built, per the verified-claims discipline in
+`docs/research/competitors/django-waf/market-strategy.md` (umbrella repo).
+
+---
+
+## 2. Capability matrix
+
+### In scope (built, verified against source)
+
+| Capability | Module | Notes |
+|---|---|---|
+| Bot / scraper detection | `services/ua_analyser.py`, `services/fingerprint.py` | Heuristic UA scoring plus HTTP fingerprint mismatch scoring (claimed browser UA missing the headers a real browser sends) |
+| Rate limiting | `services/rate_limiter.py` | Redis sliding-window, per-IP and optionally per-path |
+| Proof-of-work challenges | `services/challenge_service.py`, `views.ChallengeView`/`VerifyView` | Hashcash-style; solved client-side, verified server-side |
+| IP / CIDR / UA block and allow rules | `services/rule_engine.py`, `models.BlockRule`/`AllowRule` | Priority-ordered; rDNS-gated allow rules for verified crawlers |
+| IP reputation scoring | `services/anomaly_detector.py` (`update_ip_reputation`), `models.IPReputation` | Rebuilt from `RequestLog` on a schedule; a composite threat score, not a payload verdict |
+| Anomaly detection (auto rule creation) | `services/anomaly_detector.py` | UA rotation, cloud spray, challenge farms, subnet bursts; see section 4 for the safety gaps this document exists to surface |
+| Collective threat feed (opt-in) | `services/threat_feed.py`, `06-threat-feed-api.md` | Client only; see section 3 |
+| Form-submission defence chain | `forms/` (eight defences) | Honeypot, timing, render-token replay protection, UA consistency, JS touch, credential/signup throttling, form-level PoW |
+| Site-password gate (opt-in) | `services/site_password_service.py` | Whole-site shared-password wall, independent of rule evaluation |
+| nginx blocklist export | `services/blocklist_generator.py` | Generates `map`/`geo` config from active rules; enforcement is operator-wired (BR-BL-007) |
+
+### Out of scope (not built; do not claim)
+
+| Not covered | Why this matters |
+|---|---|
+| Application payload inspection (SQLi, XSS, command injection, OWASP CRS-class signatures) | `RuleType` has exactly four values (`ua`, `ip`, `cidr`, `composite`, `enums.py`); none inspects a request body or query string against attack signatures. `request.body` is read in exactly one place in the whole package (`views.py:247`), to parse the challenge-solution JSON on `POST /waf/verify/`, not to scan a payload. The closest existing capability is reconnaissance-path scoring (`DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS`, matched against the path only), which is not payload inspection |
+| File upload scanning | No upload-handling code exists in the package |
+| Volumetric / network-layer DDoS mitigation | The package is in-process Django middleware plus an nginx export; it has no edge network, no anycast, no capacity beyond the host it runs on. A large enough flood exhausts the host before the WAF's own logic runs |
+| TLS termination, certificate management | Out of scope by design; a consumer's existing web server owns this |
+| GeoIP database lifecycle beyond `django_waf_install_geoip` | The package ships a download command; it does not operate or update a hosted GeoIP service |
+| Central threat feed service | `threats.drystane.com` is a separate, closed commercial implementation of the public wire contract (`06-threat-feed-api.md`); this package is the client only |
+
+If a page or a customer conversation ever needs the phrase "web application
+firewall" without qualification, that claim is false against this matrix.
+The honest framing, consistent with the market-strategy document's
+positioning lines, is anti-abuse and bot-management, in-process, with WAF
+used as a category label buyers search for rather than a literal capability
+promise.
+
+---
+
+## 3. Trust boundaries
+
+- **The package trusts Redis.** Rule evaluation, rate limiting, and
+  challenge state have no safe fallback on a non-Redis cache backend (see
+  `django_waf.services.redis_client`, issue #44); a misconfigured or
+  unreachable Redis makes the WAF evaluate nothing for the duration
+  (fail-open, BR-EVAL-007). This is a deliberate choice, not an oversight:
+  the alternative (fail closed on every Redis hiccup) would make the WAF
+  itself the site's biggest availability risk. An operator who needs
+  fail-closed behaviour for a specific route must build that at the
+  reverse-proxy layer, not expect it from this package.
+- **The package trusts the operator's Redis and database, not any third
+  party, for anything except the opt-in threat feed and telemetry.** No
+  request data leaves the process unless `DJANGO_WAF_FEED_REPORT` (default
+  `False`) is explicitly turned on, and even then only hashed UAs and
+  truncated IP subnets are sent (BR-TEL-002), never full IPs, paths,
+  headers, cookies, or user identifiers.
+- **The package trusts `AuthenticationMiddleware` ordering, with an opt-in
+  escape hatch.** The staff/superuser bypass (BR-RATE-003) reads
+  `request.user` by default, which requires `WafMiddleware` to run after
+  auth; `django_waf.W004` warns when it does not. From 1.8.0, the
+  trusted-user cookie (`DJANGO_WAF_TRUSTED_COOKIE_ENABLED`) removes this
+  dependency for sites that opt in, at the cost of a new signed,
+  short-TTL, IP-bound cookie the WAF issues and trusts itself.
+- **A feed-sourced allow rule is trusted only after forward-confirmed rDNS
+  and, by default, operator review.** Feed-sourced `AllowRule`s require
+  `verify_rdns=True` and are created `is_active=False` (quarantined) unless
+  `DJANGO_WAF_FEED_QUARANTINE_ALLOW_RULES` is explicitly disabled
+  (BR-FEED-008). This is the one place the package already implements
+  approval-before-enforcement; section 4 covers where it does not.
+- **Feed responses are not cryptographically signed.** A compromised or
+  on-path-tampered feed (mitigated for HTTP by `django_waf.W005`, which
+  warns when the feed URL is not HTTPS, but not eliminated) can inject or
+  suppress `BlockRule`s up to the confidence and validation checks in
+  BR-FEED-002/007. Signing is deferred to a separate service-side decision
+  (tracked at `drystane/drystane.com#6`), out of this package's control.
+
+---
+
+## 4. Operator safety controls: what exists, what does not
+
+The acceptance criteria for this issue ask whether automatic enforcement
+retains evidence, confidence, TTL, and provenance, whether detectors
+support observe-only rollout, and whether outcomes are exposed. The honest
+answer, checked against `services/anomaly_detector.py` as of this pass, is
+partial: the schema already has the right shape, but the detectors that
+populate it do not use most of it.
+
+### What exists today
+
+- **The schema already carries provenance, confidence, and TTL fields.**
+  `BlockRule` has `source` (`admin`/`auto`/`feed`), `confidence`
+  (`DecimalField`), `expires_at`, `hit_count`, `last_hit_at`, and `notes`
+  (`models.py`). An auto-generated rule is tagged `source=auto` and expires
+  after `DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS` (or the escalation-specific TTL
+  for challenge-escalation blocks), so nothing an automatic detector
+  creates is permanent by default (BR-LIFE-001).
+- **A review path exists, after the fact.** The staff dashboard's
+  "Anomalies" panel (`views.DashboardAnomalyPanel`) lists auto-generated
+  `BlockRule`s created in the last 48 hours; a superuser can confirm
+  (promote to a permanent `source=admin` rule) or reject (deactivate) via
+  `DashboardAnomalyConfirmView`/`DashboardAnomalyRejectView`
+  (`views.py:611-656`). This is enforce-then-review, not
+  approve-before-enforcement: the rule is already live (challenging or
+  blocking real traffic) by the time a human sees it.
+- **Log-only exists as an enum value the rule engine honours.**
+  `RuleAction.LOG_ONLY` (`enums.py:13`) is a real, evaluated action for
+  manually-authored `BlockRule`s (BR-BL-005 excludes it from the nginx
+  export; the middleware still applies it at the application layer).
+- **A dry-run mode exists for manual detector invocation.** From 1.7.0,
+  `run_all_detectors(dry_run=True)` and the `django_waf_detect_anomalies
+  --dry-run` command flag genuinely suppress every write (BR-ANOM-006).
+  This is a per-invocation safety valve for an operator testing detector
+  behaviour, not a standing configuration a detector runs under
+  continuously.
+- **The closest existing proxy for a false-positive signal is the
+  challenge solve rate.** `IPReputationAdmin` (`admin.py:424-425`) computes
+  `challenge_success_rate` (passes over total challenges) per IP. It is a
+  proxy, not a purpose-built false-positive metric: it conflates "solved
+  the PoW" with "was not a false positive", which are not the same claim
+  for every verdict type (a `BlockRule` block, for instance, is never
+  challenged at all, so it never contributes to this rate).
+
+### What does not exist today (gaps this document surfaces, not fixes)
+
+- **No detector runs in a standing observe-only mode.** Every anomaly
+  detector hardcodes its action: `detect_ua_rotation`, `detect_subnet_burst`,
+  and `detect_cloud_spray` create `action=RuleAction.CHALLENGE`
+  (`anomaly_detector.py:76, 142, 455`); `detect_challenge_farms` and
+  `detect_unsolved_challenges` create `action=RuleAction.BLOCK`
+  (`anomaly_detector.py:196, 336`). Every one of these is created
+  `is_active=True` (`anomaly_detector.py:614`), so
+  it enforces from the moment it is written, before any human sees it. The
+  `dry_run` flag above is the only way to run a detector without writing
+  anything, and it is an all-or-nothing per-invocation switch, not a
+  per-detector "log only, do not enforce" standing policy.
+- **Auto-generated rules carry none of the evidence fields the schema
+  already has room for.** `_get_or_create_auto_rule`'s `defaults` dict
+  sets `name`, `match_type`, `is_active`, and `expires_at` only
+  (`anomaly_detector.py:611-616`); it never sets `confidence` (so every
+  auto rule silently inherits the model default, `1.00`, the same value a
+  hand-authored admin rule would carry) and never sets `notes` (so the
+  only human-readable evidence for why a rule fired lives in the rule's
+  `name` string and a transient `anomaly_detected` signal payload that is
+  not persisted anywhere a later reviewer can read). A reviewer looking at
+  the dashboard's Anomalies panel sees a rule and a creation timestamp,
+  not the request counts, score, or window that triggered it.
+- **No aggregate outcome metric is exposed anywhere.** The dashboard shows
+  today's verdict counts (`DashboardStatsPanel`) and top-blocked IPs
+  (`DashboardTopBlockedPanel`), but nothing answers "of the rules an
+  automatic detector created this week, how many were confirmed versus
+  rejected versus left un-reviewed and simply expired". That number would
+  be the honest false-positive proxy this package is missing.
+
+### Follow-on work (tracked separately, not part of this documentation pass)
+
+Per the triage plan for #36, closing the gaps above is implementation
+work, scoped here and filed as separate issues so this documentation pass
+does not silently expand into a feature build:
+
+1. Give each detector an independent `dry_run`-equivalent standing mode
+   (observe-only per detector, not only per manual invocation), so an
+   operator can run detection with zero enforcement until they trust it.
+2. Populate `confidence` and `notes` on every auto-generated rule with the
+   evidence that triggered it (request counts, score, window), using the
+   fields the schema already has.
+3. Turn the dashboard's Anomalies panel into an approval queue for a
+   configurable subset of detectors (quarantined like feed-sourced allow
+   rules, BR-FEED-008, rather than enforce-then-review by default).
+4. Add a confirmed/rejected/expired-unreviewed outcome metric, surfaced on
+   the dashboard, as the real false-positive proxy this document
+   identifies as missing.
+
+---
+
+## 5. Summary position
+
+django-waf is an in-process Django anti-abuse and bot-management system:
+rate limiting, PoW challenges, IP/UA/CIDR rules, reputation scoring, an
+opt-in collective threat feed, and a form-defence chain, all built and
+verified against source. It is not a payload-inspecting firewall, has no
+DDoS mitigation, and its automatic-enforcement detectors currently act
+before any human reviews them, with the review path itself running
+after enforcement rather than before it. Any positioning or sales
+conversation should lead with what section 2 lists as built, name the
+gaps in section 4 rather than let a prospective buyer discover them, and
+treat "WAF" as the category label the market searches for, not a literal
+capability claim this document cannot back up.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,9 +83,10 @@ ignore = ["S101", "S104", "S105", "S106", "S107", "S110", "S112", "S311", "S603"
 # hand-edited, so lint rules for them are relaxed.
 "src/django_waf/migrations/*.py" = ["E501"]
 # Pytest fixtures imported from django_waf.testing.fixtures are used as
-# test-function parameters of the same name — the standard pytest fixture
+# test-function parameters of the same name, the standard pytest fixture
 # pattern, which ruff's F811 misreads as shadowing/redefinition.
 "tests/test_testing_fixtures.py" = ["F811"]
+"tests/test_redis_fallback.py" = ["F811"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -56,6 +56,16 @@ that reports healthy while blocking nothing is worse than one that refuses
 to start, and this check exists so an operator catches the misconfiguration
 at ``manage.py check`` rather than discovering it from a stream of
 per-request log lines.
+
+The leftmost-XFF check (``django_waf.W007``) warns when
+``DJANGO_WAF_TRUST_X_FORWARDED_FOR`` is enabled and
+``DJANGO_WAF_TRUSTED_PROXIES`` is empty (#42), the configuration under
+which ``client_ip.resolve_client_ip`` (BR-EVAL-008) falls back to trusting
+the leftmost ``X-Forwarded-For`` entry unconditionally: exactly the hop a
+client controls, and therefore spoofable by design. The resolver already
+logs a warning on every such request; this check surfaces the same risk
+once, at boot, so it is not only discoverable by noticing a per-request log
+line.
 """
 
 from __future__ import annotations
@@ -356,5 +366,44 @@ def check_redis_backend(app_configs, **kwargs):
                 "that is."
             ),
             id="django_waf.E004",
+        )
+    ]
+
+
+@register()
+def check_legacy_xff_trust(app_configs, **kwargs):
+    """Warn (``django_waf.W007``) when ``DJANGO_WAF_TRUST_X_FORWARDED_FOR``
+    is enabled with no ``DJANGO_WAF_TRUSTED_PROXIES`` configured (#42).
+
+    Under this combination, ``client_ip.resolve_client_ip`` (BR-EVAL-008)
+    falls back to trusting the leftmost ``X-Forwarded-For`` entry
+    unconditionally: exactly the entry a client controls, and therefore
+    spoofable by design. The resolver already logs a warning on every
+    request that takes this path; this check surfaces the same
+    configuration risk once, at boot.
+    """
+    from django_waf import conf
+
+    if not conf.DJANGO_WAF_TRUST_X_FORWARDED_FOR:
+        return []
+
+    if conf.DJANGO_WAF_TRUSTED_PROXIES:
+        return []
+
+    return [
+        Warning(
+            "DJANGO_WAF_TRUST_X_FORWARDED_FOR is True and "
+            "DJANGO_WAF_TRUSTED_PROXIES is empty: the client-IP resolver "
+            "is trusting the leftmost X-Forwarded-For entry unconditionally, "
+            "which is exactly the entry a client controls and can spoof to "
+            "choose its own block or rate-limit identity.",
+            hint=(
+                "Set DJANGO_WAF_TRUSTED_PROXIES to the CIDR ranges of your "
+                "actual reverse proxies so the resolver walks "
+                "X-Forwarded-For from a trusted boundary instead, or set "
+                "DJANGO_WAF_TRUST_X_FORWARDED_FOR = False if you do not sit "
+                "behind a proxy that sets this header."
+            ),
+            id="django_waf.W007",
         )
     ]

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -44,6 +44,18 @@ The trust-level check (``django_waf.W006``) warns when
 (``django_waf.services.trusted_user_service.get_trust_level`` coerces an
 unrecognised value to ``"staff"``), so this is a Warning about an
 ineffective setting, not an Error about a lockout.
+
+The Redis backend check (``django_waf.E004``) errors when
+``DJANGO_WAF_REDIS_ALIAS`` is not configured as a ``django-redis`` cache
+backend (#44). Rule evaluation, rate limiting, and challenge state have no
+safe equivalent on a generic Django cache backend (rate limiting alone uses
+Redis sorted sets and pipelines), so a misconfigured alias means the WAF
+fails open (BR-EVAL-007) for every single request, silently, from process
+start. This is an Error, not a Warning, deliberately: a security control
+that reports healthy while blocking nothing is worse than one that refuses
+to start, and this check exists so an operator catches the misconfiguration
+at ``manage.py check`` rather than discovering it from a stream of
+per-request log lines.
 """
 
 from __future__ import annotations
@@ -307,5 +319,42 @@ def check_trusted_cookie_trust_level(app_configs, **kwargs):
             "population) rather than honouring this value.",
             hint='Set DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL to "staff" or "authenticated".',
             id="django_waf.W006",
+        )
+    ]
+
+
+@register()
+def check_redis_backend(app_configs, **kwargs):
+    """Error (``django_waf.E004``) when ``DJANGO_WAF_REDIS_ALIAS`` is not a
+    django-redis cache backend (#44).
+
+    Only inspects ``settings.CACHES``, never opens a connection: this check
+    must be cheap and side-effect-free like every other check in this
+    module, and must not be confused with a live Redis health check (a
+    correctly configured backend that is merely unreachable right now is
+    the outage BR-EVAL-007 already handles at runtime, not a misconfigured
+    one this check should flag).
+    """
+    from django_waf import conf
+    from django_waf.services.redis_client import is_redis_backend
+
+    if is_redis_backend(conf.DJANGO_WAF_REDIS_ALIAS):
+        return []
+
+    return [
+        Error(
+            f"DJANGO_WAF_REDIS_ALIAS={conf.DJANGO_WAF_REDIS_ALIAS!r} is not "
+            "configured as a django-redis cache backend. The WAF has no "
+            "safe fallback for rule evaluation, rate limiting, or "
+            "challenge state on a generic Django cache backend, and will "
+            "fail open (pass every request through without evaluation) "
+            "for the lifetime of this process.",
+            hint=(
+                f"Set CACHES[{conf.DJANGO_WAF_REDIS_ALIAS!r}]['BACKEND'] to "
+                "'django_redis.cache.RedisCache' pointing at a real Redis "
+                "instance, or point DJANGO_WAF_REDIS_ALIAS at a cache alias "
+                "that is."
+            ),
+            id="django_waf.E004",
         )
     ]

--- a/src/django_waf/forms/protection.py
+++ b/src/django_waf/forms/protection.py
@@ -214,25 +214,21 @@ def _order_defences(names: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _default_redis_factory():
-    """Return the package-wide Redis client (or None on failure).
+    """Return the package-wide Redis client, or None on failure.
 
     The factory shape (callable returning client) matches what
     individual defences expect, so we can swap it for tests without
     monkey-patching the conf module.
+
+    Thin wrapper over ``django_waf.services.redis_client.get_redis_client``
+    (#44): never falls back to a non-Redis cache object, since a defence
+    calling a Redis-only command against a plain Django cache object would
+    raise deep inside the form-protection chain instead of the caller
+    taking a single clean fail-open decision.
     """
-    from django_waf import conf
+    from django_waf.services.redis_client import get_redis_client
 
-    try:
-        from django_redis import get_redis_connection
-
-        return get_redis_connection(conf.DJANGO_WAF_REDIS_ALIAS)
-    except Exception:
-        try:
-            from django.core.cache import cache
-
-            return cache
-        except Exception:
-            return None
+    return get_redis_client()
 
 
 # ---------------------------------------------------------------------------

--- a/src/django_waf/handlers.py
+++ b/src/django_waf/handlers.py
@@ -31,8 +31,12 @@ def _get_cache():
     """
     Return the configured cache backend for WAF operations.
 
-    Prefers django-redis (which supports atomic INCR) but falls back to
-    Django's default cache so the package works without django-redis in tests.
+    Unlike ``django_waf.services.redis_client.get_redis_client`` (#44), this
+    is intentionally allowed to fall back to the plain Django cache API,
+    because every call site below only ever calls ``incr``/``set``, both of
+    which the Django cache API implements directly. That is the one part of
+    #44's advertised fallback that was already genuinely safe: this
+    function's contract does not change.
     """
     from django.conf import settings
 
@@ -41,7 +45,10 @@ def _get_cache():
         from django_redis import get_redis_connection  # type: ignore[import-untyped]
 
         return get_redis_connection(alias)
-    except ImportError:
+    except (NotImplementedError, ImportError):
+        # NotImplementedError: alias is configured but not django-redis
+        # backed (e.g. LocMemCache), safe to fall back to here, unlike
+        # the Redis-only callers in middleware.py/views.py/rule_engine.py.
         from django.core.cache import caches
 
         return caches[alias]

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -563,31 +563,22 @@ def _is_staff_user(request) -> bool:
 
 
 def _get_redis_client():
-    """Return a Redis client instance.
+    """Return a Redis client instance, or None if Redis is unavailable.
 
-    Tries django-redis's get_redis_connection first; falls back to the default
-    Django cache. Returns None if Redis is unavailable (fail-open policy).
+    Thin wrapper over ``django_waf.services.redis_client.get_redis_client``
+    (#44), kept so existing call sites and test patches within this module
+    (and ``django_waf.testing.fixtures.waf_redis_mock``) don't need to
+    change. See that module for why this never falls back to a non-Redis
+    cache object: a WAF that appears to keep evaluating requests using a
+    fake Redis client fails several frames deeper with an unhandled
+    AttributeError, which the middleware's outer handler then catches and
+    fails the whole WAF open, silently. Returning None here instead makes
+    every existing "if redis_client is None: fail open" call site in this
+    module (BR-EVAL-007) trigger deterministically instead.
     """
-    from django_waf import conf
+    from django_waf.services.redis_client import get_redis_client
 
-    try:
-        from django_redis import get_redis_connection
-
-        return get_redis_connection(conf.DJANGO_WAF_REDIS_ALIAS)
-    except Exception:
-        pass
-
-    try:
-        from django.core.cache import cache
-
-        # For non-redis cache backends this returns the cache object — callers
-        # that need Redis-specific commands will raise and be caught.
-        return cache
-    except Exception:
-        pass
-
-    logger.warning("django-waf: Redis unavailable — failing open")
-    return None
+    return get_redis_client()
 
 
 def _emit_request_blocked(result, ip_address: str, user_agent: str, path: str) -> None:

--- a/src/django_waf/services/redis_client.py
+++ b/src/django_waf/services/redis_client.py
@@ -1,0 +1,126 @@
+"""Single source of truth for resolving django-waf's Redis client.
+
+``django-redis`` is a hard dependency of this package (see
+``pyproject.toml``), so it is always importable. The failure mode this
+module exists to close (#44) is not "django-redis is missing": it is
+``django_redis.get_redis_connection(alias)`` raising ``NotImplementedError``
+whenever the configured cache alias is backed by something other than
+``django_redis.cache.RedisCache`` (``LocMemCache`` is the common case, for
+example under ``DEBUG=True``). Before #44, three call sites each caught that
+broadly and fell back to returning ``django.core.cache.cache`` itself, a
+plain Django cache object with no ``setex``, no incr-with-init, no pipeline,
+and no sorted-set support. Redis-only calls several frames downstream
+(sliding-window rate limiting, ``SETEX``, ``INCR`` on a key that has never
+been set, ``HINCRBY``) then raised ``AttributeError``, caught by the
+middleware's outermost handler, which failed the whole WAF open per
+BR-EVAL-007. A security control that reports healthy while blocking nothing
+is the worst possible failure mode for this package specifically.
+
+The fix is not to build a full adapter over the Django cache API: rate
+limiting (``services/rate_limiter.py``) uses Redis sorted sets and
+pipelines, for which the generic cache API has no safe equivalent. Building
+a partial adapter would let the WAF look healthy while its rate limiter
+silently no-ops or behaves incorrectly, which is the same failure mode in a
+different disguise. Instead:
+
+* ``get_redis_client`` returns a real Redis client or ``None``, never a
+  non-Redis object pretending to be one. Every existing
+  ``if redis_client is None: <fail open>`` call site (already correct per
+  BR-EVAL-007 / AC-EVAL-007) then triggers deterministically, once, at the
+  top of the request, instead of a fake client crashing three frames
+  deeper with a traceback that reads like noise.
+* ``django_waf.E004`` (see ``checks.py``) surfaces the misconfiguration
+  (wrong backend configured) at boot as an Error, so an operator catches it
+  via ``manage.py check`` before it reaches production, rather than only
+  learning about it from a stream of per-request tracebacks.
+
+BR-EVAL-007 itself is unchanged: a genuine Redis outage, where the correctly
+configured backend is temporarily unreachable, must still fail the request
+through rather than 500. This module only makes the "is this actually
+Redis" determination once, cleanly, in one place.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger("django_waf.redis_client")
+
+# Logged once per process (not once per request) so a misconfigured
+# deployment doesn't drown its own logs in a repeat of the same message on
+# every single request.
+_warned_aliases: set[str] = set()
+
+
+def get_redis_client(alias: str | None = None):
+    """Return a Redis client for ``alias``, or ``None`` if unavailable.
+
+    Args:
+        alias: Django cache alias to resolve. Defaults to
+            ``django_waf.conf.DJANGO_WAF_REDIS_ALIAS`` when not given.
+
+    Returns:
+        A ``django_redis``-backed Redis client instance, or ``None``. Never
+        returns a non-Redis cache object: callers that receive ``None`` must
+        take their own fail-open (or fail-closed, for a boot-time check)
+        path rather than attempting to call Redis-only commands on a
+        fallback object.
+    """
+    from django_waf import conf
+
+    resolved_alias = alias or conf.DJANGO_WAF_REDIS_ALIAS
+
+    try:
+        from django_redis import get_redis_connection
+
+        return get_redis_connection(resolved_alias)
+    except (NotImplementedError, ImportError):
+        # NotImplementedError: the configured cache alias exists but is not
+        # a django-redis backend (e.g. LocMemCache), a misconfiguration,
+        # not a transient outage.
+        # ImportError: django-redis itself is not installed, despite being
+        # a declared dependency (e.g. a broken or partial install).
+        if resolved_alias not in _warned_aliases:
+            _warned_aliases.add(resolved_alias)
+            logger.error(
+                "django-waf: cache alias %r is not a django-redis backend. "
+                "The WAF requires Redis for rule evaluation, rate limiting, "
+                "and challenge state, and has no safe equivalent for these "
+                "on a generic Django cache backend. The WAF is failing open "
+                "(BR-EVAL-007) for every request on this alias until this is "
+                "fixed. Set CACHES[%r] to a django_redis.cache.RedisCache "
+                "backend, or point DJANGO_WAF_REDIS_ALIAS at one that is. "
+                "Run `manage.py check` to see this as django_waf.E004.",
+                resolved_alias,
+                resolved_alias,
+            )
+        return None
+    except Exception:
+        # A genuine runtime failure talking to an otherwise correctly
+        # configured Redis (connection refused, timeout, auth failure).
+        # This is exactly the outage BR-EVAL-007 exists for: fail open,
+        # but don't spam an ERROR per request for a condition operators
+        # already monitor via Redis's own health checks.
+        logger.warning("django-waf: Redis unavailable for alias %r, failing open", resolved_alias)
+        return None
+
+
+def is_redis_backend(alias: str | None = None) -> bool:
+    """Return True if ``alias`` is configured as a django-redis backend.
+
+    Used by ``django_waf.E004`` (``checks.py``) to distinguish "correctly
+    configured, just unreachable right now" (not our concern, that is the
+    outage BR-EVAL-007 handles) from "the wrong kind of cache backend is
+    configured" (a boot-time misconfiguration this check should catch).
+
+    Never raises: any error while inspecting the configured backend is
+    treated as "cannot confirm this is Redis", which is the safer answer
+    for a check whose job is to flag a possible misconfiguration.
+    """
+    from django.conf import settings
+
+    resolved_alias = alias or getattr(settings, "DJANGO_WAF_REDIS_ALIAS", "default")
+
+    caches_setting = getattr(settings, "CACHES", {})
+    backend = caches_setting.get(resolved_alias, {}).get("BACKEND", "")
+    return backend.startswith("django_redis.cache.")

--- a/src/django_waf/views.py
+++ b/src/django_waf/views.py
@@ -75,20 +75,19 @@ def _get_ip(request: HttpRequest) -> str:
 
 
 def _get_redis_client():
+    """Return a Redis client instance, or None if Redis is unavailable.
+
+    Thin wrapper over ``django_waf.services.redis_client.get_redis_client``
+    (#44), kept so existing call sites and test patches within this module
+    (``django_waf.testing.fixtures.waf_redis_mock``) don't need to change.
+    Never falls back to a non-Redis cache object: see that module for why a
+    fake Redis client is worse than None here, it lets Redis-only calls
+    (``setex``, ``delete``, and so on in this module) raise deep inside a
+    view instead of the caller taking a clean, single fail-open decision.
     """
-    Return a Redis client, preferring django-redis.
-    Falls back to django.core.cache if django-redis is not installed.
-    """
-    try:
-        from django_redis import get_redis_connection  # type: ignore[import]
+    from django_waf.services.redis_client import get_redis_client
 
-        from django_waf import conf
-
-        return get_redis_connection(conf.DJANGO_WAF_REDIS_ALIAS)
-    except (ImportError, Exception):
-        from django.core.cache import cache
-
-        return cache
+    return get_redis_client()
 
 
 def _validate_next_url(request: HttpRequest, next_param: str | None) -> str:
@@ -169,6 +168,13 @@ class ChallengeView(NoIndexResponseMixin, TemplateView):
         ip = _get_ip(request)
         next_url = _validate_next_url(request, request.GET.get("next"))
         redis_client = _get_redis_client()
+        if redis_client is None:
+            # This view is only reached via a middleware redirect that
+            # itself required a working Redis client (#44): a direct hit
+            # with Redis unavailable is a misconfigured deployment or a
+            # stale bookmark, not the normal path. Fail explicitly rather
+            # than raise AttributeError deep inside issue_challenge().
+            return HttpResponse(_("This site is temporarily unavailable."), status=503)
         user_agent = request.META.get("HTTP_USER_AGENT", "")
 
         challenge_token = issue_challenge(ip, redis_client, user_agent=user_agent)
@@ -255,6 +261,10 @@ class VerifyView(NoIndexResponseMixin, View):
         ip = _get_ip(request)
         next_url = _validate_next_url(request, next_param)
         redis_client = _get_redis_client()
+        if redis_client is None:
+            # See ChallengeView.get: a direct hit on /waf/verify/ with Redis
+            # unavailable is a misconfiguration, not the normal path (#44).
+            return JsonResponse({"error": _("This site is temporarily unavailable.")}, status=503)
 
         try:
             verify_challenge_solution(token, nonce, ip, redis_client)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -43,6 +43,12 @@ def _run_trusted_cookie_trust_level_check():
     return check_trusted_cookie_trust_level(app_configs=None)
 
 
+def _run_legacy_xff_trust_check():
+    from django_waf.checks import check_legacy_xff_trust
+
+    return check_legacy_xff_trust(app_configs=None)
+
+
 class TestChallengeDifficultyCheck:
     def test_recommended_defaults_produce_no_messages(self):
         import django_waf.conf as conf_mod
@@ -326,3 +332,50 @@ class TestTrustedCookieTrustLevelCheck:
             patch.object(conf_mod, "DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL", "everyone"),
         ):
             assert _run_trusted_cookie_trust_level_check() == []
+
+
+class TestLegacyXffTrustCheck:
+    """W007 warns when DJANGO_WAF_TRUST_X_FORWARDED_FOR is enabled with no
+    DJANGO_WAF_TRUSTED_PROXIES configured (#42)."""
+
+    def test_disabled_produces_no_messages(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_TRUST_X_FORWARDED_FOR", False),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_PROXIES", []),
+        ):
+            assert _run_legacy_xff_trust_check() == []
+
+    def test_enabled_with_trusted_proxies_produces_no_messages(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_TRUST_X_FORWARDED_FOR", True),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_PROXIES", ["10.0.0.0/8"]),
+        ):
+            assert _run_legacy_xff_trust_check() == []
+
+    def test_enabled_with_no_trusted_proxies_emits_w007_warning(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_TRUST_X_FORWARDED_FOR", True),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_PROXIES", []),
+        ):
+            messages = _run_legacy_xff_trust_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W007"
+
+    def test_disabled_with_no_trusted_proxies_is_silent(self):
+        """The default combination (both settings at their defaults) must
+        not warn: this check only fires when the spoofable legacy path is
+        actually reachable."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_TRUST_X_FORWARDED_FOR", False),
+            patch.object(conf_mod, "DJANGO_WAF_TRUSTED_PROXIES", []),
+        ):
+            assert _run_legacy_xff_trust_check() == []

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1061,14 +1061,22 @@ class TestMiddlewareHelpers:
         with patch("django_redis.get_redis_connection", return_value=fake_conn):
             assert _get_redis_client() is fake_conn
 
-    def test_get_redis_client_falls_back_to_django_cache(self):
-        """When django-redis fails, falls back to django.core.cache."""
+    def test_get_redis_client_fails_open_to_none(self):
+        """When the configured cache is not a Redis backend, resolution fails open to None.
+
+        Superseded by #44 (tests/test_redis_fallback.py is the crux suite for
+        this contract): the pre-fix behaviour asserted here used to fall back
+        to django.core.cache.cache, an object with no Redis-only methods, so
+        callers several frames downstream raised AttributeError. Post-fix,
+        django_waf.services.redis_client.get_redis_client() is the single
+        resolution point and returns a real Redis client or None, never a
+        non-Redis stand-in.
+        """
         from django_waf.middleware import _get_redis_client
 
-        with patch("django_redis.get_redis_connection", side_effect=RuntimeError("no redis")):
-            client = _get_redis_client()
-            # Should return the Django cache instance
-            assert client is not None
+        client = _get_redis_client()
+
+        assert client is None
 
     def test_emit_request_blocked_sends_signal_with_verdict(self):
         """_emit_request_blocked sends the request_blocked signal with verdict from result.

--- a/tests/test_redis_fallback.py
+++ b/tests/test_redis_fallback.py
@@ -1,0 +1,265 @@
+"""Regression tests for #44: the non-Redis cache fallback was broken.
+
+Before this fix, ``_get_redis_client()`` (three near-identical copies in
+``middleware.py``, ``views.py``, and ``forms/protection.py``) fell back to
+returning ``django.core.cache.cache`` itself whenever the configured cache
+alias was not a django-redis backend (the common case for ``LocMemCache``
+under ``DEBUG=True``). That object has no ``setex``, no incr-with-init, no
+pipeline, and no sorted-set support, so Redis-only calls several frames
+downstream raised ``AttributeError``, caught by the middleware's outermost
+handler, which failed the whole WAF open: it evaluated no rules at all,
+while looking, from a plain 200 response, exactly like a healthy pass.
+
+The crux of this file is ``TestMiddlewareActuallyBlocksWithWorkingRedis``:
+it proves the WAF genuinely blocks what it should block when Redis is
+available (via the ``waf_redis_mock``/fakeredis fixture the package already
+ships), and separately proves that when Redis genuinely is not the
+configured backend (plain ``LocMemCache``, the default test settings, no
+fakeredis override), the fallback fails cleanly, once, at the top of the
+middleware (BR-EVAL-007), rather than raising deep inside the rule engine.
+An assertion that only checks "no exception was raised" would have passed
+on the pre-fix code too, since the outer ``except Exception`` already
+swallowed the crash, so every test below asserts on the actual HTTP
+response and/or a system check message, never merely on absence of a
+traceback.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+from django.core.checks import Error
+from django.test import RequestFactory, override_settings
+
+from django_waf.checks import check_redis_backend
+from django_waf.enums import RuleAction, RuleType
+from django_waf.middleware import WafMiddleware
+from django_waf.models import BlockRule
+from django_waf.services.redis_client import get_redis_client, is_redis_backend
+
+# ---------------------------------------------------------------------------
+# The crux: the WAF must actually BLOCK when Redis is genuinely available,
+# proving the fix did not just suppress the crash while leaving evaluation
+# inert. tests/settings.py runs on LocMemCache; waf_redis_mock (fakeredis)
+# is what makes the underlying cache alias Redis-shaped for this test only.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestMiddlewareActuallyBlocksWithWorkingRedis:
+    """The regression-proving tests: the precondition is never hand-set.
+
+    Each test creates a real BlockRule and issues a real request through
+    the full middleware stack via the Django test client, then asserts on
+    the HTTP response the WAF actually returned. It never reaches into the
+    middleware internals to assert a verdict was computed, which is exactly
+    the shortcut that would pass unchanged whether or not evaluation ran.
+    """
+
+    def test_blocks_a_request_matching_an_active_block_rule(self, client, waf_redis_mock):
+        BlockRule.objects.create(
+            name="test-block-ip",
+            rule_type=RuleType.IP,
+            match_type="exact",
+            pattern="203.0.113.50",
+            action=RuleAction.BLOCK,
+        )
+
+        response = client.get("/", REMOTE_ADDR="203.0.113.50")
+
+        assert response.status_code == 403
+
+    def test_does_not_block_a_request_from_a_different_ip(self, client, waf_redis_mock):
+        """Negative control: the same rule must not block an unrelated IP.
+
+        Without this, a middleware bug that 403s everything (a different
+        failure mode entirely, but one that would still make the positive
+        test above pass) would go undetected.
+        """
+        BlockRule.objects.create(
+            name="test-block-ip",
+            rule_type=RuleType.IP,
+            match_type="exact",
+            pattern="203.0.113.50",
+            action=RuleAction.BLOCK,
+        )
+
+        response = client.get("/", REMOTE_ADDR="203.0.113.99")
+
+        assert response.status_code == 200
+
+    def test_challenges_a_request_matching_an_active_challenge_rule(self, client, waf_redis_mock):
+        BlockRule.objects.create(
+            name="test-challenge-ua",
+            rule_type=RuleType.UA,
+            match_type="exact",
+            pattern="known-bad-scraper/1.0",
+            action=RuleAction.CHALLENGE,
+        )
+
+        response = client.get("/", HTTP_USER_AGENT="known-bad-scraper/1.0")
+
+        assert response.status_code == 302
+        assert "/waf/challenge/" in response["Location"]
+
+
+# ---------------------------------------------------------------------------
+# get_redis_client(): never falls back to a non-Redis cache object.
+# ---------------------------------------------------------------------------
+
+
+class TestGetRedisClientNeverReturnsANonRedisFallback:
+    def test_returns_none_on_locmemcache_default_test_settings(self):
+        """tests/settings.py CACHES['default'] is LocMemCache (no override
+        here, unlike the tests above): this is the exact configuration
+        #44 was filed against."""
+        assert get_redis_client() is None
+
+    def test_does_not_return_the_django_cache_object(self):
+        """The pre-fix bug: the fallback silently returned
+        django.core.cache.cache, which round-trips like a working client
+        until a Redis-only method is called on it. Assert the specific
+        wrong-object regression directly, not just "is None"."""
+        from django.core.cache import cache as django_cache
+
+        result = get_redis_client()
+
+        assert result is not django_cache
+
+    def test_logs_a_single_error_with_no_traceback(self, caplog):
+        """Pre-fix, the failure surfaced as an unhandled AttributeError
+        traceback logged from deep inside rule_engine.py. Post-fix it must
+        be one clean ERROR log line from the resolution point itself."""
+        import django_waf.services.redis_client as redis_client_mod
+
+        redis_client_mod._warned_aliases.clear()
+
+        with caplog.at_level(logging.ERROR, logger="django_waf.redis_client"):
+            get_redis_client()
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert len(error_records) == 1
+        assert error_records[0].exc_info is None  # no traceback attached
+
+    def test_warns_only_once_per_process_not_once_per_call(self, caplog):
+        import django_waf.services.redis_client as redis_client_mod
+
+        redis_client_mod._warned_aliases.clear()
+
+        with caplog.at_level(logging.ERROR, logger="django_waf.redis_client"):
+            get_redis_client()
+            get_redis_client()
+            get_redis_client()
+
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert len(error_records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Middleware fails open cleanly (BR-EVAL-007 / AC-EVAL-007) when Redis is
+# genuinely not the configured backend, rather than crashing several frames
+# into rule evaluation.
+# ---------------------------------------------------------------------------
+
+
+class TestMiddlewareFailsOpenCleanlyWithoutRedis:
+    def _make_middleware(self):
+        from django.http import HttpResponse
+
+        return WafMiddleware(lambda req: HttpResponse("passed-through"))
+
+    def test_request_passes_through_on_locmemcache(self):
+        middleware = self._make_middleware()
+        request = RequestFactory().get("/", REMOTE_ADDR="203.0.113.5")
+
+        response = middleware(request)
+
+        assert response.status_code == 200
+        assert response.content == b"passed-through"
+
+    def test_no_evaluation_error_traceback_is_logged(self, caplog):
+        """Pre-fix: an "evaluation error, failing open" log line plus a
+        full AttributeError traceback from three frames inside
+        rule_engine.py. Post-fix: the middleware never reaches
+        evaluate_request() at all, because _get_redis_client() returns
+        None and the existing "if redis_client is None" guard (BR-EVAL-007)
+        fires first."""
+        middleware = self._make_middleware()
+        request = RequestFactory().get("/", REMOTE_ADDR="203.0.113.6")
+
+        with caplog.at_level(logging.WARNING):
+            middleware(request)
+
+        traceback_records = [r for r in caplog.records if r.exc_info is not None]
+        assert traceback_records == []
+
+    def test_evaluate_request_is_never_called(self):
+        """Positive proof the fail-open path is taken before rule
+        evaluation, not that evaluation happened to raise and get caught."""
+        middleware = self._make_middleware()
+        request = RequestFactory().get("/", REMOTE_ADDR="203.0.113.7")
+
+        with patch("django_waf.services.rule_engine.evaluate_request") as mock_eval:
+            middleware(request)
+
+            mock_eval.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# django_waf.E004 system check
+# ---------------------------------------------------------------------------
+
+
+class TestRedisBackendSystemCheck:
+    def test_errors_on_locmemcache(self):
+        messages = check_redis_backend(None)
+
+        assert len(messages) == 1
+        assert isinstance(messages[0], Error)
+        assert messages[0].id == "django_waf.E004"
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django_redis.cache.RedisCache",
+                "LOCATION": "redis://localhost:6379/0",
+            }
+        }
+    )
+    def test_silent_on_a_configured_redis_backend(self):
+        import importlib
+
+        import django_waf.conf as conf_mod
+
+        importlib.reload(conf_mod)
+
+        messages = check_redis_backend(None)
+
+        assert messages == []
+
+    def test_is_redis_backend_helper_matches_the_check(self):
+        assert is_redis_backend() is False
+
+    @override_settings(
+        CACHES={
+            "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+            "waf": {
+                "BACKEND": "django_redis.cache.RedisCache",
+                "LOCATION": "redis://localhost:6379/1",
+            },
+        },
+        DJANGO_WAF_REDIS_ALIAS="waf",
+    )
+    def test_respects_a_non_default_redis_alias(self):
+        import importlib
+
+        import django_waf.conf as conf_mod
+
+        importlib.reload(conf_mod)
+
+        messages = check_redis_backend(None)
+
+        assert messages == []
+        importlib.reload(conf_mod)

--- a/tests/test_redis_fallback.py
+++ b/tests/test_redis_fallback.py
@@ -38,6 +38,7 @@ from django_waf.enums import RuleAction, RuleType
 from django_waf.middleware import WafMiddleware
 from django_waf.models import BlockRule
 from django_waf.services.redis_client import get_redis_client, is_redis_backend
+from django_waf.testing.fixtures import waf_redis_mock  # noqa: F401 (used as a pytest fixture)
 
 # ---------------------------------------------------------------------------
 # The crux: the WAF must actually BLOCK when Redis is genuinely available,


### PR DESCRIPTION
## Summary

- **#44** (priority): the non-Redis cache fallback silently degraded the WAF to evaluating no rules at all. `django_waf.services.redis_client.get_redis_client()` is now the single resolution point, returning a real Redis client or `None`, never a non-Redis object standing in for one. New `django_waf.E004` system check (Error) fires at boot when the configured cache alias is not a django-redis backend.
- **#42**: new `django_waf.W007` boot-time system check for the legacy leftmost-`X-Forwarded-For` trust path when no trusted proxies are configured.
- **#36**: new `docs/THREAT-MODEL.md`, a verified capability matrix, trust boundaries, and honest accounting of the automatic-enforcement safety-control gaps. Four follow-on implementation issues filed (#45, #46, #47, #48) for the gaps it identifies.

`#40` (spec drift) is handled separately in the umbrella repo: [icvoss/icv-oss-umbrella#200](https://github.com/icvoss/icv-oss-umbrella/pull/200).

## Test plan

- [ ] `pytest tests/test_redis_fallback.py -v` — the #44 regression tests. The crux: `TestMiddlewareActuallyBlocksWithWorkingRedis` proves the WAF genuinely blocks a matching `BlockRule` end-to-end via the `waf_redis_mock`/fakeredis fixture (never just "no exception raised"); `TestGetRedisClientNeverReturnsANonRedisFallback` and `TestMiddlewareFailsOpenCleanlyWithoutRedis` prove the `LocMemCache` fallback returns `None` cleanly with a single `ERROR` log and no traceback; `TestRedisBackendSystemCheck` covers `django_waf.E004`.
- [ ] `pytest tests/test_checks.py -v` — `TestLegacyXffTrustCheck` covers `django_waf.W007`.
- [ ] `pytest` (full suite) — confirm no regressions in the existing suite.
- [ ] `ruff check src/ tests/` and `ruff format --check src/ tests/` — both pass locally.