### PR TITLE
ci: add Django 6.1 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
         django-version: ["5.2", "6.0", "6.1"]
         exclude:
-          # Django 6.0 requires Python 3.12+
+          # Django 6.0 and 6.1 require Python 3.12+
           - python-version: "3.11"
             django-version: "6.0"
+          - python-version: "3.11"
+            django-version: "6.1"
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]
-        django-version: ["5.2", "6.0"]
+        django-version: ["5.2", "6.0", "6.1"]
         exclude:
           # Django 6.0 requires Python 3.12+
           - python-version: "3.11"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Django 6.1 added to the CI test matrix** and declared via the
+  `Framework :: Django :: 6.1` classifier.
+
 ## [1.10.0] - 2026-08-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Framework :: Django",
     "Framework :: Django :: 5.2",
     "Framework :: Django :: 6.0",
+    "Framework :: Django :: 6.1",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary

The CI matrix's `django-version` list stopped at 6.0 while `pyproject.toml` declared an unbounded `Django>=5.2` dependency, so the package claimed compatibility with any future 5.x/6.x release the suite had never actually run against. Django 6.1 is now the current release.

- Adds `6.1` to the `django-version` matrix list in `.github/workflows/ci.yml`.
- Adds the `Framework :: Django :: 6.1` trove classifier in `pyproject.toml`, alongside the existing 6.0 entry.
- Adds a changelog entry noting the new matrix leg and classifier.

No change to the `Django>=5.2` dependency floor or any upper bound.

## Test plan

- [ ] CI passes on this PR, including the new Django 6.1 matrix leg