### PR TITLE
chore(release): 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.0] - 2026-08-10
 
 ### Added
 
@@ -57,6 +57,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   has passed, independently of whether they were ever activated, so a
   quarantined rule nobody reviews is marked expired unreviewed rather than
   sitting pending forever.
+
+### Fixed
+
+- **The `anomaly_detected` signal's documented payload now matches what the
+  code actually sends (#52).** `signals.py` described the signal as
+  providing `ip_address`, `anomaly_type`, `score`, and `details`, but the
+  only call site sends `rule`, `anomaly_type`, and `details`: a receiver
+  written against the documented payload raised `KeyError` on `ip_address`
+  or `score`. The comment is corrected to describe the real payload rather
+  than the code changed to match the comment, since the sent payload is the
+  one any existing receiver is already written against. The offending IP or
+  CIDR is available as the rule's own `pattern`.
 
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "1.8.1"
+version = "1.9.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/django_waf/signals.py
+++ b/src/django_waf/signals.py
@@ -7,8 +7,11 @@ from django.dispatch import Signal
 # Provides: instance, created (for saves) / instance (for deletes)
 rule_saved = Signal()
 
-# Fired when the anomaly scorer detects suspicious behaviour from an IP.
-# Provides: ip_address, anomaly_type, score, details
+# Fired when an anomaly detector creates a rule for suspicious behaviour.
+# Provides: rule (the BlockRule created), anomaly_type, details
+# The sender is the rule's model class. The offending IP or CIDR is the
+# rule's own pattern, and the evidence that triggered detection is in
+# details (and, since 1.9.0, mirrored onto the rule's notes field).
 anomaly_detected = Signal()
 
 # Fired when a proof-of-work challenge is issued to a client.


### PR DESCRIPTION
Cuts 1.9.0, releasing the approve-before-enforce cluster merged in #54.

## Version rationale

**Minor, not patch.** Per `RELEASING.md`, any new public API or behaviour change is a minor. This adds `DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES` and `DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS`, the `BlockRule.review_status`/`reviewed_at` fields, `auto_rule_review_outcomes`, and the `django_waf.W008` check. No breaking changes: the quarantine default is `False`, so an existing deployment upgrading sees identical enforcement behaviour.

## Bundled fix: #52

`signals.py` documented `anomaly_detected` as providing `ip_address`, `anomaly_type`, `score`, `details`, but the only call site sends `rule`, `anomaly_type`, `details`. A receiver written against the documented payload raised `KeyError`.

Corrected the comment to match the code, not the reverse: the sent payload is what any existing receiver is already written against, so changing the code would break working consumers to satisfy a docstring. The offending IP or CIDR is available as the rule's own `pattern`.

Bundled rather than deferred because it sits in the exact code path this release changes. Shipping the approval workflow while the signal docstring still lies would hand a `KeyError` to the first consumer wiring up the new evidence payload.

## Not included

**#53** (`AnomalyType.BURST` and `PATH_HAMMERING` are dead values, confirmed: zero references in `src/`). Removing them is a breaking change to a public enum, so it belongs in a major, and whether they are reserved for future detectors is still an open question. Left for a decision.

## Verification

- Suite **1095 passing** on the release branch.
- Verified on the **built wheel**, not just the source tree: `django_waf-1.9.0-py3-none-any.whl` carries `Version: 1.9.0`, the corrected `signals.py` docstring, and migration `0005_blockrule_review_status`.
- No em or en dashes introduced.

## After merge

Tag `v1.9.0` on the merged commit. Tagging is publishing (OIDC trusted publishing to PyPI) and is irreversible, so that stays a gated manual step.