### PR TITLE
fix: confirmed-bucket metric and dead AnomalyType values (#56 #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The confirmed/rejected outcome metric no longer empties its own
+  `confirmed` bucket (#56).** `auto_rule_review_outcomes` filtered on
+  `source=auto`, but confirming a rule promotes it to `source=admin` (which
+  is what stops it reappearing in the review queue and stops the detector
+  re-matching it on its `source=auto` lookup key), so every rule left the
+  metric at the exact moment it was confirmed. The `confirmed` bucket was
+  therefore permanently zero, and the metric reported only the outcomes
+  nobody approved: precisely inverting what BR-ANOM-010 exists to show. The
+  window now matches a rule that is either still `source=auto` or carries
+  any review status other than `not_applicable`. Widening on review status
+  rather than source is precise rather than loose, since `review_status`
+  only ever leaves `not_applicable` for a rule an anomaly detector created,
+  so no hand-authored or feed-sourced rule can enter the count.
+
+### Removed
+
+- **`AnomalyType.BURST` and `AnomalyType.PATH_HAMMERING` (#53).** Neither
+  was emitted by any detector, so both advertised a category that could
+  never have members: in a security tool that reads as "the detector exists
+  and is quiet" rather than "it was never built", and any per-anomaly-type
+  breakdown carried two permanently empty rows. Both behaviours are already
+  covered elsewhere and were never detector-shaped: per-second burst by
+  `DJANGO_WAF_RATE_LIMIT_BURST` in the rate limiter, and path hammering by
+  `DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS` scoring. No data migration is
+  needed, because no model field stores an `AnomalyType`: the enum travels
+  only as an `anomaly_detected` signal kwarg. This is technically breaking
+  for any consumer that references either constant by name, which is why it
+  is called out here rather than folded into a patch.
+
 ## [1.9.0] - 2026-08-10
 
 ### Added

--- a/src/django_waf/enums.py
+++ b/src/django_waf/enums.py
@@ -78,12 +78,19 @@ class ChallengeStatus(models.TextChoices):
 
 
 class AnomalyType(models.TextChoices):
-    """The category of anomaly detected by the scoring engine."""
+    """The category of anomaly detected by the scoring engine.
+
+    Every value here is emitted by a detector in
+    ``services/anomaly_detector.py`` and travels only as an
+    ``anomaly_detected`` signal kwarg; no model field stores an
+    ``AnomalyType``. Adding a value without a detector that sends it makes
+    the WAF advertise a category that can never have members, which reads to
+    an operator as "that detector exists and is quiet" rather than "it was
+    never built" (django-waf #53).
+    """
 
     UA_ROTATION = "ua_rotation", _("UA rotation")
-    BURST = "burst", _("Burst")
     SUBNET_FLOOD = "subnet_flood", _("Subnet flood")
-    PATH_HAMMERING = "path_hammering", _("Path hammering")
     CHALLENGE_FARM = "challenge_farm", _("Challenge farm")
     UNSOLVED_CHALLENGE = "unsolved_challenge", _("Unsolved challenge")
     CLOUD_SPRAY = "cloud_spray", _("Cloud spray")

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -607,6 +607,11 @@ def auto_rule_review_outcomes(window_hours: int = 168) -> dict:
     metric does not misrepresent a rule nobody was ever asked to review as
     one still awaiting a decision.
 
+    The window matches a rule that is either still ``source=auto`` or carries
+    any review status other than ``not_applicable``. Confirming a rule
+    promotes it to ``source=admin``, so filtering on source alone would empty
+    the ``confirmed`` bucket permanently (django-waf #56).
+
     Args:
         window_hours: How far back, in hours, to look at BlockRule.created_at.
             Default 168 (7 days).
@@ -615,14 +620,27 @@ def auto_rule_review_outcomes(window_hours: int = 168) -> dict:
         Dict with keys "pending", "confirmed", "rejected",
         "expired_unreviewed", "not_applicable", and "total".
     """
-    from django.db.models import Count
+    from django.db.models import Count, Q
 
     from django_waf.enums import ReviewStatus, RuleSource
     from django_waf.models import BlockRule
 
     window_start = timezone.now() - timedelta(hours=window_hours)
+    # Match on provenance OR review state, not on source alone. A confirmed
+    # rule is promoted to source=ADMIN by DashboardAnomalyConfirmView (which
+    # is what stops it reappearing in the review queue and stops the detector
+    # re-matching it on its source=AUTO lookup key), so a source=AUTO-only
+    # filter would drop every rule out of this metric at the exact moment it
+    # was confirmed, leaving the confirmed bucket permanently empty and the
+    # metric reporting only the outcomes nobody approved.
+    #
+    # Widening on review_status rather than source is precise rather than
+    # loose: review_status only ever leaves NOT_APPLICABLE for a rule an
+    # anomaly detector created, so no hand-authored or feed-sourced rule can
+    # enter the count through this arm.
+    reviewed = ~Q(review_status=ReviewStatus.NOT_APPLICABLE)
     rows = (
-        BlockRule.objects.filter(source=RuleSource.AUTO, created_at__gte=window_start)
+        BlockRule.objects.filter(Q(source=RuleSource.AUTO) | reviewed, created_at__gte=window_start)
         .values("review_status")
         .annotate(count=Count("id"))
     )

--- a/tests/test_review_workflow.py
+++ b/tests/test_review_workflow.py
@@ -470,3 +470,91 @@ class TestAutoRuleReviewOutcomes:
         outcomes = auto_rule_review_outcomes()
 
         assert outcomes["total"] == 0
+
+    def test_hand_authored_admin_rule_still_excluded_after_widened_filter(self):
+        """django-waf#56 regression guard: widening the filter to catch a
+        confirmed (now source=ADMIN) rule must not sweep in an unrelated
+        hand-authored admin rule that was never touched by the review
+        workflow. A plain BlockRuleFactory() row (source=ADMIN,
+        review_status=NOT_APPLICABLE) must stay out of every bucket."""
+        from django_waf.services.anomaly_detector import auto_rule_review_outcomes
+
+        BlockRuleFactory()
+
+        outcomes = auto_rule_review_outcomes()
+
+        assert outcomes["total"] == 0
+        assert outcomes["confirmed"] == 0
+        assert outcomes["not_applicable"] == 0
+
+    def test_confirmed_rule_counted_in_confirmed_bucket_via_real_confirm_path(self, client: Client, settings):
+        """django-waf#56: confirming a rule through the real
+        DashboardAnomalyConfirmView promotes it to source=ADMIN. Against the
+        pre-fix source=AUTO-only filter this rule would vanish from the
+        metric the instant it was confirmed, permanently zeroing the
+        confirmed bucket. Must go through the real HTTP confirm path. a
+        hand-set source/review_status on a factory would not exercise the
+        promotion this bug depends on.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.services.anomaly_detector import auto_rule_review_outcomes, detect_ua_rotation
+
+        settings.ROOT_URLCONF = "tests.urls"
+        superuser = _make_superuser("outcomes-confirmer")
+        client.force_login(superuser)
+
+        ip = "203.0.113.40"
+        _seed_rotating_ip(ip)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch.object(conf_mod, "DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES", True),
+        ):
+            created = detect_ua_rotation(window_minutes=10, threshold=20)
+        assert len(created) == 1
+        rule_id = created[0].pk
+
+        response = client.post(f"/waf/dashboard/anomalies/{rule_id}/confirm/")
+        assert response.status_code == 200
+
+        rule = BlockRule.objects.get(pk=rule_id)
+        assert rule.source == RuleSource.ADMIN
+        assert rule.review_status == ReviewStatus.CONFIRMED
+
+        outcomes = auto_rule_review_outcomes()
+
+        assert outcomes["confirmed"] == 1
+        assert outcomes["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# django-waf#53: AnomalyType has no value without an emitting detector
+# ---------------------------------------------------------------------------
+
+
+class TestAnomalyTypeMatchesEmittingDetectors:
+    def test_burst_and_path_hammering_removed(self):
+        """django-waf#53: BURST and PATH_HAMMERING were never emitted by any
+        detector and are removed from the enum."""
+        from django_waf.enums import AnomalyType
+
+        assert not hasattr(AnomalyType, "BURST")
+        assert not hasattr(AnomalyType, "PATH_HAMMERING")
+        assert "burst" not in AnomalyType.values
+        assert "path_hammering" not in AnomalyType.values
+
+    def test_every_remaining_value_is_emitted_by_a_detector(self):
+        """Every AnomalyType value is referenced as an anomaly_type= kwarg
+        somewhere in anomaly_detector.py, i.e. some detector actually emits
+        it. Guards against the category re-drifting from its detectors."""
+        import inspect
+
+        from django_waf.enums import AnomalyType
+        from django_waf.services import anomaly_detector
+
+        source = inspect.getsource(anomaly_detector)
+
+        for member in AnomalyType:
+            assert f"AnomalyType.{member.name}" in source, (
+                f"AnomalyType.{member.name} has no emitting detector in anomaly_detector.py"
+            )


### PR DESCRIPTION
Two follow-ups to 1.9.0. Closes #56 and #53, and resolves umbrella CHK-OPEN-008.

## #56: the outcome metric inverted its own meaning

CHK-OPEN-008 flagged this as a tension to decide. On inspection it is a defect.

`auto_rule_review_outcomes` filtered on `source=AUTO`, but `DashboardAnomalyConfirmView` promotes a confirmed rule to `source=ADMIN`. A rule therefore left the metric at the exact moment it was confirmed, so the `confirmed` bucket was **permanently zero** and the metric reported only `rejected`, `expired_unreviewed` and `pending`: the outcomes nobody approved. BR-ANOM-010 exists to give an operator an honest false-positive proxy, and as shipped it showed the opposite.

**Not fixed by dropping the re-source**, which is load-bearing in two places: the review queue scopes to `source=AUTO` (so re-sourcing is what removes a confirmed rule from the queue), and `_get_or_create_auto_rule`'s `update_or_create` lookup key includes it (so re-sourcing is what stops a detector re-matching a promoted rule). Dropping it would break both.

The window now matches `source=auto` OR any `review_status` other than `not_applicable`. Widening on review status is **precise rather than loose**: `review_status` only ever leaves `not_applicable` for a rule an anomaly detector created, so no hand-authored or feed-sourced rule can enter the count. A test pins that a plain admin rule stays out of every bucket.

Verified against a scratch database: the pre-fix filter counts **0** confirmed where the fix counts **1**, with the hand-authored rule correctly excluded.

## #53: two dead enum values removed

`AnomalyType.BURST` and `PATH_HAMMERING` were emitted by no detector, so both advertised a category that could never have members. In a security tool that reads as "the detector exists and is quiet" rather than "it was never built", and any per-anomaly-type breakdown carried two permanently empty rows.

Removed rather than reserved, because both behaviours **already ship elsewhere and were never detector-shaped**: per-second burst via `DJANGO_WAF_RATE_LIMIT_BURST` in the rate limiter, path hammering via `DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS` scoring. Calling them "reserved for a future detector" would have been fiction.

**No migration needed**: no model field stores an `AnomalyType`. It travels only as an `anomaly_detected` signal kwarg, which was the issue's main stated worry about removal.

This is technically **breaking** for a consumer referencing either constant by name, so it is called out under `### Removed` in the changelog and the next release should be a major, or these should ride with one.

## Verification

Suite **1099 passing** (1095 baseline plus 4 new). Both regression tests were confirmed to fail against the pre-fix code. The #56 test goes through the real `DashboardAnomalyConfirmView` HTTP endpoint rather than hand-setting `source`/`review_status`, which matters because the bug depends on the promotion that path performs. Ruff `check` and `format` clean at the CI-pinned 0.15.22.