### PR TITLE
fix: support trusted unix-socket proxy peers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trusted-proxy client IP resolution now supports unix-socket WSGI binds
+  (#62).** `DJANGO_WAF_TRUSTED_UNIX_SOCKET`, default `False`, explicitly
+  treats an empty `REMOTE_ADDR` as the trusted direct hop and applies the
+  existing right-to-left, validated `X-Forwarded-For` walk. It must be enabled
+  only when the unix socket is accessible exclusively to the reverse proxy;
+  non-empty peers remain subject to `DJANGO_WAF_TRUSTED_PROXIES` CIDR checks.
+
 - Removed the default `ordering = ["-created_at"]` from the bundled
   abstract `BaseModel` (ADR-066): a default ordering on a shared abstract
   base defeats `values()`/`values_list()` combined with `distinct()` in

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ All settings are namespaced under `DJANGO_WAF_*` and have sensible defaults.
 | `DJANGO_WAF_EXEMPT_PATHS` | `["/static/", "/media/", "/health/", "/favicon.ico"]` | URL prefixes that bypass WAF evaluation entirely |
 | `DJANGO_WAF_EXEMPT_HOSTS` | `[]` | Hostnames that bypass WAF evaluation entirely. Exact match, or a leading-dot entry (`.example.com`) matching the domain and any subdomain (mirrors Django's `ALLOWED_HOSTS`). Port is stripped before matching |
 | `DJANGO_WAF_TRUST_X_FORWARDED_FOR` | `False` | Trust `X-Forwarded-For` header for client IP extraction |
+| `DJANGO_WAF_TRUSTED_PROXIES` | `[]` | CIDR ranges for direct TCP reverse proxies. When `REMOTE_ADDR` is in a configured range, resolve `X-Forwarded-For` from right to left, skipping trusted proxy hops |
+| `DJANGO_WAF_TRUSTED_UNIX_SOCKET` | `False` | Explicitly trust an empty `REMOTE_ADDR` from a unix-socket WSGI peer and use the same right-to-left `X-Forwarded-For` walk. Enable only when the socket is accessible exclusively to your reverse proxy |
 | `DJANGO_WAF_REDIS_ALIAS` | `"default"` | Django cache alias for Redis connections |
 | `DJANGO_WAF_ALLOWED_METHODS` | `None` | Allowed HTTP methods; requests with other methods receive 405 before rule evaluation. `None` allows all methods. |
 | `DJANGO_WAF_ALLOW_VERIFIED_CRAWLERS` | `True` | Seed rDNS-verified `AllowRule` rows for major search crawlers (Googlebot, Bingbot) so a verified crawler is never served the `noindex` challenge. See [Search engine crawlers](#search-engine-crawlers). Set `False` to opt out |

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -564,6 +564,12 @@ DJANGO_WAF_CELERY_BEAT_SCHEDULE: dict = getattr(
 # internal load balancer, or the exact /32 of a single fronting proxy).
 DJANGO_WAF_TRUSTED_PROXIES: list[str] = getattr(settings, "DJANGO_WAF_TRUSTED_PROXIES", [])
 
+# Trust an empty REMOTE_ADDR from a unix-socket WSGI peer as the direct proxy
+# hop. This is deliberately opt-in: an operator must ensure that only their
+# reverse proxy can connect to the socket before the X-Forwarded-For header is
+# honoured.
+DJANGO_WAF_TRUSTED_UNIX_SOCKET: bool = getattr(settings, "DJANGO_WAF_TRUSTED_UNIX_SOCKET", False)
+
 # ---------------------------------------------------------------------------
 # Threat-feed import constraints (#33)
 # ---------------------------------------------------------------------------

--- a/src/django_waf/services/client_ip.py
+++ b/src/django_waf/services/client_ip.py
@@ -21,6 +21,12 @@ hop that is *not itself* a trusted proxy is taken, the standard walk for a
 chain of trusted reverse proxies, each of which appends the previous hop's
 address to the header.
 
+``DJANGO_WAF_TRUSTED_UNIX_SOCKET`` is a separate, explicit opt-in for a WSGI
+server reached through a unix socket, where ``REMOTE_ADDR`` is empty. It treats
+that empty direct peer as trusted and uses the same right-to-left walk. The
+operator is responsible for allowing only their reverse proxy to connect to
+the socket.
+
 The legacy ``DJANGO_WAF_TRUST_X_FORWARDED_FOR`` setting keeps working for
 backwards compatibility: with no trusted proxies configured, it falls back
 to the pre-#29 behaviour of trusting the leftmost XFF entry unconditionally.
@@ -48,12 +54,12 @@ def resolve_client_ip(request) -> str:
 
     Resolution order:
 
-    1. If ``DJANGO_WAF_TRUSTED_PROXIES`` is configured and ``REMOTE_ADDR`` is
-       within one of those CIDR ranges, walk ``X-Forwarded-For`` from the
-       right and return the first entry that is a valid IP address and is
-       not itself inside a trusted-proxy range. Malformed or empty entries
-       are skipped. If nothing valid remains after the walk, fall back to
-       ``REMOTE_ADDR``.
+    1. If ``REMOTE_ADDR`` is within ``DJANGO_WAF_TRUSTED_PROXIES``, or it is
+       empty and ``DJANGO_WAF_TRUSTED_UNIX_SOCKET`` is enabled, walk
+       ``X-Forwarded-For`` from the right and return the first entry that is
+       a valid IP address and is not itself inside a trusted-proxy range.
+       Malformed or empty entries are skipped. If nothing valid remains after
+       the walk, fall back to ``REMOTE_ADDR``.
     2. Otherwise, if ``DJANGO_WAF_TRUST_X_FORWARDED_FOR`` is set (legacy
        opt-in) and the header is present, return the leftmost entry
        unconditionally (spoofable, kept only for backwards compatibility;
@@ -67,8 +73,9 @@ def resolve_client_ip(request) -> str:
 
     remote_addr = request.META.get("REMOTE_ADDR", "") or ""
     trusted_proxies = conf.DJANGO_WAF_TRUSTED_PROXIES
+    trusted_unix_socket = conf.DJANGO_WAF_TRUSTED_UNIX_SOCKET and not remote_addr
 
-    if trusted_proxies and _is_trusted_proxy(remote_addr, trusted_proxies):
+    if _is_trusted_proxy(remote_addr, trusted_proxies) or trusted_unix_socket:
         forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR", "")
         resolved = _resolve_from_forwarded_chain(forwarded_for, trusted_proxies)
         if resolved:

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -164,6 +164,68 @@ class TestTrustedProxiesConfigured:
 
 
 # ---------------------------------------------------------------------------
+# Trusted unix-socket peer
+# ---------------------------------------------------------------------------
+
+
+class TestTrustedUnixSocket:
+    @override_settings(DJANGO_WAF_TRUSTED_UNIX_SOCKET=False)
+    def test_empty_remote_addr_does_not_trust_xff_by_default(self):
+        _reload_conf()
+        from django_waf.services.client_ip import resolve_client_ip
+
+        request = RequestFactory().get(
+            "/",
+            REMOTE_ADDR="",
+            HTTP_X_FORWARDED_FOR="203.0.113.9",
+        )
+
+        assert resolve_client_ip(request) == ""
+
+    @override_settings(DJANGO_WAF_TRUSTED_UNIX_SOCKET=True)
+    def test_empty_remote_addr_uses_hardened_xff_walk(self):
+        _reload_conf()
+        from django_waf.services.client_ip import resolve_client_ip
+
+        request = RequestFactory().get(
+            "/",
+            REMOTE_ADDR="",
+            HTTP_X_FORWARDED_FOR="6.6.6.6, 198.51.100.7",
+        )
+
+        assert resolve_client_ip(request) == "198.51.100.7"
+
+    @override_settings(DJANGO_WAF_TRUSTED_UNIX_SOCKET=True)
+    def test_empty_remote_addr_with_no_valid_xff_remains_empty(self):
+        _reload_conf()
+        from django_waf.services.client_ip import resolve_client_ip
+
+        request = RequestFactory().get(
+            "/",
+            REMOTE_ADDR="",
+            HTTP_X_FORWARDED_FOR="not-an-ip, ",
+        )
+
+        assert resolve_client_ip(request) == ""
+
+    @override_settings(
+        DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"],
+        DJANGO_WAF_TRUSTED_UNIX_SOCKET=True,
+    )
+    def test_nonempty_untrusted_remote_addr_still_ignores_xff(self):
+        _reload_conf()
+        from django_waf.services.client_ip import resolve_client_ip
+
+        request = RequestFactory().get(
+            "/",
+            REMOTE_ADDR="203.0.113.9",
+            HTTP_X_FORWARDED_FOR="198.51.100.7",
+        )
+
+        assert resolve_client_ip(request) == "203.0.113.9"
+
+
+# ---------------------------------------------------------------------------
 # Malformed / empty XFF entries
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- add an explicit, default-off DJANGO_WAF_TRUSTED_UNIX_SOCKET setting
- use the existing right-to-left, validated X-Forwarded-For walk when an enabled unix-socket peer has an empty REMOTE_ADDR
- document the socket-access trust boundary and add regression coverage

## Root cause

A unix-socket Gunicorn bind exposes an empty REMOTE_ADDR, which cannot match a trusted-proxy CIDR. The hardened resolver therefore never ran and could fall back to the legacy leftmost-XFF path.

## Validation

- uv run --extra dev pytest tests/test_client_ip.py --no-cov
- uv run --extra dev ruff check src/django_waf/conf.py src/django_waf/services/client_ip.py tests/test_client_ip.py
- git diff --check