### PR TITLE
ci: drop cache: pip from setup-python

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
 
       - name: Install dependencies
         run: |
@@ -103,7 +102,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-          cache: "pip"
 
       - name: Install build tools
         run: |


### PR DESCRIPTION
Removes the `cache: "pip"` hint from every `actions/setup-python` step.

On the self-hosted runners this hint restores an ~877MB blob from GitHub's remote cache service at roughly 3MB/s, duplicating the warm `~ghrunner/.cache/pip` that plain `pip install` already reads from local disk. Proven on icv-cms (icvoss/icv-cms#73): the Lint job's "Set up Python" step went from 5m08s to 1s, taking the whole job from 5m19s to 6s.

Follows the canonical template, icvoss/icv-oss-umbrella#342.

**Files touched**: publish.yml (2) (2 occurrences total)

Pure removal, no correctness change, no change to pinned tool versions or python-version.