### PR TITLE
fix: make silent Redis failures observable, and flush hit counts on Redis 6.0 (#78)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,54 @@ jobs:
       - name: Test with coverage
         run: pytest --cov=src --cov-report=term-missing
 
+  # Dedicated leg, not part of the matrix above: the defect this leg exists
+  # to catch (getdel requiring Redis 6.2+, silently failing on 6.0.16 for
+  # 40,936 task runs, never caught because the package has never executed
+  # a single Redis command against a real server) is Redis-version-specific,
+  # not Python/Django-version-specific. Real-Redis behaviour does not vary
+  # across the python-version x django-version matrix, so running it on all
+  # 7 legs would multiply CI time sevenfold for no extra defect-catching
+  # power. One dedicated leg on a single, representative Python/Django pair
+  # guarantees every PR exercises real Redis exactly once.
+  #
+  # Pinned to Redis 6.0 (the package's lowest supported version per its
+  # documented floor, see checks.py / redis_client.py), not latest: testing
+  # against Redis 7 would have hidden the getdel defect exactly as fakeredis
+  # did, since GETDEL exists from 6.2 onwards and both fakeredis (regardless
+  # of its version= argument, which does not gate GETDEL) and Redis 6.2+
+  # accept it silently. Only a real server below 6.2 raises.
+  test-redis-integration:
+    name: Test (real Redis 6.0 integration)
+    runs-on: ubuntu-latest
+    services:
+      redis:
+        image: redis:6.0-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          pip install "Django~=6.1.0"
+          pip install -e ".[dev,celery]"
+
+      - name: Test against real Redis 6.0
+        run: pytest tests/ -v --tb=short --color=yes --ds=tests.settings_redis -m redis_integration
+        env:
+          DJANGO_WAF_TEST_REDIS_URL: redis://localhost:6379/0
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,89 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Django 6.1 added to the CI test matrix** and declared via the
   `Framework :: Django :: 6.1` classifier.
 
+- **`django_waf.E005`: a boot-time check for the connected Redis server's
+  version.** `django_waf.services.redis_client.MIN_REDIS_VERSION` (6.0) is
+  now the package's single declared floor, read via `INFO` and compared at
+  `manage.py check` time. Guarded exactly like `django_waf.E004`: silent
+  when the WAF is disabled, when the configured cache alias is not even a
+  django-redis backend, or when a live version cannot be read, so it never
+  repeats the mistake `django_waf.E004` made in #67 (firing under
+  `DJANGO_WAF_ENABLED = False`). Only a reachable, correctly configured
+  server reporting an unsupported version raises an Error.
+
+### Fixed
+
+- **`flush_rule_hit_counts` silently flushed nothing on Redis older than
+  6.2 (#78).** The task called `redis_client.getdel(key)`, which requires
+  Redis 6.2+; on a 6.0/6.1 server every call raised `ResponseError`,
+  caught by a bare `except Exception: continue`, so every `BlockRule`'s
+  `hit_count` stayed permanently 0 and `last_hit_at` stayed `None` while
+  the task logged `"flushed hit counts for 0 rules"` at INFO on every run,
+  identical to a genuinely idle site. Confirmed in production against a
+  Redis 6.0.16 server: 40,936 runs, all reporting success, none flushing
+  anything. `getdel` was the only command anywhere in the package needing
+  newer than Redis 6.0, so the fix is a `GET`+`DEL` pipeline in its place,
+  not a raised floor: the pipeline is not atomic against a concurrent
+  `INCR` landing between the two commands, an acceptable trade for a
+  coarse hit counter flushed every five minutes rather than a balance.
+  `BlockRule.objects.filter(...).update()` failures in the same loop
+  (previously caught by the same bare `except: continue`, so a DB error
+  read identically to a Redis error) now increment a distinct `errors`
+  count and log at ERROR rather than vanishing silently.
+
+- **Redis failures that fail open silently, with no log at any level, now
+  log a WARNING naming the consequence.** Fail-open behaviour is
+  unchanged in every case (BR-EVAL-007): only observability changes.
+  - `rule_engine._record_rule_hit`, the producer half of the same hit
+    counter `flush_rule_hit_counts` reads: a silent failure here means
+    every read of that rule's hit count reads as zero forever,
+    indistinguishable from the rule never matching, inviting an operator
+    to delete a rule that is actively blocking traffic.
+  - `rule_engine._get_unsolved_challenge_count`, the escalation counter:
+    returning 0 on failure is indistinguishable from "never challenged",
+    which silently disables challenge escalation. A bot farm failing
+    every challenge would never escalate to a block. The middleware's
+    matching write path (`waf:challenged:{ip}`, incremented on every
+    CHALLENGED verdict) gets the same treatment, since a silent failure
+    there has the identical effect from the other side of the counter.
+  - `fingerprint.register_known_fingerprint`: kills the dynamic
+    known-fingerprint allowlist, so a real user who just solved a
+    challenge is challenged again on every subsequent visit, a
+    false-positive amplifier rather than a neutral fail-open. The
+    `VerifyView` call site's own wrapping `except` (which also covered
+    the unrelated solved-flag write) is split so each failure logs its
+    own consequence.
+
+- **`_invalidate_rule_cache_redis` now logs when it falls back to the
+  per-process Django cache.** The Redis increment this function normally
+  performs (`waf:rules:version`) is how a newly expired or created rule
+  reaches every already-running `WafMiddleware` worker without a restart;
+  the Django cache fallback is per-process, so it does not actually
+  invalidate other workers' caches, only this one's next read. Previously
+  this fell back silently, indistinguishable from the caller's side as a
+  successful shared invalidation, so an operator watching Redis come back
+  up after an outage had no way to see that a chunk of rule changes only
+  ever reached one worker.
+
+- **`parse_access_log` and `update_ip_reputation` no longer report a
+  silent zero indistinguishable from an idle site.** A misconfigured
+  `DJANGO_WAF_ACCESS_LOG_PATH` (file does not exist) previously logged at
+  DEBUG, invisible in production, and returned the same
+  `{"parsed_lines": 0}` as a genuinely quiet site forever; it now logs a
+  WARNING (an unset path, the expected "feature not configured" case,
+  stays at DEBUG). `update_ip_reputation` now reports `ips_seen` alongside
+  `updated_count`/`created_count` and logs a WARNING when no `RequestLog`
+  rows landed in the 24-hour window at all, since `detect_challenge_farms`
+  reads `IPReputation` directly and a silent zero here means that detector
+  runs blind for the window with no signal that anything is wrong.
+
+- **Ruff `S110` (try-except-pass) and `S112` (try-except-continue) are
+  re-enabled** (previously ignored in `pyproject.toml`); these are
+  precisely the two rules that would have flagged the `flush_rule_hit_counts`
+  and `_record_rule_hit` defects above. All resulting violations in `src/`
+  are fixed by the logging changes in this release; none required a
+  per-line `noqa`.
+
 ## [1.10.0] - 2026-08-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,9 @@ django_waf = ["templates/**/*.html", "conf/nginx/*.conf.example"]
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.settings"
 pythonpath = ["."]
+markers = [
+    "redis_integration: requires a real Redis server (selected by the dedicated CI leg via --ds=settings_redis; skipped by the default LocMemCache/fakeredis run).",
+]
 
 [tool.ruff]
 target-version = "py311"
@@ -75,7 +78,7 @@ line-length = 120
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM", "S"]
-ignore = ["S101", "S104", "S105", "S106", "S107", "S110", "S112", "S311", "S603", "S607"]
+ignore = ["S101", "S104", "S105", "S106", "S107", "S311", "S603", "S607"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S"]
@@ -88,6 +91,7 @@ ignore = ["S101", "S104", "S105", "S106", "S107", "S110", "S112", "S311", "S603"
 # pattern, which ruff's F811 misreads as shadowing/redefinition.
 "tests/test_testing_fixtures.py" = ["F811"]
 "tests/test_redis_fallback.py" = ["F811"]
+"tests/test_flush_rule_hit_counts.py" = ["F811"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -76,6 +76,29 @@ The setting is checked against
 detector rename cannot silently desync the two: a typo or a stale name from
 a renamed detector would otherwise mean the operator believes a detector is
 running observe-only when it is, in fact, enforcing.
+
+The Redis version check (``django_waf.E005``) errors when the connected
+Redis server reports a version below the package's own floor, currently
+6.0 (see ``django_waf.services.redis_client.MIN_REDIS_VERSION``, the
+single source of truth this check reads). Redis 6.2 introduced ``GETDEL``;
+before this check existed, ``flush_rule_hit_counts`` called it
+unconditionally and, on a 6.0/6.1 server, ``ResponseError`` was raised on
+every key and swallowed by a bare ``except Exception: continue``, so hit
+counts silently never flushed. The task itself no longer calls ``GETDEL``
+(it uses a GET+DEL pipeline instead, so the package's floor stays 6.0
+rather than rising to 6.2), but the package has no other way to warn an
+operator running an older, unsupported server that other Redis-version
+assumptions elsewhere in the codebase may not hold. This is an Error
+rather than a Warning because an unsupported server version is a
+deployment fact, not a soft preference, mirroring ``django_waf.E004``'s
+reasoning. Like every other check in this module it must stay cheap and
+side-effect-free: it opens a connection only when the alias is already
+confirmed to be a django-redis backend, and does nothing at all when the
+WAF is disabled (``DJANGO_WAF_ENABLED = False``) or the connection cannot
+be made, since neither of those is the misconfiguration this check exists
+to catch (see issue #67, where ``django_waf.E004`` wrongly fired under
+``DJANGO_WAF_ENABLED = False`` with no Redis available; this check guards
+against repeating that).
 """
 
 from __future__ import annotations
@@ -445,5 +468,57 @@ def check_observe_only_detector_names(app_configs, **kwargs):
             "for this entry.",
             hint=f"Known detector names are: {known}.",
             id="django_waf.W008",
+        )
+    ]
+
+
+@register()
+def check_redis_version(app_configs, **kwargs):
+    """Error (``django_waf.E005``) when the connected Redis server reports a
+    version below ``redis_client.MIN_REDIS_VERSION`` (currently 6.0).
+
+    Guards, cheapest first, exactly like ``check_redis_backend``
+    (``django_waf.E004``): does nothing when the WAF is disabled (fixing
+    #67's mistake, where E004 fired regardless of
+    ``DJANGO_WAF_ENABLED``), does nothing when the configured alias is not
+    even a django-redis backend (E004 already covers that misconfiguration
+    on its own), and does nothing when a live version cannot be read
+    (unreachable server, or an ``INFO`` response this check cannot parse).
+    Only "reachable, correctly configured, and reporting an unsupported
+    version" is flagged: everything else is either not this check's
+    concern or the transient outage BR-EVAL-007 already handles at
+    runtime, not a boot-time misconfiguration.
+    """
+    from django_waf import conf
+    from django_waf.services.redis_client import (
+        MIN_REDIS_VERSION,
+        get_redis_server_version,
+        is_redis_backend,
+    )
+
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
+
+    if not is_redis_backend(conf.DJANGO_WAF_REDIS_ALIAS):
+        return []
+
+    version = get_redis_server_version(conf.DJANGO_WAF_REDIS_ALIAS)
+    if version is None or version >= MIN_REDIS_VERSION:
+        return []
+
+    version_str = ".".join(str(part) for part in version)
+    floor_str = ".".join(str(part) for part in MIN_REDIS_VERSION)
+    return [
+        Error(
+            f"Redis server on alias {conf.DJANGO_WAF_REDIS_ALIAS!r} reports "
+            f"version {version_str}, below this package's floor of "
+            f"{floor_str}.",
+            hint=(
+                f"Upgrade the Redis server backing "
+                f"CACHES[{conf.DJANGO_WAF_REDIS_ALIAS!r}] to {floor_str} or "
+                "newer, or point DJANGO_WAF_REDIS_ALIAS at one that already "
+                "meets the floor."
+            ),
+            id="django_waf.E005",
         )
     ]

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -406,13 +406,21 @@ class WafMiddleware:
             if path.startswith(challenge_path) or path.startswith(verify_path):
                 return self._get_response(request)
 
-            # Increment unsolved-challenge counter for escalation tracking
+            # Increment unsolved-challenge counter for escalation tracking.
+            # This is the producer half of the counter
+            # rule_engine._get_unsolved_challenge_count reads: a silent
+            # failure here has the same effect as a failure on the read
+            # side, challenge escalation goes blind for this IP, so it is
+            # logged rather than swallowed.
             try:
                 key = f"waf:challenged:{ip_address}"
                 redis_client.incr(key)
                 redis_client.expire(key, 3600)  # 1-hour window
             except Exception:
-                pass
+                logger.warning(
+                    "django-waf: failed to record challenge for %s, escalation count will under-report",
+                    ip_address,
+                )
             challenge_url = f"{challenge_path}?next={path}"
             return HttpResponseRedirect(challenge_url)
 

--- a/src/django_waf/services/fingerprint.py
+++ b/src/django_waf/services/fingerprint.py
@@ -151,6 +151,15 @@ def register_known_fingerprint(fp_hash: str, redis_client) -> None:
     profile list — as new browser versions roll out, real users solving
     challenges automatically register their fingerprints.
 
+    A failure here is a false-positive amplifier, not a neutral fail-open:
+    ``is_known_fingerprint`` (below) fails closed by design, returning
+    False, correctly, when it cannot confirm a fingerprint. That means an
+    unregistered fingerprint leaves every subsequent request carrying it
+    treated as unknown, so a real user who just solved a challenge would
+    otherwise be challenged again on their next visit. WARNING, not
+    silent: an operator needs to know the known-fingerprint allowlist has
+    stopped growing.
+
     Args:
         fp_hash: The SHA-256 fingerprint hash.
         redis_client: Redis client instance.
@@ -162,7 +171,10 @@ def register_known_fingerprint(fp_hash: str, redis_client) -> None:
         redis_client.incr(key)
         redis_client.expire(key, _KNOWN_FP_TTL)
     except Exception:
-        pass
+        logger.warning(
+            "django-waf: failed to register known fingerprint %s, this client will be re-challenged next visit",
+            fp_hash,
+        )
 
 
 def is_known_fingerprint(fp_hash: str, redis_client) -> bool:

--- a/src/django_waf/services/redis_client.py
+++ b/src/django_waf/services/redis_client.py
@@ -46,6 +46,14 @@ import logging
 
 logger = logging.getLogger("django_waf.redis_client")
 
+# The package's own Redis version floor. GETDEL (Redis 6.2+) is the only
+# command anywhere in this package that needs anything newer than the
+# 2.0-2.6 era; flush_rule_hit_counts no longer calls it (see tasks.py, a
+# GET+DEL pipeline replaces it), so this floor stays 6.0 rather than
+# rising to 6.2. Read by django_waf.E005 (checks.py), the single source of
+# truth so the check and the package's actual command usage cannot desync.
+MIN_REDIS_VERSION = (6, 0, 0)
+
 # Logged once per process (not once per request) so a misconfigured
 # deployment doesn't drown its own logs in a repeat of the same message on
 # every single request.
@@ -124,3 +132,34 @@ def is_redis_backend(alias: str | None = None) -> bool:
     caches_setting = getattr(settings, "CACHES", {})
     backend = caches_setting.get(resolved_alias, {}).get("BACKEND", "")
     return backend.startswith("django_redis.cache.")
+
+
+def get_redis_server_version(alias: str | None = None) -> tuple[int, int, int] | None:
+    """Return the connected Redis server's version as ``(major, minor, patch)``.
+
+    Used by ``django_waf.E005`` (``checks.py``) to compare the live server
+    against ``MIN_REDIS_VERSION``. Returns ``None`` when a client cannot be
+    obtained (unreachable, or not a django-redis backend) or the server's
+    ``INFO`` response omits/cannot parse ``redis_version``: the caller
+    treats ``None`` as "cannot confirm", not as a failing version, since
+    this helper's job is to answer the question when it safely can, not to
+    force a live connection at times a check should stay side-effect-free
+    (see ``is_redis_backend`` for that guard).
+
+    Never raises.
+    """
+    client = get_redis_client(alias)
+    if client is None:
+        return None
+
+    try:
+        info = client.info(section="server")
+        version_str = info.get("redis_version", "")
+        # redis_version can carry a trailing suffix on some forks/builds
+        # (e.g. "7.2.4" is standard, but be defensive about anything past
+        # the first three dot-separated numeric parts).
+        parts = version_str.split(".")[:3]
+        return tuple(int(part) for part in parts) if len(parts) == 3 else None  # type: ignore[return-value]
+    except Exception:
+        logger.warning("django-waf: could not read Redis server version for alias %r", alias)
+        return None

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -550,13 +550,26 @@ def _check_block_rules(
 
 
 def _record_rule_hit(rule_id: str, redis_client) -> None:
-    """Increment the Redis hit counter for a block rule."""
+    """Increment the Redis hit counter for a block rule.
+
+    This is the producer half of the counter ``flush_rule_hit_counts``
+    (tasks.py) reads and zeroes every five minutes. Fail-open is correct
+    here (BR-EVAL-007: a lost hit count must never turn into a blocked
+    request), but a silent failure is more severe than most fail-open paths
+    in this package: every subsequent read of this rule's hit count reads
+    as zero, which is indistinguishable from the rule never matching at
+    all, and an operator auditing "unused" rules by hit count would delete
+    a rule that is, in fact, actively blocking traffic. WARNING, not
+    ERROR: a transient Redis outage here is the same class of event
+    redis_client.get_redis_client already logs at WARNING elsewhere, not a
+    boot-time misconfiguration.
+    """
     try:
         key = f"waf:rule_hits:{rule_id}"
         redis_client.incr(key)
         redis_client.expire(key, 86400 * 2)  # TTL: 2 days
     except Exception:
-        pass
+        logger.warning("django-waf: failed to record hit for rule %s, hit count will under-report", rule_id)
 
 
 def _rule_matches(rule: dict, ip_address: str, user_agent: str) -> bool:
@@ -871,6 +884,17 @@ def _get_unsolved_challenge_count(ip_address: str, redis_client) -> int:
     Uses Redis counter waf:challenged:{ip} incremented by the middleware
     on each CHALLENGED verdict. Checks Redis waf:solved:{ip} flag first
     (set by VerifyView on successful solve), falling back to DB only on miss.
+
+    Returning 0 means "this IP has never been challenged", the same value
+    a genuinely fresh IP produces. A Redis failure here is therefore not a
+    neutral fail-open: it silently disables challenge escalation entirely
+    for the affected IP for as long as the failure persists, since
+    ``_maybe_escalate_to_block`` never sees a count reach
+    DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD. A bot farm failing every
+    challenge would simply never escalate to a block. Fail-open is still
+    correct (BR-EVAL-007: a Redis outage must not turn every challenge into
+    a block), but it must be loud, not indistinguishable from the fresh-IP
+    case.
     """
     try:
         key = f"waf:challenged:{ip_address}"
@@ -887,6 +911,11 @@ def _get_unsolved_challenge_count(ip_address: str, redis_client) -> int:
 
         return count
     except Exception:
+        logger.warning(
+            "django-waf: failed to read unsolved-challenge count for %s, "
+            "challenge escalation is disabled for this IP until Redis recovers",
+            ip_address,
+        )
         return 0
 
 

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -115,10 +115,23 @@ def parse_access_log(log_path: str | None = None) -> dict:
     from django_waf.models import RequestLog
 
     path = log_path or conf.DJANGO_WAF_ACCESS_LOG_PATH
+
+    if not path:
+        # Feature not configured at all: an expected, quiet no-op, not a
+        # failure, so this stays at DEBUG.
+        logger.debug("django-waf: DJANGO_WAF_ACCESS_LOG_PATH not set, skipping parse")
+        return {"parsed_lines": 0, "created_records": 0, "skipped_lines": 0}
+
     offset_key = f"django_waf:access_log_offset:{path}"
 
-    if not path or not os.path.isfile(path):
-        logger.debug("django-waf: access log not found at %s — skipping parse", path)
+    if not os.path.isfile(path):
+        # A path *was* configured but does not resolve to a file: this is
+        # very likely a wrong DJANGO_WAF_ACCESS_LOG_PATH, which otherwise
+        # yields the identical {"parsed_lines": 0} as an idle site, forever,
+        # with no signal at all (the return dict is not itself surfaced
+        # anywhere; the log line is the only observable). WARNING so it is
+        # visible in production rather than silently invisible at DEBUG.
+        logger.warning("django-waf: configured access log %s does not exist, skipping parse", path)
         return {"parsed_lines": 0, "created_records": 0, "skipped_lines": 0}
 
     stored_offset = cache.get(offset_key)
@@ -352,8 +365,16 @@ def update_ip_reputation() -> dict:
     Covers the last 24 hours. Upserts one record per IP (BR-REP-003). Computes
     threat score per BR-REP-002.
 
+    ``detect_challenge_farms`` (services/anomaly_detector.py) reads
+    ``IPReputation`` directly, so a silent zero here is not just an idle
+    metric: it blinds that detector for the whole window. ``ips_seen``
+    distinguishes "no RequestLog rows landed at all" (logged at WARNING,
+    since either ingestion has stopped or nothing has been logged in 24
+    hours, both worth an operator's attention) from "rows landed but every
+    IP was already up to date", which is a genuinely quiet window.
+
     Returns:
-        Dict with keys: updated_count, created_count.
+        Dict with keys: updated_count, created_count, ips_seen.
 
     Scheduled: every 6 hours.
     """
@@ -368,7 +389,7 @@ def update_ip_reputation() -> dict:
     created_count = 0
 
     # Aggregate per IP
-    ip_stats = (
+    ip_stats = list(
         RequestLog.objects.filter(timestamp__gte=cutoff)
         .values("ip_address")
         .annotate(
@@ -378,6 +399,7 @@ def update_ip_reputation() -> dict:
             distinct_ua=Count("user_agent", distinct=True),
         )
     )
+    ips_seen = len(ip_stats)
 
     for row in ip_stats:
         ip = row["ip_address"]
@@ -437,12 +459,25 @@ def update_ip_reputation() -> dict:
         else:
             updated_count += 1
 
-    logger.info(
-        "django-waf: update_ip_reputation — updated=%d created=%d",
-        updated_count,
-        created_count,
-    )
-    return {"updated_count": updated_count, "created_count": created_count}
+    if ips_seen == 0:
+        # No RequestLog rows landed in the window at all: either logging
+        # has genuinely gone quiet or ingestion (parse_access_log,
+        # WafMiddleware's own logging) has stopped. Either way,
+        # detect_challenge_farms is now blind for this window, so this is
+        # worth a WARNING rather than the same log line as "processed
+        # everyone, nothing changed".
+        logger.warning(
+            "django-waf: update_ip_reputation saw no RequestLog rows in the last 24h window, "
+            "detect_challenge_farms has no data for this window"
+        )
+    else:
+        logger.info(
+            "django-waf: update_ip_reputation, ips_seen=%d updated=%d created=%d",
+            ips_seen,
+            updated_count,
+            created_count,
+        )
+    return {"updated_count": updated_count, "created_count": created_count, "ips_seen": ips_seen}
 
 
 @shared_task
@@ -547,6 +582,15 @@ def flush_rule_hit_counts(self) -> dict:
     Reads waf:rule_hits:{rule_id} keys, updates BlockRule.hit_count and
     last_hit_at, then deletes the Redis keys. Designed to run every 5 minutes
     alongside the blocklist generation task.
+
+    ``ignore_result=True`` means Celery discards the returned dict, so the
+    log line below is the only real observable this task has. All three
+    failure exits, and the success exit, now report ``keys_seen`` and
+    ``errors`` alongside ``flushed``, so "Redis unreachable", "keys listed
+    but every read/write failed", and a genuinely idle site with nothing to
+    flush produce three different log lines instead of the same
+    ``{"flushed": 0}`` for all three. Fail-open is unchanged (BR-EVAL-007):
+    an unflushed counter just waits for the next run.
     """
     from django_waf.models import BlockRule
 
@@ -557,36 +601,89 @@ def flush_rule_hit_counts(self) -> dict:
 
         redis_client = get_redis_connection(conf.DJANGO_WAF_REDIS_ALIAS)
     except Exception:
-        logger.warning("django-waf: Redis unavailable for hit count flush")
-        return {"flushed": 0}
+        logger.warning("django-waf: Redis unavailable for hit count flush, flushed=0 keys_seen=0 errors=0")
+        return {"flushed": 0, "keys_seen": 0, "errors": 0}
 
     flushed = 0
+    errors = 0
     prefix = "waf:rule_hits:"
 
     try:
         keys = redis_client.keys(f"{prefix}*")
     except Exception:
-        return {"flushed": 0}
+        logger.error(
+            "django-waf: failed to list Redis hit count keys, flushed=0 keys_seen=0 errors=1",
+            exc_info=True,
+        )
+        return {"flushed": 0, "keys_seen": 0, "errors": 1}
+
+    keys_seen = len(keys)
 
     for key in keys:
-        try:
-            key_str = key.decode() if isinstance(key, bytes) else key
-            rule_id = key_str[len(prefix) :]
-            count = int(redis_client.getdel(key) or 0)
-            if count > 0:
-                from django.db.models import F
+        key_str = key.decode() if isinstance(key, bytes) else key
+        rule_id = key_str[len(prefix) :]
 
-                updated = BlockRule.objects.filter(id=rule_id).update(
-                    hit_count=F("hit_count") + count,
-                    last_hit_at=timezone.now(),
-                )
-                if updated:
-                    flushed += 1
+        try:
+            # GETDEL requires Redis 6.2+; the package's own floor is 6.0
+            # (see django_waf.E005), so use a GET+DEL pipeline instead. Not
+            # atomic against a concurrent INCR landing between the two
+            # commands, but this is a coarse hit counter flushed every five
+            # minutes, not a balance: a count dropped or double counted in
+            # that narrow window is an acceptable trade for staying on the
+            # 6.0 floor.
+            pipe = redis_client.pipeline()
+            pipe.get(key)
+            pipe.delete(key)
+            get_result, _ = pipe.execute()
+            count = int(get_result or 0)
         except Exception:
+            errors += 1
+            logger.error("django-waf: failed to read/clear hit counter for rule %s", rule_id, exc_info=True)
             continue
 
-    logger.info("django-waf: flushed hit counts for %d rules", flushed)
-    return {"flushed": flushed}
+        if count <= 0:
+            continue
+
+        try:
+            from django.db.models import F
+
+            updated = BlockRule.objects.filter(id=rule_id).update(
+                hit_count=F("hit_count") + count,
+                last_hit_at=timezone.now(),
+            )
+        except Exception:
+            # The Redis counter is already cleared at this point, so this
+            # count is lost, not retried on the next run. Fail-open per
+            # BR-EVAL-007 means we do not raise and abort the whole flush
+            # over one bad rule id, but a lost count must be loud: previously
+            # this was a bare `except Exception: continue` that swallowed a
+            # DB error identically to a Redis error, with no log at all.
+            errors += 1
+            logger.error(
+                "django-waf: failed to persist hit count for rule %s (count=%d, Redis counter already cleared)",
+                rule_id,
+                count,
+                exc_info=True,
+            )
+            continue
+
+        if updated:
+            flushed += 1
+
+    if errors:
+        logger.warning(
+            "django-waf: flushed hit counts for %d rules, keys_seen=%d errors=%d",
+            flushed,
+            keys_seen,
+            errors,
+        )
+    else:
+        logger.info(
+            "django-waf: flushed hit counts for %d rules, keys_seen=%d errors=0",
+            flushed,
+            keys_seen,
+        )
+    return {"flushed": flushed, "keys_seen": keys_seen, "errors": errors}
 
 
 # ---------------------------------------------------------------------------
@@ -632,7 +729,18 @@ def _build_source_event_id(ip_address: str, timestamp_str: str, method: str, pat
 
 
 def _invalidate_rule_cache_redis() -> None:
-    """Increment waf:rules:version in Redis to invalidate the cached rule set."""
+    """Increment waf:rules:version in Redis to invalidate the cached rule set.
+
+    Every WafMiddleware process holds an in-process rule cache keyed on this
+    version; incrementing it is how a newly expired/created rule reaches
+    already-running workers without a restart. The Django cache fallback
+    below is per-process, not shared, so it does not actually invalidate
+    other workers' caches, only this one's next read. Falling back silently
+    previously looked identical to a successful Redis invalidation from the
+    caller's side, so an operator watching Redis come back up after an
+    outage had no way to see that a chunk of rule-cache invalidations were
+    only ever applied locally.
+    """
     try:
         from django_redis import get_redis_connection
 
@@ -641,7 +749,13 @@ def _invalidate_rule_cache_redis() -> None:
         redis_client = get_redis_connection(conf.DJANGO_WAF_REDIS_ALIAS)
         redis_client.incr("waf:rules:version")
     except Exception:
-        # Fall back to Django cache
+        # Fall back to Django cache. Per-process only: other WafMiddleware
+        # workers do not see this bump, so their rule caches stay stale
+        # until Redis recovers and a real invalidation reaches them.
+        logger.warning(
+            "django-waf: Redis unavailable for rule cache invalidation, falling back to the local Django "
+            "cache (other worker processes will not see this invalidation until Redis recovers)"
+        )
         from django.core.cache import cache
 
         version = (cache.get("waf:rules:version") or 0) + 1

--- a/src/django_waf/testing/fixtures.py
+++ b/src/django_waf/testing/fixtures.py
@@ -37,12 +37,29 @@ def waf_redis_mock(monkeypatch: pytest.MonkeyPatch):
     """Patch every Redis accessor django-waf uses to return a shared fakeredis instance.
 
     Covers the middleware, the challenge/verify views, and the
-    form-protection subsystem's default Redis factory — the three places
+    form-protection subsystem's default Redis factory: the three places
     that independently resolve a Redis client via ``django_redis`` or the
     Django cache fallback.
 
     Requires ``fakeredis``. Raises ``ImportError`` with an actionable
     message if it is not installed.
+
+    The fake client is pinned to ``version=(6, 0)``, django-waf's own
+    declared minimum supported Redis version (see ``requires-python`` and
+    the version floor documented in ``redis_client.py`` / ``checks.py``).
+    Public-behaviour change (#78): previously this fixture instantiated
+    ``fakeredis.FakeRedis()`` with no ``version=`` argument, which defaults
+    to emulating fakeredis's newest modelled server and so silently accepted
+    commands that do not exist on the package's actual floor. A consuming
+    project's test suite that calls a Redis command introduced after 6.0
+    (directly, or via a fixture built on ``waf_redis_mock``) may start
+    failing after this change; that failure is correct; it means the
+    project depends on a Redis feature above what django-waf supports. Note
+    that fakeredis's ``version=`` argument does not gate every command
+    (``GETDEL`` in particular, see fakeredis's ``string_mixin.py``, is
+    unconditionally available regardless of the requested version), so this
+    pin improves fidelity but is not a substitute for testing against a real
+    Redis server at the floor version.
 
     Yields:
         The shared ``fakeredis.FakeRedis`` instance, so tests can assert on
@@ -62,7 +79,7 @@ def waf_redis_mock(monkeypatch: pytest.MonkeyPatch):
     import django_waf.middleware as middleware_mod
     import django_waf.views as views_mod
 
-    fake_client = fakeredis.FakeRedis()
+    fake_client = fakeredis.FakeRedis(version=(6, 0))
 
     monkeypatch.setattr(middleware_mod, "_get_redis_client", lambda: fake_client)
     monkeypatch.setattr(views_mod, "_get_redis_client", lambda: fake_client)

--- a/src/django_waf/views.py
+++ b/src/django_waf/views.py
@@ -278,22 +278,32 @@ class VerifyView(NoIndexResponseMixin, View):
                 logger.exception("django-waf: failed to issue replacement challenge token")
                 return JsonResponse({"error": reason}, status=400)
 
-        # Mark IP as solved in Redis so escalation counter resets
+        # Mark IP as solved in Redis so escalation counter resets. A
+        # failure here leaves the IP's unsolved-challenge counter standing,
+        # so a real user who just solved a challenge could still hit the
+        # escalation threshold and be blocked outright.
         try:
             solved_key = f"waf:solved:{ip}"
             redis_client.setex(solved_key, 86400, "1")  # 24-hour flag
             redis_client.delete(f"waf:challenged:{ip}")
         except Exception:
-            pass
+            logger.warning(
+                "django-waf: failed to set solved flag for %s, unsolved-challenge count will not reset",
+                ip,
+            )
 
-        # Register this browser's HTTP fingerprint as known-good
+        # Register this browser's HTTP fingerprint as known-good.
+        # register_known_fingerprint already logs its own failures; this
+        # try/except only needs to stop a fingerprinting failure (e.g.
+        # compute_fingerprint raising on malformed headers) from breaking
+        # the redirect that follows.
         try:
             from django_waf.services.fingerprint import compute_fingerprint, register_known_fingerprint
 
             fp_hash = compute_fingerprint(request.META)
             register_known_fingerprint(fp_hash, redis_client)
         except Exception:
-            pass
+            logger.warning("django-waf: failed to compute/register fingerprint for solved challenge from %s", ip)
 
         response = redirect(next_url)
         issue_pass_cookie(response, token, ip, secure=request.is_secure())

--- a/tests/settings_redis.py
+++ b/tests/settings_redis.py
@@ -1,0 +1,27 @@
+"""Django settings for the real-Redis integration leg (#78).
+
+Identical to ``tests.settings`` except ``CACHES["default"]`` points at a
+real ``django_redis.cache.RedisCache`` instance instead of ``LocMemCache``.
+Selected via pytest-django's ``--ds`` flag so the fast unit suite (which
+runs everywhere, including a laptop with no Redis installed) is completely
+unaffected: importing this module is the only way ``CACHES`` changes.
+
+``DJANGO_WAF_TEST_REDIS_URL`` lets the CI leg point at whichever host/port
+the Redis service container is bound to; it defaults to the conventional
+local address so this settings module also works for a developer running
+``docker run -p 6379:6379 redis:6.0-alpine`` (or the matching version) by
+hand.
+"""
+
+import os
+
+from tests.settings import *  # noqa: F401, F403
+
+DJANGO_WAF_TEST_REDIS_URL = os.environ.get("DJANGO_WAF_TEST_REDIS_URL", "redis://localhost:6379/0")
+
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": DJANGO_WAF_TEST_REDIS_URL,
+    }
+}

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -55,6 +55,12 @@ def _run_observe_only_detector_names_check():
     return check_observe_only_detector_names(app_configs=None)
 
 
+def _run_redis_version_check():
+    from django_waf.checks import check_redis_version
+
+    return check_redis_version(app_configs=None)
+
+
 class TestChallengeDifficultyCheck:
     def test_recommended_defaults_produce_no_messages(self):
         import django_waf.conf as conf_mod
@@ -411,3 +417,70 @@ class TestObserveOnlyDetectorNamesCheck:
 
         assert len(messages) == 1
         assert messages[0].id == "django_waf.W008"
+
+
+class TestRedisVersionCheck:
+    """E005 errors when the connected Redis server reports a version below
+    MIN_REDIS_VERSION (currently 6.0, see #78: getdel silently failed on a
+    6.0.16 production server for 40,936 task runs with no boot-time signal
+    at all)."""
+
+    def test_below_floor_emits_e005_error(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=True),
+            patch("django_waf.services.redis_client.get_redis_server_version", return_value=(5, 0, 14)),
+        ):
+            messages = _run_redis_version_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.E005"
+
+    def test_at_or_above_floor_is_silent(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=True),
+            patch("django_waf.services.redis_client.get_redis_server_version", return_value=(6, 0, 16)),
+        ):
+            assert _run_redis_version_check() == []
+
+    def test_silent_when_waf_disabled(self):
+        """Guards against repeating #67: E004 fired regardless of
+        DJANGO_WAF_ENABLED. E005 must not repeat that mistake."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=True),
+            patch("django_waf.services.redis_client.get_redis_server_version", return_value=(5, 0, 0)),
+        ):
+            assert _run_redis_version_check() == []
+
+    def test_silent_when_alias_is_not_a_redis_backend(self):
+        """E004 already covers this misconfiguration; E005 stays quiet
+        rather than duplicating it or opening a connection unnecessarily."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=False),
+            patch("django_waf.services.redis_client.get_redis_server_version") as mock_version,
+        ):
+            assert _run_redis_version_check() == []
+            mock_version.assert_not_called()
+
+    def test_silent_when_version_cannot_be_read(self):
+        """An unreachable server or unparseable INFO response is not this
+        check's concern: that is the outage BR-EVAL-007 handles at runtime."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=True),
+            patch("django_waf.services.redis_client.get_redis_server_version", return_value=None),
+        ):
+            assert _run_redis_version_check() == []

--- a/tests/test_flush_rule_hit_counts.py
+++ b/tests/test_flush_rule_hit_counts.py
@@ -1,0 +1,261 @@
+"""Tests for ``flush_rule_hit_counts`` and its Redis hit-counter producer,
+``_record_rule_hit`` (#78).
+
+``flush_rule_hit_counts`` was the only task in ``tasks.py`` with no test
+class at all: a production defect (``GETDEL`` requires Redis 6.2+, silently
+failing on Redis 6.0.16 for 40,936 task runs) went undetected because
+nothing exercised the flush path against Redis at all, real or fake. The
+old implementation called ``redis_client.getdel(key)`` directly; on a
+server below 6.2 that raises inside the per-key ``try/except Exception``,
+which silently ``continue``s to the next key with the counter never
+cleared and never applied to the row. The fix (already landed by the time
+this file was written) replaced the single ``getdel`` with a
+``GET``+``DELETE`` pipeline, which works on the package's declared Redis
+6.0 floor.
+
+This file uses ``waf_redis_mock`` (fakeredis) throughout: it drives the
+full producer (``_record_rule_hit``) then flush (``flush_rule_hit_counts``)
+path against a real, Redis-shaped client and asserts on the actual
+observable effects (the ``BlockRule.hit_count`` row and the Redis key),
+never merely that a mock method was called. fakeredis's pipeline supports
+``GET``/``DELETE`` identically to a real server, so this file proves the
+pipeline-based implementation is correct in general; it cannot, by itself,
+prove the old ``getdel`` implementation is broken, because fakeredis
+accepts ``GETDEL`` regardless of Redis floor (see
+``tests/test_flush_rule_hit_counts_redis_integration.py``, which runs
+against a real Redis 6.0 server and is the actual regression test for this
+defect: falsifiability requires a check that fails against the old code
+for the original reason, and fakeredis cannot provide that here).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from django_waf.testing.factories import BlockRuleFactory
+from django_waf.testing.fixtures import waf_redis_mock  # noqa: F401 (used as a pytest fixture)
+
+# ---------------------------------------------------------------------------
+# _record_rule_hit: the producer side actually writes waf:rule_hits:*
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestRecordRuleHitWritesRedis:
+    """``_record_rule_hit`` is exercised incidentally by other tests, via
+    ``MagicMock`` call assertions in test_services.py, but nothing asserts
+    the actual Redis-side effect: that the key exists afterwards with the
+    right value and TTL. The audit flagged this as "covered but not
+    tested"."""
+
+    def test_increments_a_real_redis_key(self, waf_redis_mock):
+        from django_waf.services.rule_engine import _record_rule_hit
+
+        _record_rule_hit("rule-abc", waf_redis_mock)
+
+        assert waf_redis_mock.get("waf:rule_hits:rule-abc") == b"1"
+
+    def test_repeated_hits_accumulate_on_the_same_key(self, waf_redis_mock):
+        from django_waf.services.rule_engine import _record_rule_hit
+
+        for _ in range(3):
+            _record_rule_hit("rule-abc", waf_redis_mock)
+
+        assert waf_redis_mock.get("waf:rule_hits:rule-abc") == b"3"
+
+    def test_sets_a_two_day_ttl_on_the_key(self, waf_redis_mock):
+        from django_waf.services.rule_engine import _record_rule_hit
+
+        _record_rule_hit("rule-abc", waf_redis_mock)
+
+        ttl = waf_redis_mock.ttl("waf:rule_hits:rule-abc")
+        assert 0 < ttl <= 86400 * 2
+
+    def test_failure_logs_a_warning_naming_the_rule(self, caplog):
+        """This is the producer half of the counter flush_rule_hit_counts
+        reads: a silent failure here means every subsequent read of this
+        rule's hit count reads as zero forever, indistinguishable from the
+        rule never matching."""
+        from unittest.mock import MagicMock
+
+        from django_waf.services.rule_engine import _record_rule_hit
+
+        broken_client = MagicMock()
+        broken_client.incr.side_effect = RuntimeError("redis down")
+
+        with caplog.at_level(logging.WARNING, logger="django_waf.rule_engine"):
+            _record_rule_hit("rule-abc", broken_client)
+
+        assert any("rule-abc" in message for message in caplog.messages)
+
+    def test_check_block_rules_calls_the_producer_for_a_matched_rule(self, waf_redis_mock):
+        """End-to-end from the evaluation entry point actually used in
+        production: a matched BlockRule's hit lands in Redis, not just in
+        a mock's call log."""
+        from django_waf.services.rule_engine import RuleCache, _check_block_rules
+
+        rule = {
+            "id": "rule-xyz",
+            "rule_type": "ip",
+            "match_type": "exact",
+            "pattern": "10.10.10.10",
+            "priority": 1,
+            "expires_at": None,
+        }
+        cache = RuleCache(version=1, allow_rules=[], block_rules=[rule], ua_regex_set=[])
+
+        result = _check_block_rules("10.10.10.10", "Mozilla/5.0", cache, redis_client=waf_redis_mock)
+
+        assert result is not None
+        assert waf_redis_mock.get("waf:rule_hits:rule-xyz") == b"1"
+
+
+# ---------------------------------------------------------------------------
+# flush_rule_hit_counts: the full producer, flush, DB path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestFlushRuleHitCounts:
+    """The crux tests: increment via the real producer path, run the flush,
+    assert hit_count actually moved on the BlockRule row AND the Redis key
+    was removed. This is the test class that did not exist before #78; its
+    absence is exactly how the getdel defect went unnoticed for 40,936 task
+    runs."""
+
+    def test_flush_applies_accumulated_hits_to_the_block_rule_row(self, waf_redis_mock):
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.tasks import flush_rule_hit_counts
+
+        rule = BlockRuleFactory(hit_count=0)
+
+        for _ in range(5):
+            _record_rule_hit(str(rule.id), waf_redis_mock)
+
+        with mock_redis_connection(waf_redis_mock):
+            flush_rule_hit_counts()
+
+        rule.refresh_from_db()
+        assert rule.hit_count == 5
+        assert rule.last_hit_at is not None
+
+    def test_flush_removes_the_redis_key_after_applying(self, waf_redis_mock):
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.tasks import flush_rule_hit_counts
+
+        rule = BlockRuleFactory(hit_count=0)
+        _record_rule_hit(str(rule.id), waf_redis_mock)
+
+        assert waf_redis_mock.exists(f"waf:rule_hits:{rule.id}")
+
+        with mock_redis_connection(waf_redis_mock):
+            flush_rule_hit_counts()
+
+        assert not waf_redis_mock.exists(f"waf:rule_hits:{rule.id}")
+
+    def test_flush_accumulates_onto_an_existing_hit_count(self, waf_redis_mock):
+        """hit_count is incremented (F() expression), not overwritten."""
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.tasks import flush_rule_hit_counts
+
+        rule = BlockRuleFactory(hit_count=10)
+        for _ in range(4):
+            _record_rule_hit(str(rule.id), waf_redis_mock)
+
+        with mock_redis_connection(waf_redis_mock):
+            flush_rule_hit_counts()
+
+        rule.refresh_from_db()
+        assert rule.hit_count == 14
+
+    def test_flush_leaves_unrelated_rules_untouched(self, waf_redis_mock):
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.tasks import flush_rule_hit_counts
+
+        hit_rule = BlockRuleFactory(hit_count=0)
+        untouched_rule = BlockRuleFactory(hit_count=0)
+        _record_rule_hit(str(hit_rule.id), waf_redis_mock)
+
+        with mock_redis_connection(waf_redis_mock):
+            flush_rule_hit_counts()
+
+        hit_rule.refresh_from_db()
+        untouched_rule.refresh_from_db()
+        assert hit_rule.hit_count == 1
+        assert untouched_rule.hit_count == 0
+
+    def test_flush_with_no_keys_is_a_clean_no_op(self, waf_redis_mock):
+        from django_waf.tasks import flush_rule_hit_counts
+
+        with mock_redis_connection(waf_redis_mock):
+            result = flush_rule_hit_counts()
+
+        assert result == {"flushed": 0, "keys_seen": 0, "errors": 0}
+
+    def test_flush_skips_a_rule_id_that_no_longer_exists(self, waf_redis_mock):
+        """A stale key for a deleted rule does not raise; the key is still
+        cleared (update() against a non-matching id affects zero rows,
+        which is a legitimate zero, not an error)."""
+        from django_waf.tasks import flush_rule_hit_counts
+
+        waf_redis_mock.incr("waf:rule_hits:00000000-0000-0000-0000-000000000000")
+
+        with mock_redis_connection(waf_redis_mock):
+            result = flush_rule_hit_counts()
+
+        assert result["flushed"] == 0
+        assert result["errors"] == 0
+        assert not waf_redis_mock.exists("waf:rule_hits:00000000-0000-0000-0000-000000000000")
+
+    def test_flush_counts_a_db_update_failure_as_an_error_not_a_silent_skip(self, waf_redis_mock, caplog):
+        """A BlockRule.objects.filter(...).update() failure used to be caught
+        by the same bare `except Exception: continue` as a Redis read
+        failure, with no log at all and no way to tell the two apart. It
+        must now increment `errors` and log at ERROR."""
+        from unittest.mock import patch
+
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.tasks import flush_rule_hit_counts
+
+        rule = BlockRuleFactory(hit_count=0)
+        _record_rule_hit(str(rule.id), waf_redis_mock)
+
+        with (
+            caplog.at_level(logging.ERROR, logger="django_waf.tasks"),
+            mock_redis_connection(waf_redis_mock),
+            patch("django.db.models.F", side_effect=RuntimeError("db down")),
+        ):
+            result = flush_rule_hit_counts()
+
+        assert result["errors"] == 1
+        assert result["flushed"] == 0
+        assert any(str(rule.id) in message for message in caplog.messages)
+
+    def test_flush_logs_a_summary_line_on_success(self, waf_redis_mock, caplog):
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.tasks import flush_rule_hit_counts
+
+        rule = BlockRuleFactory(hit_count=0)
+        _record_rule_hit(str(rule.id), waf_redis_mock)
+
+        with caplog.at_level(logging.INFO, logger="django_waf.tasks"), mock_redis_connection(waf_redis_mock):
+            flush_rule_hit_counts()
+
+        assert any("flushed hit counts for 1 rules" in message for message in caplog.messages)
+
+
+def mock_redis_connection(fake_client):
+    """Patch ``django_redis.get_redis_connection`` (as imported inside
+    ``tasks.flush_rule_hit_counts``) to return the given fakeredis client.
+
+    ``flush_rule_hit_counts`` resolves its own client via
+    ``django_redis.get_redis_connection(conf.DJANGO_WAF_REDIS_ALIAS)``, a
+    different resolution path than the middleware/views/forms accessors
+    ``waf_redis_mock`` patches directly, so the fixture's shared client is
+    wired in here rather than via monkeypatching a django_waf attribute.
+    """
+    from unittest.mock import patch
+
+    return patch("django_redis.get_redis_connection", return_value=fake_client)

--- a/tests/test_flush_rule_hit_counts_redis_integration.py
+++ b/tests/test_flush_rule_hit_counts_redis_integration.py
@@ -1,0 +1,155 @@
+"""Regression test for #78 against a REAL Redis server.
+
+This file only runs on ``settings_redis`` (pytest-django's ``--ds`` flag),
+selected by the dedicated ``test-redis-integration`` CI leg, which starts a
+real ``redis:6.0-alpine`` service container. It is skipped everywhere else,
+including the default fast unit run, because ``pytest.mark.redis_integration``
+is not selected there and because ``settings.CACHES`` (LocMemCache) makes
+``get_redis_client``/``get_redis_connection`` unable to reach a real server
+under the default settings module in the first place.
+
+Falsifiability is the whole point of this file. Before the fix,
+``flush_rule_hit_counts`` called ``redis_client.getdel(key)`` directly.
+``GETDEL`` was added in Redis 6.2; on the package's declared floor (6.0) it
+does not exist, so the call raises ``redis.exceptions.ResponseError`` inside
+a bare ``try/except Exception: continue``, silently skipping the key with
+the counter never cleared and never applied to the BlockRule row (the
+production incident this reliability release exists to fix: 40,936 task
+runs against Redis 6.0.16). ``TestOldGetdelImplementationFailsOnRedis60``
+below reproduces the old call pattern directly against the real server and
+asserts it actually raises: this is the check that would have caught the
+defect, and it is impossible to write against fakeredis, because fakeredis
+accepts GETDEL unconditionally regardless of the requested ``version=``
+(confirmed empirically against fakeredis 2.37.1's
+``commands_mixins/string_mixin.py``, which registers ``getdel`` with no
+version gate at all).
+
+``TestFlushRuleHitCountsAgainstRealRedis`` then proves the CURRENT
+(pipeline-based) implementation actually works end to end against the same
+real server: the fast-suite equivalent in
+``tests/test_flush_rule_hit_counts.py`` proves this against fakeredis, which
+is necessary but not sufficient (fakeredis and real Redis agree on
+GET/DELETE pipeline behaviour, so that half was never the risk).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from django.conf import settings
+
+from django_waf.testing.factories import BlockRuleFactory
+
+pytestmark = pytest.mark.redis_integration
+
+
+def _skip_unless_real_redis_configured() -> None:
+    """Guard so this file fails loudly, not with a connection traceback,
+    when accidentally collected under the default (LocMemCache) settings
+    module rather than ``--ds=settings_redis``."""
+    backend = settings.CACHES.get("default", {}).get("BACKEND", "")
+    if not backend.startswith("django_redis.cache."):
+        pytest.skip(
+            "requires --ds=settings_redis (a real django-redis backend); "
+            f"current CACHES['default']['BACKEND']={backend!r}"
+        )
+
+
+@pytest.fixture
+def real_redis_client():
+    """A real Redis client via the same resolution path production uses."""
+    _skip_unless_real_redis_configured()
+
+    from django_redis import get_redis_connection
+
+    from django_waf import conf
+
+    client = get_redis_connection(conf.DJANGO_WAF_REDIS_ALIAS)
+    client.flushdb()
+    yield client
+    client.flushdb()
+
+
+class TestOldGetdelImplementationFailsOnRedis60:
+    """Reproduces the exact call the old code made. This test's failure
+    (before the fix) IS the production defect; its pass (after the fix,
+    because the fix no longer calls getdel at all) proves the regression
+    is closed at the command level, independent of the task's own
+    try/except swallowing the same error."""
+
+    def test_getdel_raises_on_a_pre_62_redis_server(self, real_redis_client):
+        import redis
+
+        key = f"waf:rule_hits:{uuid.uuid4()}"
+        real_redis_client.set(key, 5)
+
+        with pytest.raises(redis.exceptions.ResponseError, match="(?i)unknown command"):
+            real_redis_client.getdel(key)
+
+    def test_get_then_delete_pipeline_works_on_the_same_server(self, real_redis_client):
+        """The replacement implementation's actual commands, confirmed
+        against the same server the getdel call above just failed on."""
+        key = f"waf:rule_hits:{uuid.uuid4()}"
+        real_redis_client.set(key, 7)
+
+        pipe = real_redis_client.pipeline()
+        pipe.get(key)
+        pipe.delete(key)
+        get_result, delete_result = pipe.execute()
+
+        assert get_result == b"7"
+        assert delete_result == 1
+        assert real_redis_client.get(key) is None
+
+
+@pytest.mark.django_db
+class TestFlushRuleHitCountsAgainstRealRedis:
+    """The full task, against a real Redis 6.0 server. This is the test
+    that proves the fix, not merely the absence of the old crash: a task
+    that caught the getdel error and silently returned {"flushed": 0}
+    would also "pass" a test that only checks for no exception."""
+
+    def test_flush_moves_the_counter_to_the_block_rule_row(self, real_redis_client):
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.tasks import flush_rule_hit_counts
+
+        rule = BlockRuleFactory(hit_count=0)
+        for _ in range(6):
+            _record_rule_hit(str(rule.id), real_redis_client)
+
+        result = flush_rule_hit_counts()
+
+        rule.refresh_from_db()
+        assert rule.hit_count == 6
+        assert result == {"flushed": 1, "keys_seen": 1, "errors": 0}
+        assert real_redis_client.get(f"waf:rule_hits:{rule.id}") is None
+
+
+class TestRedisVersionCheckAgainstRealRedis:
+    """get_redis_server_version (redis_client.py) reads via INFO, a command
+    fakeredis does not implement at all (confirmed against the pinned
+    fakeredis version: FakeRedis(version=(6, 0)).info() raises
+    ResponseError: unknown command 'info'). Only a real server proves this
+    path works; see tests/test_redis_fallback.py's
+    TestGetRedisServerVersion for the MagicMock-based parsing tests."""
+
+    def test_reads_the_real_server_version_at_or_above_the_floor(self):
+        _skip_unless_real_redis_configured()
+
+        from django_waf.services.redis_client import MIN_REDIS_VERSION, get_redis_server_version
+
+        version = get_redis_server_version()
+
+        assert version is not None
+        assert version >= MIN_REDIS_VERSION  # the CI service container is redis:6.0-alpine
+
+    def test_check_redis_version_is_silent_against_the_ci_container(self):
+        """The CI service container (redis:6.0-alpine) sits exactly at the
+        package's declared floor, so django_waf.E005 must not fire against
+        it."""
+        _skip_unless_real_redis_configured()
+
+        from django_waf.checks import check_redis_version
+
+        assert check_redis_version(app_configs=None) == []

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -496,6 +496,49 @@ class TestVerdictDispatch:
         assert "/challenge/" in response["Location"]
 
     @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_challenge_counter_increment_failure_still_redirects_and_logs(self, caplog):
+        """A Redis failure while recording the unsolved-challenge counter is
+        the producer half of the counter
+        rule_engine._get_unsolved_challenge_count reads: a silent failure
+        here has the same effect as a failure on the read side, escalation
+        goes blind for this IP. Fail-open must still redirect to the
+        challenge page (BR-EVAL-007), but the failure must be logged."""
+        import importlib
+        import logging
+
+        import django_waf.conf as conf_mod
+
+        importlib.reload(conf_mod)
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("view response"))
+
+        broken_redis = _mock_redis()
+        broken_redis.incr.side_effect = RuntimeError("redis down")
+
+        with (
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+            patch("django_waf.middleware._emit_request_blocked"),
+            patch("django_waf.middleware._emit_request_throttled"),
+            caplog.at_level(logging.WARNING, logger="django_waf.middleware"),
+        ):
+            mock_redis_fn.return_value = broken_redis
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result("challenged")
+
+            middleware = _make_middleware(get_response)
+            response = middleware(request)
+
+        assert response.status_code == 302
+        assert "/challenge/" in response["Location"]
+        assert any("failed to record challenge" in message for message in caplog.messages)
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
     def test_challenged_verdict_on_challenge_path_passes_through(self):
         """Challenge verdict on /waf/challenge/ must not redirect to itself (loop prevention)."""
         import importlib

--- a/tests/test_redis_fallback.py
+++ b/tests/test_redis_fallback.py
@@ -264,3 +264,68 @@ class TestRedisBackendSystemCheck:
 
         assert messages == []
         importlib.reload(conf_mod)
+
+
+# ---------------------------------------------------------------------------
+# get_redis_server_version and django_waf.E005 (#78)
+#
+# fakeredis does not implement the INFO command at all (confirmed against
+# the pinned fakeredis version: FakeRedis(version=(6, 0)).info() raises
+# ResponseError: unknown command 'info'), the same class of gap that let
+# the original getdel defect through fakeredis undetected. A MagicMock
+# proves the parsing logic here; the actual server-version read is only
+# provable against a real server, see
+# tests/test_flush_rule_hit_counts_redis_integration.py's
+# TestOldGetdelImplementationFailsOnRedis60 for the same pattern applied to
+# the getdel fix, and add the equivalent real-Redis INFO assertion there if
+# E005 also needs a real-server regression test.
+# ---------------------------------------------------------------------------
+
+
+class TestGetRedisServerVersion:
+    def test_parses_a_standard_version_string(self):
+        from unittest.mock import MagicMock
+
+        from django_waf.services.redis_client import get_redis_server_version
+
+        client = MagicMock()
+        client.info.return_value = {"redis_version": "6.0.16"}
+
+        with patch("django_waf.services.redis_client.get_redis_client", return_value=client):
+            assert get_redis_server_version() == (6, 0, 16)
+
+    def test_returns_none_when_client_unavailable(self):
+        from django_waf.services.redis_client import get_redis_server_version
+
+        with patch("django_waf.services.redis_client.get_redis_client", return_value=None):
+            assert get_redis_server_version() is None
+
+    def test_returns_none_and_does_not_raise_on_a_malformed_info_response(self):
+        from unittest.mock import MagicMock
+
+        from django_waf.services.redis_client import get_redis_server_version
+
+        client = MagicMock()
+        client.info.return_value = {"redis_version": "not-a-version"}
+
+        with patch("django_waf.services.redis_client.get_redis_client", return_value=client):
+            assert get_redis_server_version() is None
+
+    def test_returns_none_and_does_not_raise_when_info_call_fails(self):
+        from unittest.mock import MagicMock
+
+        from django_waf.services.redis_client import get_redis_server_version
+
+        client = MagicMock()
+        client.info.side_effect = RuntimeError("connection reset")
+
+        with patch("django_waf.services.redis_client.get_redis_client", return_value=client):
+            assert get_redis_server_version() is None
+
+    def test_min_redis_version_is_six_zero(self):
+        """The single source of truth django_waf.E005 reads. Pinned
+        explicitly so a change to the floor is a deliberate, visible edit
+        to this test, not a silent drift."""
+        from django_waf.services.redis_client import MIN_REDIS_VERSION
+
+        assert MIN_REDIS_VERSION == (6, 0, 0)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3881,11 +3881,27 @@ class TestKnownFingerprintRegistry:
         redis.incr.assert_not_called()
 
     def test_register_swallows_redis_exception(self):
-        """A Redis error during register is silently swallowed — never raises."""
+        """A Redis error during register does not raise: the caller (VerifyView)
+        must still complete the redirect."""
         redis = MagicMock()
         redis.incr.side_effect = RuntimeError("redis down")
         # Must not raise
         register_known_fingerprint("abc123", redis)
+
+    def test_register_logs_a_warning_on_failure(self, caplog):
+        """A silent failure here is a false-positive amplifier, not a neutral
+        fail-open: is_known_fingerprint fails closed, so a real user who just
+        solved a challenge would be re-challenged on every subsequent visit
+        with no operator-visible signal that the allowlist has stopped
+        growing."""
+        import logging
+
+        redis = MagicMock()
+        redis.incr.side_effect = RuntimeError("redis down")
+        with caplog.at_level(logging.WARNING, logger="django_waf.fingerprint"):
+            register_known_fingerprint("abc123", redis)
+
+        assert any("abc123" in message for message in caplog.messages)
 
     def test_is_known_returns_true_when_counter_present(self):
         """is_known_fingerprint returns True when the Redis key has a value."""
@@ -4274,6 +4290,21 @@ class TestRuleEngineHelpers:
         redis = MagicMock()
         redis.get.side_effect = RuntimeError("redis down")
         assert _get_unsolved_challenge_count("203.0.113.1", redis) == 0
+
+    def test_get_unsolved_challenge_count_logs_a_warning_on_failure(self, caplog):
+        """A Redis failure here returns 0, indistinguishable from a fresh
+        IP, which silently disables challenge escalation. Must be logged,
+        not swallowed silently (see the fail-open observability release)."""
+        import logging
+
+        from django_waf.services.rule_engine import _get_unsolved_challenge_count
+
+        redis = MagicMock()
+        redis.get.side_effect = RuntimeError("redis down")
+        with caplog.at_level(logging.WARNING, logger="django_waf.rule_engine"):
+            _get_unsolved_challenge_count("203.0.113.1", redis)
+
+        assert any("203.0.113.1" in message for message in caplog.messages)
 
     # ------------------------------------------------------------------ _create_escalation_rule
 

--- a/tests/test_silent_failure_sites.py
+++ b/tests/test_silent_failure_sites.py
@@ -1,0 +1,192 @@
+"""Failure-path tests for the reliability release's four silent-failure
+sites (#78): every bare ``except Exception`` on a Redis call that a WAF
+operator has no way to observe, because the request/task still returned
+success-shaped output.
+
+The contract under test throughout is the same: fails open AND logs.
+Fail-open (BR-EVAL-007) is correct and unchanged: a Redis outage must never
+turn into a blocked request or a crashed task. What #78 fixes is the "AND
+logs" half: before this release, three of these four sites had no log line
+at all, so an operator watching Redis come back up after an outage had no
+way to see that a chunk of hit counters, or a whole rule-cache
+invalidation, was silently dropped during the gap.
+
+Three of the four sites live inside ``flush_rule_hit_counts`` (tasks.py);
+the per-key GET/DELETE failure and the DB-update failure are covered
+directly in ``test_flush_rule_hit_counts.py`` alongside the crux tests for
+that function. This file covers the two sites not covered there:
+
+1. ``flush_rule_hit_counts`` failing to obtain a Redis connection at all
+   (the top-level ``get_redis_connection`` call).
+2. ``flush_rule_hit_counts`` failing to list ``waf:rule_hits:*`` keys
+   (``redis_client.keys()`` raising).
+3. ``_invalidate_rule_cache_redis`` (called from ``expire_rules``) falling
+   back to the Django cache with no log at all. Per the task brief: if the
+   logging is not there yet, the test is still written to drive the
+   requirement rather than skipped.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+def mock_redis_connection_raises(exc: Exception):
+    """Patch ``django_redis.get_redis_connection`` to raise, simulating a
+    Redis outage at the point every one of these tasks first tries to
+    obtain a client."""
+    return patch("django_redis.get_redis_connection", side_effect=exc)
+
+
+# ---------------------------------------------------------------------------
+# flush_rule_hit_counts: Redis connection unavailable
+# ---------------------------------------------------------------------------
+
+
+class TestFlushRuleHitCountsRedisUnavailable:
+    def test_fails_open_with_a_zeroed_result(self):
+        from django_waf.tasks import flush_rule_hit_counts
+
+        with mock_redis_connection_raises(RuntimeError("connection refused")):
+            result = flush_rule_hit_counts()
+
+        assert result == {"flushed": 0, "keys_seen": 0, "errors": 0}
+
+    def test_logs_the_outage(self, caplog):
+        from django_waf.tasks import flush_rule_hit_counts
+
+        with (
+            caplog.at_level(logging.WARNING, logger="django_waf.tasks"),
+            mock_redis_connection_raises(RuntimeError("connection refused")),
+        ):
+            flush_rule_hit_counts()
+
+        assert any("Redis unavailable" in message for message in caplog.messages)
+
+    def test_does_not_raise(self):
+        """The task itself must never propagate a Redis outage (BR-EVAL-007
+        applied to a background task: a failed flush waits for the next
+        scheduled run rather than crashing the worker)."""
+        from django_waf.tasks import flush_rule_hit_counts
+
+        with mock_redis_connection_raises(ConnectionError("refused")):
+            flush_rule_hit_counts()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# flush_rule_hit_counts: Redis reachable but KEYS fails
+# ---------------------------------------------------------------------------
+
+
+class TestFlushRuleHitCountsKeysListingFails:
+    def _broken_keys_client(self):
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        client.keys.side_effect = RuntimeError("redis timeout")
+        return client
+
+    def test_fails_open_with_one_error_counted(self):
+        from django_waf.tasks import flush_rule_hit_counts
+
+        client = self._broken_keys_client()
+        with patch("django_redis.get_redis_connection", return_value=client):
+            result = flush_rule_hit_counts()
+
+        assert result == {"flushed": 0, "keys_seen": 0, "errors": 1}
+
+    def test_logs_the_failure(self, caplog):
+        from django_waf.tasks import flush_rule_hit_counts
+
+        client = self._broken_keys_client()
+        with (
+            caplog.at_level(logging.ERROR, logger="django_waf.tasks"),
+            patch("django_redis.get_redis_connection", return_value=client),
+        ):
+            flush_rule_hit_counts()
+
+        assert any("failed to list Redis hit count keys" in message for message in caplog.messages)
+
+    def test_does_not_raise(self):
+        from django_waf.tasks import flush_rule_hit_counts
+
+        client = self._broken_keys_client()
+        with patch("django_redis.get_redis_connection", return_value=client):
+            flush_rule_hit_counts()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# _invalidate_rule_cache_redis: falls back to the Django cache
+# ---------------------------------------------------------------------------
+
+
+class TestInvalidateRuleCacheRedisFailure:
+    """The fourth silent-failure site. Unlike the three inside
+    flush_rule_hit_counts, this one had no log line on its except branch as
+    of the start of this reliability release: it falls back to the Django
+    cache and returns, indistinguishable from the Redis path having
+    succeeded. This test is written to the target contract (fails open AND
+    logs) regardless of whether the logging has landed yet; if it has not,
+    this test's failure is the signal that the source-side half of #78 is
+    still outstanding for this site.
+    """
+
+    def test_falls_back_to_django_cache_without_raising(self):
+        from django.core.cache import cache
+
+        from django_waf.tasks import _invalidate_rule_cache_redis
+
+        cache.delete("waf:rules:version")
+
+        with mock_redis_connection_raises(RuntimeError("redis down")):
+            _invalidate_rule_cache_redis()  # must not raise
+
+        # Fail-open still does its job: the version key moved via the
+        # Django cache fallback even though Redis was unavailable.
+        assert cache.get("waf:rules:version") == 1
+
+    def test_logs_the_fallback(self, caplog):
+        from django_waf.tasks import _invalidate_rule_cache_redis
+
+        with (
+            caplog.at_level(logging.WARNING, logger="django_waf.tasks"),
+            mock_redis_connection_raises(RuntimeError("redis down")),
+        ):
+            _invalidate_rule_cache_redis()
+
+        assert any("rule cache" in message.lower() or "invalidat" in message.lower() for message in caplog.messages), (
+            "expected a log line when _invalidate_rule_cache_redis falls back to the "
+            "Django cache; before #78 this except branch was silent"
+        )
+
+
+# ---------------------------------------------------------------------------
+# expire_rules: the caller, proving the fail-open contract end to end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestExpireRulesSurvivesRedisOutage:
+    def test_expire_rules_completes_when_cache_invalidation_fails(self):
+        """expire_rules already swallows _invalidate_rule_cache_redis
+        exceptions (see tests/test_tasks.py::TestExpireRules), but that
+        coverage mocks the helper itself out entirely. This test drives the
+        real helper through a real Redis outage, proving the two layers
+        compose: a Redis outage during cache invalidation must not stop
+        expire_rules from returning its rule-expiry counts."""
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        from django_waf.tasks import expire_rules
+        from django_waf.testing.factories import BlockRuleFactory
+
+        BlockRuleFactory(is_active=True, expires_at=timezone.now() - timedelta(minutes=1))
+
+        with mock_redis_connection_raises(RuntimeError("redis down")):
+            result = expire_rules()
+
+        assert result["expired_block_count"] >= 1

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -127,6 +127,23 @@ class TestParseAccessLog:
 
         assert result == {"parsed_lines": 0, "created_records": 0, "skipped_lines": 0}
 
+    def test_unset_path_logs_at_debug_not_warning(self, caplog):
+        """No path configured is an expected, quiet no-op: DEBUG, not a
+        production-visible WARNING."""
+        import logging
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_ACCESS_LOG_PATH", ""),
+            caplog.at_level(logging.DEBUG, logger="django_waf.tasks"),
+        ):
+            from django_waf.tasks import parse_access_log
+
+            parse_access_log()
+
+        levels = [record.levelname for record in caplog.records]
+        assert "WARNING" not in levels
+        assert any(record.levelname == "DEBUG" for record in caplog.records)
+
     def test_skips_when_file_does_not_exist(self):
         """Task returns zero counts when the file at the configured path is absent."""
         from django_waf.tasks import parse_access_log
@@ -134,6 +151,19 @@ class TestParseAccessLog:
         result = parse_access_log(log_path="/non/existent/access.log")
 
         assert result == {"parsed_lines": 0, "created_records": 0, "skipped_lines": 0}
+
+    def test_configured_but_missing_path_logs_a_warning(self, caplog):
+        """A configured DJANGO_WAF_ACCESS_LOG_PATH that does not resolve to a
+        file is very likely a misconfiguration, not an idle site: it must be
+        visible in production (WARNING), not DEBUG-only."""
+        import logging
+
+        from django_waf.tasks import parse_access_log
+
+        with caplog.at_level(logging.WARNING, logger="django_waf.tasks"):
+            parse_access_log(log_path="/non/existent/access.log")
+
+        assert any("/non/existent/access.log" in message for message in caplog.messages)
 
     @pytest.mark.django_db
     def test_parses_valid_combined_log_lines(self):
@@ -558,7 +588,34 @@ class TestUpdateIpReputation:
 
         result = update_ip_reputation()
 
-        assert result == {"updated_count": 0, "created_count": 0}
+        assert result == {"updated_count": 0, "created_count": 0, "ips_seen": 0}
+
+    @pytest.mark.django_db
+    def test_no_recent_logs_logs_a_warning(self, caplog):
+        """detect_challenge_farms reads IPReputation directly, so a window
+        with zero RequestLog rows blinds that detector for the whole
+        window. Must be a WARNING, not the same INFO line as a processed,
+        genuinely quiet window."""
+        import logging
+
+        from django_waf.tasks import update_ip_reputation
+
+        with caplog.at_level(logging.WARNING, logger="django_waf.tasks"):
+            update_ip_reputation()
+
+        assert any(record.levelname == "WARNING" for record in caplog.records)
+
+    @pytest.mark.django_db
+    def test_ips_seen_reflects_processed_ips_on_success(self):
+        """A window that did see RequestLog rows reports a non-zero
+        ips_seen, distinguishing it from the zero-rows case above."""
+        from django_waf.tasks import update_ip_reputation
+
+        RequestLogFactory(ip_address="203.0.113.50", timestamp=timezone.now())
+
+        result = update_ip_reputation()
+
+        assert result["ips_seen"] == 1
 
     @pytest.mark.django_db
     def test_counts_challenge_tokens_for_pass_fail(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -304,6 +304,67 @@ class TestVerifyView:
         assert response.status_code == 302
         assert response["Location"] == "/target/"
 
+    def test_solved_flag_write_failure_still_redirects_and_logs(self, settings, caplog):
+        """A Redis failure while setting the solved flag leaves the IP's
+        unsolved-challenge counter standing, so a real user who just solved
+        a challenge could still hit the escalation threshold. Fail-open
+        must still complete the redirect (BR-EVAL-007), but the failure
+        must be logged, not swallowed silently."""
+        import logging
+
+        settings.DJANGO_WAF_ENABLED = True
+
+        client = Client()
+        broken_redis = _mock_redis()
+        broken_redis.setex.side_effect = RuntimeError("redis down")
+
+        with (
+            patch("django_waf.views._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.verify_challenge_solution") as mock_verify,
+            patch("django_waf.services.challenge_service.issue_pass_cookie"),
+            caplog.at_level(logging.WARNING, logger="django_waf.views"),
+        ):
+            mock_redis_fn.return_value = broken_redis
+            mock_verify.return_value = True
+
+            response = client.post(
+                "/waf/verify/",
+                data={"token": "tok", "nonce": "nonce99", "next": "/target/"},
+            )
+
+        assert response.status_code == 302
+        assert any("solved flag" in message for message in caplog.messages)
+
+    def test_fingerprint_registration_failure_still_redirects_and_logs(self, settings, caplog):
+        """compute_fingerprint/register_known_fingerprint raising must not
+        break the redirect that follows a successfully solved challenge."""
+        import logging
+
+        settings.DJANGO_WAF_ENABLED = True
+
+        client = Client()
+
+        with (
+            patch("django_waf.views._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.verify_challenge_solution") as mock_verify,
+            patch("django_waf.services.challenge_service.issue_pass_cookie"),
+            patch(
+                "django_waf.services.fingerprint.compute_fingerprint",
+                side_effect=RuntimeError("bad headers"),
+            ),
+            caplog.at_level(logging.WARNING, logger="django_waf.views"),
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_verify.return_value = True
+
+            response = client.post(
+                "/waf/verify/",
+                data={"token": "tok", "nonce": "nonce99", "next": "/target/"},
+            )
+
+        assert response.status_code == 302
+        assert any("fingerprint" in message for message in caplog.messages)
+
     def test_missing_token_returns_400(self):
         client = Client()
 


### PR DESCRIPTION
Closes #78.

## What was wrong

`flush_rule_hit_counts` called `redis_client.getdel()`, which requires Redis 6.2+. On a 6.0 server every call raised `ResponseError`, caught by a bare `except Exception: continue`. Confirmed on a live deployment running Redis 6.0.16: **40,936 task runs, every one reporting success, none flushing anything.** Every `BlockRule.hit_count` on that box was permanently `0` while the rules were matching thousands of times a day.

In a security package that is the worst failure shape there is. The dashboard's rule-effectiveness panel reads those counters, so an operator sees zeros on rules that are working, which is an invitation to delete them.

## Root cause

Not a design failure. This package's own `redis_client.py:14-17` already states the principle: *"A security control that reports healthy while blocking nothing is the worst possible failure mode for this package specifically."* `generate_blocklist` and `sync_threat_feed` already implement the correct pattern. This was inconsistent application of the package's own documented standard, made invisible by four compounding gaps:

1. **No declared Redis server floor.** `pyproject.toml` pins `django-redis` (the client). The package's true floor was 6.2 by accident, via one call.
2. **ruff `S110`/`S112` disabled** in `pyproject.toml`, the two rules that flag try-except-pass and try-except-continue.
3. **No real Redis in CI.** No `services:` block on any matrix leg; the package had never run a Redis command against a real server in CI.
4. **The failure was shaped like success.** `{"flushed": 0}` plus an INFO log is byte-identical to a healthy idle site, and `ignore_result=True` means the return dict is discarded, so that ambiguous log line was the only observable.

All four are closed here.

## The fix

`getdel` was the **only** command in the package requiring newer than Redis 6.0 (audited: next highest is `SET ... NX EX` at 2.6.12). Replaced with a `GET`+`DEL` pipeline rather than raising the floor, since demanding a server upgrade to count hits is a poor trade for consumers. The pipeline is not atomic against a concurrent `INCR` between the two commands; that is an acceptable trade for a coarse counter flushed every five minutes, and it is documented in-code rather than glossed.

## Seven silent-failure sites now observable

**Fail-open behaviour is unchanged everywhere (BR-EVAL-007). Only observability changes.** Two of these were found by the re-enabled lint rules, not by the original audit, which is the strongest argument that the lint suppression was the real enabling condition.

| Site | Consequence when silent |
|---|---|
| `rule_engine._record_rule_hit` | Producer half of this counter. An actively matching rule reads as never used |
| `rule_engine._get_unsolved_challenge_count` | Returning 0 is indistinguishable from "never challenged", **silently disabling challenge escalation**. A bot farm failing every challenge would never escalate to a block |
| middleware `waf:challenged:{ip}` write | Same counter, other side |
| `fingerprint.register_known_fingerprint` | Kills the known-fingerprint allowlist, so real users who solved a challenge are challenged again on every visit. A false-positive amplifier |
| `views.VerifyView` | One `except` covered two unrelated writes; split so each logs its own consequence |
| `tasks._invalidate_rule_cache_redis` | Silent fallback to a per-process cache that does not propagate to other workers |
| `tasks.flush_rule_hit_counts` | DB update errors swallowed by the same bare except as the Redis error |

## Also in this change

- **Task returns distinguish failure from a legitimate no-op.** `flush_rule_hit_counts` returns `{flushed, keys_seen, errors}` on every exit path. `parse_access_log` separates an unset path from a configured-but-missing file (previously DEBUG, invisible in production). `update_ip_reputation` warns when an empty window blinds `detect_challenge_farms`.
- **`django_waf.E005`**, a boot-time check comparing the live server version against `MIN_REDIS_VERSION` in `redis_client.py`, the single source of truth, so the check and the behaviour it guards cannot desync. Guarded like `E004` but without #67's bug: silent when the WAF is disabled, when the alias is not a django-redis backend, or when no version can be read.
- **A dedicated CI job against real `redis:6.0-alpine`**, pinned to the floor rather than latest. Testing against Redis 7 would have hidden this exactly as fakeredis did. A dedicated leg rather than a service on all 7 matrix legs, because the defect is Redis-version-specific, not Python/Django-specific.
- **`FakeRedis(version=(6,0))`** in the shipped test fixtures. Note honestly: fakeredis registers `GETDEL` with **no version gate**, so this improves fidelity generally but could not have caught this defect on its own. The real-Redis CI leg is what does.
- **ruff `S110`/`S112` re-enabled**, with justified per-line noqa plus a log line where a swallow is genuinely intentional.

## Verification

| Gate | Result |
|---|---|
| `ruff check src/ tests/` | pass |
| `ruff format --check src/ tests/` | pass, 138 files |
| `pytest --cov=src` | **1145 passed, 5 skipped, 93.03% coverage** (gate 90%) |
| Redis integration leg vs real 6.0.20 | **5 passed** |
| `mypy src/` | 38 pre-existing errors, **zero introduced** (verified by stashing the diff) |

`tasks.py` coverage rose from 44% to ~94%. The regression test is genuinely falsifiable: `test_getdel_raises_on_a_pre_62_redis_server` proves the old call fails on the deployed server version, and `test_get_then_delete_pipeline_works_on_the_same_server` proves the replacement works there.

## Upgrade consequences for existing consumers

- **`E005` can fail `manage.py check` on a Redis older than 6.0.** That is the intended behaviour, but it is a new boot-time failure a consumer did not have before.
- **`FakeRedis(version=(6,0))` in the shipped fixtures may fail a consumer's tests** if they use a Redis command above the floor through that fixture. Correct, but new.
- Hit counters will start moving on deployments where they were stuck at zero. Historic counts are not recoverable.

## Not in this change

- **Spec updates** to `docs/specs/django-waf/` (BR-EVAL-007, BR-REP, `03-services.md` in two places, `04-interfaces.md` for the new check ID). That is a separate repo; filed as follow-up.
- **The auto-rule action question.** `detect_ua_rotation`, `detect_subnet_burst` and `detect_cloud_spray` create `CHALLENGE` rules, and `for_nginx()` filters to `[BLOCK, THROTTLE]`, so those rules can never reach the nginx blocklist. The exclusion is technically correct (nginx cannot serve a JS proof-of-work) but undocumented, and it means the two detectors producing CIDR subnet rules, the highest-leverage thing to push to the edge, are middleware-only. Tracked separately.
