### PR TITLE
fix: detect abandoned challenges by subnet, not only by IP (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **`detect_unsolved_challenges` was starved of candidates by an attacker
+  spreading traffic across a subnet.** Traced against a live deployment
+  (issue #84): an attacker rotating roughly 120 addresses per /24 leaves
+  almost no individual IP reaching the challenge-count threshold within the
+  detection window, even though the subnet in aggregate abandoned
+  thousands of challenges from over 100 distinct IPs in a week. The
+  detector now runs a parallel subnet-grain aggregation alongside the
+  existing per-IP one: a /24 (or /48 for IPv6) whose total challenged-verdict
+  count and number of distinct contributing IPs both clear a configurable
+  threshold is treated as a candidate even when no individual IP within it
+  ever reaches the per-IP threshold. The distinct-IP requirement is
+  independent of the total count, so one noisy host can never escalate its
+  neighbours by itself. A first subnet-level crossing creates a CHALLENGE
+  rule; only a repeat crossing of the same subnet, detected against an
+  already-active auto-generated CHALLENGE rule, promotes it to BLOCK.
+  Abandonment has legitimate causes (a real user closing the tab or
+  blocking JavaScript looks identical to a bot at this signal), so a
+  subnet is never blocked on a single crossing.
+
+- **The solved-challenge exemption had no time bound.** `solved_ips`
+  exempted an IP from this detector permanently after a single solved
+  challenge at any point in its history. Traced live, this removed half
+  of the candidates that otherwise met every other signal. The exemption
+  is now scoped to `DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS`
+  (default 24 hours); the same bound applies to the new subnet path, so an
+  occasional solve from a rotating pool of addresses cannot grant a whole
+  subnet permanent immunity either.
+
+### Added
+
+- `DJANGO_WAF_UNSOLVED_MIN_CHALLENGED`, `DJANGO_WAF_UNSOLVED_REFERER_RATIO`,
+  `DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS`,
+  `DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED`, and
+  `DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS` settings for tuning
+  `detect_unsolved_challenges`, matching every other detector threshold in
+  the package. The two existing thresholds were previously only reachable
+  as function-parameter defaults; an operator can now tune all five
+  without calling the detector directly. `min_challenged` and
+  `referer_ratio` remain accepted keyword arguments on
+  `detect_unsolved_challenges` and default to the new settings, so
+  existing callers and the dry-run management command are unaffected.
+
 ## [2.0.0] - 2026-08-28
 
 ### Security

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -677,3 +677,63 @@ DJANGO_WAF_TRUSTED_COOKIE_TTL: int = getattr(settings, "DJANGO_WAF_TRUSTED_COOKI
 # coverage on this cookie without configuring it twice. Set explicitly only
 # when this cookie's subdomain scope must differ from the session cookie's.
 DJANGO_WAF_TRUSTED_COOKIE_DOMAIN: str | None = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_DOMAIN", None)
+
+# ---------------------------------------------------------------------------
+# detect_unsolved_challenges (issue #84)
+# ---------------------------------------------------------------------------
+# Traced against a live deployment: an attacker rotating roughly 120
+# addresses per /24 abandons challenges (never attempts them, not failures)
+# at a rate that is unmistakable in aggregate but invisible per IP. Reading
+# these values from settings, not only the function's own parameter
+# defaults, lets an operator tune the detector without calling it directly.
+# Per #75 (still open), every value here is a conf.py import-time snapshot:
+# tests overriding it must use patch.object(conf, "NAME", ...), not
+# override_settings, or the override will not be seen.
+
+# Minimum challenged verdicts a single IP must accumulate within the
+# detection window before it is considered a candidate. Unchanged from the
+# pre-#84 function default: traced live, this threshold was not the
+# bottleneck for the IPs that reached it (3 of 3 survivors passed every
+# later check). The problem is that almost no individual IP reaches it at
+# all when the attacker spreads across a /24.
+DJANGO_WAF_UNSOLVED_MIN_CHALLENGED: int = getattr(settings, "DJANGO_WAF_UNSOLVED_MIN_CHALLENGED", 3)
+
+# Fraction of an IP's non-root requests that must carry an empty referer
+# before the per-IP path flags it. Unchanged from the pre-#84 function
+# default: traced live, this rejected nobody among the survivors, so it is
+# not the current bottleneck (kept as a safety margin for when the
+# candidate pool grows, per the issue's false-positive discipline).
+DJANGO_WAF_UNSOLVED_REFERER_RATIO: float = getattr(settings, "DJANGO_WAF_UNSOLVED_REFERER_RATIO", 0.8)
+
+# How far back to look for a SOLVED ChallengeToken before granting an IP (or
+# a subnet, see DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS below) permanent immunity
+# from this detector. Before #84 the solved-challenge exemption had no time
+# bound at all: a single solve at any point in an IP's history granted
+# immunity forever. Traced live, this removed half the candidates in a
+# 60-minute window. 24 hours is chosen to be comfortably longer than the
+# detector's own 60-minute default window (a recent, deliberate solve still
+# exempts the IP for a full day) while no longer letting a solve from weeks
+# or months ago paper over current abandonment behaviour.
+DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS: int = getattr(
+    settings, "DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS", 24
+)
+
+# Minimum total challenged-verdict count across an entire /24 (IPv4) or /48
+# (IPv6) subnet before the subnet itself becomes a candidate. Necessarily
+# far higher than DJANGO_WAF_UNSOLVED_MIN_CHALLENGED: a /24 carries up to
+# 256 addresses, and the measured attack produced up to 3,232 abandoned
+# challenges from one /24 in a week. 30 is chosen so ten distributed IPs
+# challenged 3 times each (the per-IP threshold) would already qualify,
+# while a handful of genuine visitors sharing a /24 who each abandon one
+# or two challenges does not.
+DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED: int = getattr(settings, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30)
+
+# Minimum number of DISTINCT contributing IPs within the subnet, required
+# alongside DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED. This is the guard
+# against one noisy host escalating its neighbours: without it, a single
+# IP hammering the site could cross the total-count threshold alone and
+# get an entire /24 challenged. Measured subnets in the traced attack
+# carried 100+ distinct contributing IPs; 10 is set far below that so the
+# detector catches a materially smaller, still-clearly-distributed pool
+# rather than only the extreme case already seen.
+DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS: int = getattr(settings, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10)

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -255,58 +255,96 @@ def detect_challenge_farms(window_hours: int = 24, dry_run: bool = False) -> lis
 
 def detect_unsolved_challenges(
     window_minutes: int = 60,
-    min_challenged: int = 3,
-    referer_ratio: float = 0.8,
+    min_challenged: int | None = None,
+    referer_ratio: float | None = None,
     dry_run: bool = False,
 ) -> list:
-    """Detect IPs that receive challenges but never solve them.
+    """Detect IPs, and subnets, that receive challenges but never solve them.
 
-    Composite detector combining three signals:
-    1. IP has >= min_challenged challenged verdicts in the window
-    2. IP has zero solved ChallengeTokens (ever)
+    Per issue #84, traced against a live deployment: the signal is
+    ABANDONMENT (a challenge issued and never attempted), not failure, and
+    it concentrates by subnet far more sharply than by IP. An attacker
+    rotating ~120 addresses per /24 leaves almost no individual IP reaching
+    ``min_challenged`` within the window, while the /24 in aggregate is
+    unmistakable (thousands of abandoned challenges, 100+ distinct IPs).
+    This detector therefore runs two parallel aggregations:
+
+    Per-IP path (unchanged in shape from before #84):
+    1. IP has >= min_challenged challenged verdicts in the window.
+    2. IP has no ChallengeToken solved within the configured recency
+       window (DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS). Before
+       #84 this was unbounded, granting permanent immunity from a single
+       solve at any point in history.
     3. Majority (>= referer_ratio) of the IP's requests have empty referer
        on paths other than "/"
 
-    The three-way conjunction gives high-confidence bot classification with
-    near-zero false-positive risk: real users always solve JS challenges,
-    and real browsing always produces referer headers from search engines
-    or internal navigation.
+    Creates an IP-exact BLOCK rule directly (unchanged: an IP that clears
+    all three per-IP signals is already high-confidence).
+
+    Subnet path (new, #84):
+    1. The /24 (IPv4) or /48 (IPv6) subnet's total challenged-verdict count
+       across the window meets DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED,
+       AND the number of DISTINCT contributing IPs meets
+       DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS. Both are required so one noisy
+       host cannot escalate its neighbours: a single IP alone can never
+       cross the distinct-IP floor no matter its own challenge count.
+    2. The subnet is exempted if any of its contributing IPs solved a
+       challenge within the recency window (same bound as the per-IP path,
+       for the same reason: an occasional solve from a rotating pool must
+       not grant the whole /24 permanent immunity).
+
+    The empty-referer requirement is deliberately NOT applied to the subnet
+    path: it is evaluated per-IP against a specific IP's non-root request
+    mix, and a subnet aggregate has no single "the subnet's referer" to
+    test. Composing distinct-IP weighting with challenge-before-block
+    staging (see ``_get_or_create_auto_rule``'s two-stage promotion below)
+    is what keeps the subnet path false-positive-safe without it, per
+    issue #84's stated discipline.
+
+    A subnet clearing its threshold is never blocked directly: the first
+    crossing creates (or refreshes) a CHALLENGE rule. Only a REPEAT
+    crossing, detected by an already-active auto CHALLENGE rule for the
+    same subnet, promotes it to BLOCK. This matters more here than for the
+    per-IP path because abandonment has a legitimate cause: a real user who
+    closes the tab or whose JavaScript is blocked abandons a challenge
+    exactly as a bot does, so a single crossing is not enough evidence to
+    block outright. Issue #82 measured that a coarse signal here would have
+    caught at least 35.6% real users on the same deployment.
 
     Args:
         window_minutes: Time window to analyse (default 60).
-        min_challenged: Minimum challenged verdicts to consider (default 3).
+        min_challenged: Minimum challenged verdicts for the per-IP path.
+                        Defaults to DJANGO_WAF_UNSOLVED_MIN_CHALLENGED.
         referer_ratio: Fraction of non-root requests with empty referer
-                       required to trigger (default 0.8).
+                       required to trigger the per-IP path. Defaults to
+                       DJANGO_WAF_UNSOLVED_REFERER_RATIO.
         dry_run: When True (#38), collects what would be created without
                  writing any BlockRule or emitting the anomaly_detected signal.
 
     Returns:
         List of BlockRule instances that were created (or, in dry-run, would
-        have been created).
+        have been created). May include both IP and CIDR rules.
     """
-    from django.db.models import Count, Q
+    from django.db.models import Count
 
     from django_waf import conf
-    from django_waf.enums import (
-        AnomalyType,
-        ChallengeStatus,
-        RequestLogSource,
-        RuleAction,
-        RuleType,
-        Verdict,
-    )
+    from django_waf.enums import ChallengeStatus, RequestLogSource, Verdict
     from django_waf.models import ChallengeToken, RequestLog
 
-    cutoff = timezone.now() - timedelta(minutes=window_minutes)
+    effective_min_challenged = min_challenged if min_challenged is not None else conf.DJANGO_WAF_UNSOLVED_MIN_CHALLENGED
+    effective_referer_ratio = referer_ratio if referer_ratio is not None else conf.DJANGO_WAF_UNSOLVED_REFERER_RATIO
 
-    # Step 1: IPs with >= min_challenged challenged verdicts in window.
+    cutoff = timezone.now() - timedelta(minutes=window_minutes)
+    solve_exemption_cutoff = timezone.now() - timedelta(hours=conf.DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS)
+
+    # All challenged verdicts in the window, per IP, with their counts.
     # Scoped to source=middleware (#32): a nginx_log row's verdict is
     # inferred from the access-log status code, not observed by
     # rule_engine.evaluate_request. The nginx access log records the same
     # request middleware already logged, so counting both would double the
     # apparent challenged_count for every IP and distort this detector's
-    # threshold check.
-    challenged_ips = (
+    # threshold checks.
+    challenged_by_ip = list(
         RequestLog.objects.filter(
             timestamp__gte=cutoff,
             verdict=Verdict.CHALLENGED,
@@ -314,30 +352,87 @@ def detect_unsolved_challenges(
         )
         .values("ip_address")
         .annotate(challenged_count=Count("id"))
-        .filter(challenged_count__gte=min_challenged)
     )
 
-    # Prefetch all IPs with solved challenges in one query (fixes N+1)
+    all_challenged_ips = [row["ip_address"] for row in challenged_by_ip]
+
+    # IPs with a SOLVED ChallengeToken within the recency window (#84).
+    # Before #84 this had no time bound at all, so a single solve at any
+    # point in an IP's history granted permanent immunity; traced live,
+    # that removed half the candidates in a 60-minute window.
     # order_by() clears ChallengeToken.Meta.ordering (-issued_at) before
     # distinct(): without it, Django appends issued_at to the SELECT, so
     # DISTINCT applies to (ip_address, issued_at) and this returns one row
     # per solved token rather than one row per IP (#59).
-    challenged_ip_list = [row["ip_address"] for row in challenged_ips]
     solved_ips = set(
         ChallengeToken.objects.filter(
-            ip_address__in=challenged_ip_list,
+            ip_address__in=all_challenged_ips,
             status=ChallengeStatus.SOLVED,
+            solved_at__gte=solve_exemption_cutoff,
         )
         .order_by()
         .values_list("ip_address", flat=True)
         .distinct()
     )
 
+    created_rules = []
+    expiry = timezone.now() + timedelta(hours=conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS)
+
+    created_rules.extend(
+        _detect_unsolved_challenges_per_ip(
+            challenged_by_ip=challenged_by_ip,
+            solved_ips=solved_ips,
+            cutoff=cutoff,
+            window_minutes=window_minutes,
+            min_challenged=effective_min_challenged,
+            referer_ratio=effective_referer_ratio,
+            expiry=expiry,
+            dry_run=dry_run,
+        )
+    )
+    created_rules.extend(
+        _detect_unsolved_challenges_by_subnet(
+            challenged_by_ip=challenged_by_ip,
+            solved_ips=solved_ips,
+            window_minutes=window_minutes,
+            expiry=expiry,
+            dry_run=dry_run,
+        )
+    )
+
+    return created_rules
+
+
+def _detect_unsolved_challenges_per_ip(
+    *,
+    challenged_by_ip: list,
+    solved_ips: set,
+    cutoff,
+    window_minutes: int,
+    min_challenged: int,
+    referer_ratio: float,
+    expiry,
+    dry_run: bool,
+) -> list:
+    """The per-IP half of detect_unsolved_challenges. See that function's
+    docstring for the three-signal contract this implements unchanged.
+    """
+    from django.db.models import Count, Q
+
+    from django_waf.enums import AnomalyType, RuleAction, RuleType
+    from django_waf.models import RequestLog
+
+    candidates = [row for row in challenged_by_ip if row["challenged_count"] >= min_challenged]
+    if not candidates:
+        return []
+
+    candidate_ips = [row["ip_address"] for row in candidates]
+
     # Prefetch referer stats for all candidate IPs in two queries
     non_root_counts = dict(
         RequestLog.objects.filter(
             timestamp__gte=cutoff,
-            ip_address__in=challenged_ip_list,
+            ip_address__in=candidate_ips,
         )
         .exclude(path="/")
         .values("ip_address")
@@ -347,7 +442,7 @@ def detect_unsolved_challenges(
     empty_referer_counts = dict(
         RequestLog.objects.filter(
             timestamp__gte=cutoff,
-            ip_address__in=challenged_ip_list,
+            ip_address__in=candidate_ips,
         )
         .exclude(path="/")
         .filter(Q(referer="") | Q(referer__isnull=True))
@@ -357,9 +452,8 @@ def detect_unsolved_challenges(
     )
 
     created_rules = []
-    expiry = timezone.now() + timedelta(hours=conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS)
 
-    for row in challenged_ips:
+    for row in candidates:
         ip = row["ip_address"]
 
         if ip in solved_ips:
@@ -411,6 +505,114 @@ def detect_unsolved_challenges(
                     ip,
                     row["challenged_count"],
                     empty_referer_ratio * 100,
+                )
+
+    return created_rules
+
+
+def _detect_unsolved_challenges_by_subnet(
+    *,
+    challenged_by_ip: list,
+    solved_ips: set,
+    window_minutes: int,
+    expiry,
+    dry_run: bool,
+) -> list:
+    """The subnet half of detect_unsolved_challenges (#84). See that
+    function's docstring for the two-signal, two-stage contract this
+    implements.
+    """
+    from django_waf import conf
+    from django_waf.enums import AnomalyType, RuleAction, RuleType
+    from django_waf.models import BlockRule, RuleSource
+
+    min_subnet_challenged = conf.DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED
+    min_subnet_ips = conf.DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS
+
+    # Aggregate every challenged IP (not only per-IP candidates: a subnet's
+    # abandonment can be real even when no single contributing IP reaches
+    # min_challenged, which is exactly the gap #84 measured) into subnets,
+    # tracking both the total challenged count and the set of distinct
+    # contributing IPs.
+    subnet_totals: dict[str, int] = {}
+    subnet_ips: dict[str, set] = {}
+    for row in challenged_by_ip:
+        ip = row["ip_address"]
+        try:
+            subnet = _get_subnet_prefix(ip)
+        except ValueError:
+            continue
+        subnet_totals[subnet] = subnet_totals.get(subnet, 0) + row["challenged_count"]
+        subnet_ips.setdefault(subnet, set()).add(ip)
+
+    created_rules = []
+
+    for subnet, total in subnet_totals.items():
+        distinct_ips = subnet_ips[subnet]
+        if total < min_subnet_challenged or len(distinct_ips) < min_subnet_ips:
+            continue
+
+        # Exempt a subnet if any of its contributing IPs solved a challenge
+        # within the recency window (same bound and rationale as the per-IP
+        # path): an occasional solve from a rotating pool must not grant
+        # the whole /24 permanent immunity.
+        if distinct_ips & solved_ips:
+            continue
+
+        details = {
+            "subnet_challenged_count": total,
+            "distinct_ips": len(distinct_ips),
+            "window_minutes": window_minutes,
+        }
+        confidence = _scaled_confidence(
+            observed=total,
+            threshold=min_subnet_challenged,
+            span=min_subnet_challenged * 2,
+        )
+
+        # Two-stage promotion (#84, issue #82's false-positive discipline):
+        # a subnet never goes straight to BLOCK on one crossing. Detect a
+        # repeat crossing as "this subnet already has an active auto
+        # CHALLENGE rule from this detector" and promote to BLOCK only
+        # then; a first crossing creates (or refreshes) the CHALLENGE rule.
+        # This existence check is a read, so it runs identically under
+        # dry_run: BR-ANOM-006 requires a dry run to report what a real run
+        # WOULD do, and only the write below is conditioned on dry_run.
+        already_challenged = BlockRule.objects.filter(
+            rule_type=RuleType.CIDR,
+            pattern=subnet,
+            source=RuleSource.AUTO,
+            action=RuleAction.CHALLENGE,
+            is_active=True,
+        ).exists()
+        stage_action = RuleAction.BLOCK if already_challenged else RuleAction.CHALLENGE
+
+        rule, created = _get_or_create_auto_rule(
+            name=f"Auto: unsolved challenges from {subnet} ({len(distinct_ips)} IPs)",
+            rule_type=RuleType.CIDR,
+            match_type="cidr",
+            pattern=subnet,
+            action=stage_action,
+            expiry=expiry,
+            dry_run=dry_run,
+            detector_name="detect_unsolved_challenges",
+            confidence=confidence,
+            evidence=details,
+        )
+        if created:
+            created_rules.append(rule)
+            if not dry_run:
+                _emit_anomaly_signal(
+                    rule=rule,
+                    anomaly_type=AnomalyType.UNSOLVED_CHALLENGE,
+                    details=details,
+                )
+                logger.info(
+                    "django-waf: auto-created unsolved challenge %s rule for %s (challenged=%d, ips=%d)",
+                    stage_action,
+                    subnet,
+                    total,
+                    len(distinct_ips),
                 )
 
     return created_rules

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3513,7 +3513,7 @@ class TestDetectUnsolvedChallenges:
                 referer="",
                 timestamp=now,
             )
-        ChallengeTokenFactory(ip_address=ip, status=ChallengeStatus.SOLVED)
+        ChallengeTokenFactory(ip_address=ip, status=ChallengeStatus.SOLVED, solved_at=now)
 
         rules = detect_unsolved_challenges(window_minutes=10, min_challenged=3)
 
@@ -3667,7 +3667,7 @@ class TestDetectUnsolvedChallenges:
         # issued_at is auto_now_add, so create multiple solved tokens for the
         # same IP, then use a queryset update() (which bypasses auto_now_add,
         # unlike save()) to force distinct issued_at values across rows.
-        tokens = [ChallengeTokenFactory(ip_address=ip, status=ChallengeStatus.SOLVED) for _ in range(3)]
+        tokens = [ChallengeTokenFactory(ip_address=ip, status=ChallengeStatus.SOLVED, solved_at=now) for _ in range(3)]
         for offset, token in enumerate(tokens):
             ChallengeToken.objects.filter(pk=token.pk).update(issued_at=now - timezone.timedelta(minutes=offset))
 
@@ -3684,6 +3684,207 @@ class TestDetectUnsolvedChallenges:
 
         assert "unsolved_challenge_rules" in result
         assert "total_rules_created" in result
+
+    @pytest.mark.django_db
+    def test_subnet_promoted_when_no_individual_ip_qualifies(self):
+        """A /24 whose IPs each fall below min_challenged is still promoted
+        to a CHALLENGE rule once the subnet aggregate clears its own
+        threshold with enough distinct contributing IPs (issue #84).
+
+        This must fail against a per-IP-only implementation: every
+        individual IP here carries only 2 challenged verdicts, one short of
+        min_challenged=3.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.models import BlockRule
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+        # 15 distinct IPs in 203.0.113.0/24, 2 challenges each = 30 total.
+        for i in range(15):
+            for _ in range(2):
+                RequestLogFactory(
+                    ip_address=f"203.0.113.{i}",
+                    verdict=Verdict.CHALLENGED,
+                    path="/page",
+                    referer="",
+                    timestamp=now,
+                )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            rules = detect_unsolved_challenges(window_minutes=60, min_challenged=3)
+
+        subnet_rules = [r for r in rules if r.rule_type == RuleType.CIDR]
+        assert len(subnet_rules) == 1
+        rule = subnet_rules[0]
+        assert rule.pattern == "203.0.113.0/24"
+        assert rule.action == RuleAction.CHALLENGE
+        assert rule.source == RuleSource.AUTO
+        assert BlockRule.objects.filter(pattern="203.0.113.0/24", is_active=True).exists()
+
+    @pytest.mark.django_db
+    def test_subnet_below_distinct_ip_floor_is_not_promoted(self):
+        """A single noisy IP cannot cross the subnet total-count threshold
+        alone: the distinct-IP floor guards against one host escalating its
+        whole /24.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+        # One IP alone racks up 40 challenges -- clears the 30-count floor
+        # but only 1 distinct IP, well under the 10-IP floor.
+        for _ in range(40):
+            RequestLogFactory(
+                ip_address="198.51.100.7",
+                verdict=Verdict.CHALLENGED,
+                path="/page",
+                referer="",
+                timestamp=now,
+            )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            rules = detect_unsolved_challenges(window_minutes=60, min_challenged=999)
+
+        subnet_rules = [r for r in rules if r.rule_type == RuleType.CIDR]
+        assert subnet_rules == []
+
+    @pytest.mark.django_db
+    def test_subnet_second_crossing_promotes_challenge_to_block(self):
+        """A repeat crossing of the same subnet promotes the existing active
+        auto CHALLENGE rule to BLOCK; a first crossing never blocks
+        outright (issue #82's false-positive discipline).
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+
+        def make_traffic():
+            for i in range(15):
+                for _ in range(2):
+                    RequestLogFactory(
+                        ip_address=f"203.0.114.{i}",
+                        verdict=Verdict.CHALLENGED,
+                        path="/page",
+                        referer="",
+                        timestamp=now,
+                    )
+
+        make_traffic()
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            first_pass = detect_unsolved_challenges(window_minutes=60, min_challenged=3)
+
+        first_subnet_rules = [r for r in first_pass if r.rule_type == RuleType.CIDR]
+        assert len(first_subnet_rules) == 1
+        assert first_subnet_rules[0].action == RuleAction.CHALLENGE
+
+        # A second crossing of the same subnet, with the CHALLENGE rule
+        # still active, must promote to BLOCK rather than re-issuing
+        # CHALLENGE or blocking on the very first crossing.
+        make_traffic()
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            second_pass = detect_unsolved_challenges(window_minutes=60, min_challenged=3)
+
+        second_subnet_rules = [r for r in second_pass if r.rule_type == RuleType.CIDR]
+        assert len(second_subnet_rules) == 1
+        assert second_subnet_rules[0].action == RuleAction.BLOCK
+        assert second_subnet_rules[0].pattern == "203.0.114.0/24"
+
+    @pytest.mark.django_db
+    def test_ip_solved_outside_recency_window_is_still_eligible(self):
+        """An IP whose only solved challenge falls outside the configured
+        recency window is not exempted (issue #84): this must fail against
+        the pre-#84 unbounded exemption, which grants immunity from a
+        single solve at any point in history.
+        """
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        ip = "10.0.0.20"
+        now = timezone.now()
+        for _ in range(4):
+            RequestLogFactory(
+                ip_address=ip,
+                verdict=Verdict.CHALLENGED,
+                path="/page",
+                referer="",
+                timestamp=now,
+            )
+        # Solved 48 hours ago -- well outside the default 24-hour
+        # DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS.
+        old_solve = now - timezone.timedelta(hours=48)
+        ChallengeTokenFactory(ip_address=ip, status=ChallengeStatus.SOLVED, solved_at=old_solve)
+
+        rules = detect_unsolved_challenges(window_minutes=10, min_challenged=3)
+
+        ip_rules = [r for r in rules if r.rule_type == RuleType.IP and r.pattern == ip]
+        assert len(ip_rules) == 1
+        assert ip_rules[0].action == RuleAction.BLOCK
+
+    @pytest.mark.django_db
+    def test_ip_solved_within_recency_window_is_still_exempted(self):
+        """The recency bound does not regress the existing exemption for a
+        genuinely recent solve.
+        """
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        ip = "10.0.0.21"
+        now = timezone.now()
+        for _ in range(4):
+            RequestLogFactory(
+                ip_address=ip,
+                verdict=Verdict.CHALLENGED,
+                path="/page",
+                referer="",
+                timestamp=now,
+            )
+        ChallengeTokenFactory(ip_address=ip, status=ChallengeStatus.SOLVED, solved_at=now)
+
+        rules = detect_unsolved_challenges(window_minutes=10, min_challenged=3)
+
+        ip_rules = [r for r in rules if r.rule_type == RuleType.IP and r.pattern == ip]
+        assert ip_rules == []
+
+    @pytest.mark.django_db
+    def test_dry_run_suppresses_subnet_writes(self):
+        """dry_run=True makes zero writes on the subnet path too (BR-ANOM-006)."""
+        import django_waf.conf as conf_mod
+        from django_waf.models import BlockRule
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+        for i in range(15):
+            for _ in range(2):
+                RequestLogFactory(
+                    ip_address=f"203.0.115.{i}",
+                    verdict=Verdict.CHALLENGED,
+                    path="/page",
+                    referer="",
+                    timestamp=now,
+                )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            rules = detect_unsolved_challenges(window_minutes=60, min_challenged=3, dry_run=True)
+
+        subnet_rules = [r for r in rules if r.rule_type == RuleType.CIDR]
+        assert len(subnet_rules) == 1
+        assert subnet_rules[0].action == RuleAction.CHALLENGE
+        assert not BlockRule.objects.filter(pattern="203.0.115.0/24").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #84. Supersedes the closed spec in icvoss/icv-oss-umbrella#511, which specified counting the wrong signal.

## The detector could not see the attack

`detect_unsolved_challenges` groups `RequestLog` by `ip_address` and filters on `min_challenged=3`. The observed attacker runs roughly **120 distinct addresses per /24**, so almost no individual address reaches three challenges inside the 60 minute window. Traced on the live deployment:

```
IPs with >=3 challenges in 60m:            6
  ...exempted by any past solve:           3
  ...surviving to referer check:           3
  ...passing referer_ratio >= 0.8:         3
```

Six candidates, half of them exempted, against a cohort abandoning **3,232 challenges from 120 distinct IPs in a single /24**. The detector was starved before any of its known weaknesses applied.

## The signal is abandonment, not failure

Seven days of challenge outcomes on that deployment:

```
  pending      15667   (91%, issued and never attempted)
  solved        1616
  failed            0
```

**Zero failed challenges.** #85, which assumed bots fail the proof of work and exploit the free retry, is closed as not planned: a failure counter would never increment. These clients take the challenge page and leave.

## Four changes

**1. Subnet aggregation, weighted by distinct IPs.** A parallel grouping via the existing `_get_subnet_prefix` (/24 IPv4, /48 IPv6), gated on both a total challenged count and a minimum number of distinct contributing addresses, so one noisy host cannot escalate its neighbours. The per-IP path is untouched.

**2. The solve exemption is time bounded.** It previously queried every solved token ever recorded for an address, so one solve granted permanent immunity. In the trace above that removed half the candidates, and this cohort does solve occasionally (1,616 times), so a rotating pool could keep clearing its own exemption indefinitely.

**3. Two-stage subnet promotion.** A first crossing creates a CIDR rule with `action=challenge`; only a repeat crossing promotes to `block`. Detected by a read-only check for an existing active auto CHALLENGE rule on the same CIDR, run identically under dry-run so only the write is suppressed. Both stages route through `_get_or_create_auto_rule`, so the CONFIRMED/REJECTED review guard applies, and CHALLENGE and BLOCK are distinct lookup keys so promoting never overwrites an operator's decision on the challenge row.

**4. Thresholds become settings.** `min_challenged` and `referer_ratio` were function-parameter defaults, untunable without calling the detector directly. Now `DJANGO_WAF_*` settings alongside the new subnet ones, with the function parameters retained as overrides so existing callers and the dry-run command keep working.

## Defaults, and why

| Setting | Default | Justification |
|---|---|---|
| `DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED` | 30 | 10 IPs times the per-IP floor of 3, so it is calibrated against the threshold it complements, and well below the observed 600+ per subnet so a materially smaller pool is still caught |
| `DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS` | 10 | Well below the observed 100+, but high enough that a single host or a small NAT cluster cannot promote a /24 |
| `DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS` | 24 | Longer than the detector's own 60 minute window, so a genuinely recent solve still exempts for a full day, without treating an ancient solve as current proof of good behaviour |
| `DJANGO_WAF_UNSOLVED_MIN_CHALLENGED` | 3 | Unchanged from the prior function default |
| `DJANGO_WAF_UNSOLVED_REFERER_RATIO` | 0.8 | Unchanged from the prior function default |

## False positive discipline

#82 measured that blocking on a coarse signal would have caught **at least 35.6% real users** on this same deployment, including genuine Bingbot (145,346 rows across 270 IPs) and Applebot. Abandonment has legitimate causes: a real user who closes the tab or blocks JavaScript abandons a challenge exactly as a bot does. The distinct-IP weighting and the challenge-before-block staging are what make subnet-grain action defensible, and a subnet never goes straight to BLOCK.

The empty-referer requirement is deliberately unchanged: the trace showed it rejected nobody among survivors, so it is not the bottleneck. It is not applied to the subnet path, since there is no single subnet referer to test.

## Verification

| Gate | Result |
|---|---|
| `ruff check` / `ruff format --check` | pass, 138 files |
| `pytest --cov=src` | **1157 passed, 5 skipped, 93.10%** (gate 90%) |
| Redis integration vs real 6.0-alpine | 5 passed |
| `mypy src/` | **35 errors, identical to the 2.0.0 baseline. Zero new** |

Seven new tests. **Three were confirmed falsifiable** by reverting the condition, observing the failure, and restoring with a clean diff:

1. Subnet promotion with no individual IP qualifying: reverted to per-IP-only, failed `assert 0 == 1`, no CIDR rule created.
2. Distinct-IP floor: dropped the guard, failed with one noisy host wrongly promoting its whole /24.
3. Bounded solve exemption: dropped the time filter, failed with an IP that solved 48 hours ago wrongly exempted forever.

Dry-run confirmed to suppress every write on both paths (BR-ANOM-006). `rule_engine.py` is untouched, so BR-EVAL-007 fail-open is unaffected.

## One thing found and not fixed here

Two pre-existing tests needed an explicit `solved_at`, because `ChallengeTokenFactory` hardcodes `solved_at = None` even when the caller passes `status=SOLVED`, which production never does (`challenge_service.py:259` always sets it). Their assertions are byte-for-byte unchanged.

The factory defect is filed as **#86** rather than fixed here: it is shared fixture infrastructure shipped as package API, five other call sites carry the same latent unrealism, and consumers inherit it. It is the same shape as the `fakeredis` divergence in #78, a test double that cannot produce the states production produces.

## Spec updates needed before release

`02-business-rules.md` BR-ANOM section needs the subnet aggregation, the bounded exemption and the two-stage promotion; `03-services.md` section 7 needs the subnet path and a confidence-formula row. Separate repo, so a separate PR.