### PR TITLE
fix: derive ChallengeTokenFactory.solved_at from status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `detect_unsolved_challenges` and default to the new settings, so
   existing callers and the dry-run management command are unaffected.
 
+### Fixed
+
+- **`ChallengeTokenFactory` could produce a solved token with no solve
+  timestamp, a state production never writes.** `challenge_service.py`
+  unconditionally sets `solved_at` on the solve path, so every genuinely
+  solved token has one, but the factory hardcoded `solved_at = None`
+  regardless of the `status` passed in (#86). A consuming project's own
+  tests that build a solved `ChallengeToken` via `ChallengeTokenFactory`
+  will now get a realistic `solved_at` timestamp derived from `status`
+  without having to pass one explicitly. A consumer test that (incorrectly)
+  relied on a solved token's `solved_at` being `None` will start failing,
+  which is the point: fix the assertion to match what production actually
+  writes, or pass `solved_at=None` explicitly if the inconsistent object is
+  genuinely what the test needs, which still overrides the derived value.
+  `PENDING`, `EXPIRED`, and `FAILED` were already correct (`solved_at`
+  stays `None` on every path but the solve path) and are unchanged. Two
+  tests in `tests/test_services.py` (added by #87) pass an explicit
+  `solved_at=now` that duplicates what the factory now derives on its own;
+  left as-is rather than churned, since they are otherwise unaffected by
+  this fix.
+
 ## [2.0.0] - 2026-08-28
 
 ### Security

--- a/src/django_waf/testing/factories.py
+++ b/src/django_waf/testing/factories.py
@@ -133,7 +133,18 @@ class ChallengeTokenFactory(factory.django.DjangoModelFactory):
     nonce = ""
     status = ChallengeStatus.PENDING
     expires_at = factory.LazyFunction(lambda: timezone.now() + timezone.timedelta(hours=24))
-    solved_at = None
+    # challenge_service.verify_challenge_solution() unconditionally sets
+    # solved_at on the solve path (BR-CHAL, see challenge_service.py), so a
+    # production-shaped SOLVED token always carries a timestamp. EXPIRED and
+    # FAILED never touch solved_at (update_fields=["status"] only), so None
+    # stays correct for every other status. A caller who passes solved_at
+    # explicitly, including an explicit None, still wins: that is a normal
+    # keyword override and takes precedence over this class-level default.
+    solved_at = factory.Maybe(
+        factory.LazyAttribute(lambda o: o.status == ChallengeStatus.SOLVED),
+        yes_declaration=factory.LazyFunction(timezone.now),
+        no_declaration=None,
+    )
 
     class Meta:
         model = "django_waf.ChallengeToken"

--- a/tests/test_testing_fixtures.py
+++ b/tests/test_testing_fixtures.py
@@ -8,6 +8,7 @@ tests here double as usage examples.
 from __future__ import annotations
 
 import pytest
+from django.utils import timezone
 
 from django_waf.testing.fixtures import (  # noqa: F401 — re-exported as pytest fixtures
     allow_rule,
@@ -61,6 +62,84 @@ class TestModelFixtures:
 
         assert isinstance(challenge_token, ChallengeToken)
         assert ChallengeToken.objects.filter(pk=challenge_token.pk).exists()
+
+
+# ---------------------------------------------------------------------------
+# ChallengeTokenFactory status/solved_at derivation
+# ---------------------------------------------------------------------------
+
+
+class TestChallengeTokenFactoryStatusInvariants:
+    """ChallengeTokenFactory must not produce a state production cannot (#86).
+
+    challenge_service.verify_challenge_solution() unconditionally sets
+    solved_at when it marks a token SOLVED, so a factory-built SOLVED token
+    with solved_at=None is a state that never exists in a real database.
+    """
+
+    @pytest.mark.django_db
+    def test_solved_status_derives_a_solved_at_timestamp(self):
+        from django_waf.enums import ChallengeStatus
+        from django_waf.testing.factories import ChallengeTokenFactory
+
+        token = ChallengeTokenFactory(status=ChallengeStatus.SOLVED)
+
+        assert token.solved_at is not None
+
+    @pytest.mark.django_db
+    def test_explicit_solved_at_overrides_the_derived_value(self):
+        from django_waf.enums import ChallengeStatus
+        from django_waf.testing.factories import ChallengeTokenFactory
+
+        explicit = timezone.now() - timezone.timedelta(hours=48)
+        token = ChallengeTokenFactory(status=ChallengeStatus.SOLVED, solved_at=explicit)
+
+        assert token.solved_at == explicit
+
+    @pytest.mark.django_db
+    def test_explicit_none_solved_at_is_respected_even_when_solved(self):
+        """A caller may deliberately want an inconsistent object; explicit
+        None must still win over the derived default.
+        """
+        from django_waf.enums import ChallengeStatus
+        from django_waf.testing.factories import ChallengeTokenFactory
+
+        token = ChallengeTokenFactory(status=ChallengeStatus.SOLVED, solved_at=None)
+
+        assert token.solved_at is None
+
+    @pytest.mark.django_db
+    def test_pending_status_leaves_solved_at_none(self):
+        from django_waf.enums import ChallengeStatus
+        from django_waf.testing.factories import ChallengeTokenFactory
+
+        token = ChallengeTokenFactory(status=ChallengeStatus.PENDING)
+
+        assert token.solved_at is None
+
+    @pytest.mark.django_db
+    def test_expired_status_leaves_solved_at_none(self):
+        """EXPIRED only ever sets status (update_fields=["status"]); solved_at
+        is never touched on that path (challenge_service.py).
+        """
+        from django_waf.enums import ChallengeStatus
+        from django_waf.testing.factories import ChallengeTokenFactory
+
+        token = ChallengeTokenFactory(status=ChallengeStatus.EXPIRED)
+
+        assert token.solved_at is None
+
+    @pytest.mark.django_db
+    def test_failed_status_leaves_solved_at_none(self):
+        """FAILED only ever sets status (update_fields=["status"]); solved_at
+        is never touched on that path (challenge_service.py).
+        """
+        from django_waf.enums import ChallengeStatus
+        from django_waf.testing.factories import ChallengeTokenFactory
+
+        token = ChallengeTokenFactory(status=ChallengeStatus.FAILED)
+
+        assert token.solved_at is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #86.

## Summary

`ChallengeTokenFactory` hardcoded `solved_at = None` regardless of `status`, so a caller passing `status=ChallengeStatus.SOLVED` got a token that is solved but carries no solve timestamp, a state production cannot produce (`challenge_service.verify_challenge_solution` unconditionally sets `solved_at` on the solve path).

`solved_at` is now `factory.Maybe`, keyed on `status == SOLVED`:

- `status=SOLVED` and no explicit `solved_at`: derives `timezone.now()`.
- Any other status: stays `None`, matching production (`PENDING`/`EXPIRED`/`FAILED` never touch `solved_at`; the EXPIRED and FAILED paths save with `update_fields=["status"]` only).
- An explicit `solved_at` kwarg, including an explicit `None`, still wins: it is a normal factory_boy keyword override and bypasses the class-level declaration entirely.

## Other statuses and factories checked

Per the issue, checked every other `ChallengeStatus` value and the other four factories in the file for the same class of defect (a hardcoded default that production would never leave in that state for the status/type being built):

- `PENDING`, `EXPIRED`, `FAILED`: confirmed correct, no change needed. `challenge_service.py` never writes `solved_at` on those paths.
- `BlockRuleFactory`, `AllowRuleFactory`, `RequestLogFactory`, `IPReputationFactory`: each factory's default field combination is internally consistent with what production writes for that default (e.g. `source=ADMIN` correctly pairs with empty `feed_first_seen`/`feed_reporters`, since only the threat-feed path populates those). No change made.
- One ambiguous case flagged, not fixed: `BlockRule.review_status_on_create` is `PENDING` when an auto-generated rule is created with `is_active=False` (quarantined), but the factory's default `is_active=True` pairs with `review_status=NOT_APPLICABLE`. A caller overriding only `is_active=False` without also setting `review_status` would get a combination production never writes for an auto-generated rule. This only applies when `source=AUTO`, since admin/feed rules stay `NOT_APPLICABLE` regardless of `is_active`, so it is not a clean same-shape fix and I left it for a follow-up rather than guessing.

## Tests

Added `TestChallengeTokenFactoryStatusInvariants` to `tests/test_testing_fixtures.py` (where the other factory/fixture tests live), covering: SOLVED derives a timestamp, an explicit `solved_at` overrides the derived value, an explicit `None` is respected even when SOLVED, and PENDING/EXPIRED/FAILED all stay `None`.

## Interaction with #87

#87 merged into `main` before this branch and added an explicit `solved_at=now` workaround to two pre-existing tests in `tests/test_services.py` for exactly this defect. Left those two as-is per scope (they are now redundant but harmless, not wrong) and noted the redundancy in the changelog rather than touching that file. Two other tests #87 added pass a deliberately different `solved_at` (`old_solve`, 48 hours ago) to test the new time-bounded solve exemption; those are functional, not workaround, and are untouched.

## Verification

- `ruff check` / `ruff format --check` pass on all changed files.
- `mypy src/django_waf/testing/factories.py`: no new errors introduced (one pre-existing baseline error on an unrelated line, unchanged by this diff).
- Tests not run per the implementer/tester split; the tester agent will run the full gate suite.