### PR TITLE
chore: stamp the canonical PR template with the ADR Affects checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,10 @@ exists.
 - [ ] Tests added or updated for the change (see CONTRIBUTING.md)
 - [ ] `ruff check` and `ruff format --check` pass locally
 - [ ] CHANGELOG.md has an entry under Unreleased
+- [ ] If this PR ratifies or amends an ADR, every artefact named in its
+      **Affects** field has a diff here, or a linked follow-up issue.
+      Deferring part of a sweep is fine; leaving it unstated is not
+      (project-standards LESSONS.md, Trap 30)
 - [ ] No migration was generated with icv-core installed (packages with
       an optional icv-core dependency only; see the repo's docs)
 - [ ] Breaking changes are called out explicitly below


### PR DESCRIPTION
Stamps the canonical PR template so the ADR **Affects** checklist actually reaches this repo.

## Why

ADR-056 and ADR-060 each named `docs/specs/django-brickwork/` in their Affects field, and both sweeps skipped it. The code half landed and was enforced by tests; the documentation half silently did not, because nothing anywhere fails when a spec drifts. The result was a spec documenting a required kwarg the code had renamed, so a consumer following it got a `TypeError`, plus a renamed dict key that failed silently.

The rule that came out of it: the PR ratifying or amending an ADR carries a diff for every artefact named in its Affects field, or links a follow-up issue for each one deferred. Deferring is legitimate on a large sweep; leaving it unstated is not.

That rule lives in a PR-template checklist item, so it only bites where the template is deployed. This repo either had no copy or a copy predating the item.

## The change

One file, copied verbatim from `templates/repo/PULL_REQUEST_TEMPLATE.md` in the oss umbrella. No local customisation existed to preserve: repos that already had a template differed from canonical by exactly the new item and nothing else.

Part of a sweep across all 34 package repos.

Policy: project-standards LESSONS.md Trap 30 (nigelcopley/project-standards#44). Umbrella half: icvoss/icv-oss-umbrella#217.