### PR TITLE
chore: release django-waf v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.10.0] - 2026-08-11
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "1.9.1"
+version = "1.10.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Release metadata

- bump the package version from 1.9.1 to 1.10.0
- date the existing changelog entries for this minor release

## Why minor

The merged unix-socket trusted-proxy fix adds the public DJANGO_WAF_TRUSTED_UNIX_SOCKET setting and changes client-IP resolution when explicitly enabled.

## Release rehearsal

- uv run --extra dev --extra celery pytest --no-cov: 1104 passed
- uv run --with build --with twine python -m build
- uv run --with twine twine check dist/*