### PR TITLE
chore(release): 1.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.9.1] - 2026-08-10
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "1.9.0"
+version = "1.9.1"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Ships the two post-1.9.0 fixes.

- **#56**: `auto_rule_review_outcomes` filtered on `source=AUTO` while confirming a rule promotes it to `source=ADMIN`, so the `confirmed` bucket read zero forever and the metric reported only the outcomes nobody approved. This is the fix with real operator impact.
- **#53**: removed `AnomalyType.BURST` and `PATH_HAMMERING`, neither emitted by any detector.

## On the version number

#53 is technically breaking: a consumer importing either constant by name gets an `AttributeError`. Strict SemVer would make this 2.0.0. Shipping as a minor is a deliberate owner call. The changelog's `### Removed` entry states the breakage plainly, so anyone who hits it can see the cause immediately.

Nothing in the ecosystem imports either constant (checked), so the practical blast radius is external consumers only.

## Verification

Suite 1099 passing. Verified on the built wheel: `django_waf-1.9.1-py3-none-any.whl` reports `Version: 1.9.1`.

After merge, tag `v1.9.1` on the merged commit. Tagging publishes to PyPI and is irreversible, so it stays a gated manual step.