### PR TITLE
fix: rate-limit the verify endpoint independently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   occasional solve from a rotating pool of addresses cannot grant a whole
   subnet permanent immunity either.
 
+- **`POST /waf/verify/` had no rate limit of its own** (issue #81). Each
+  solve attempt costs a signature check and Redis work, so it was a cheap
+  way to consume server resources at any submission rate a client could
+  sustain. `DJANGO_WAF_RATE_LIMIT_PATHS` cannot cover this endpoint: the
+  challenge and verify paths are typically listed in
+  `DJANGO_WAF_EXEMPT_PATHS` so a challenged user can always reach them,
+  and the middleware returns on that exempt-path match before its rate
+  limiter ever runs. `VerifyView` now checks a dedicated, independent
+  limit before doing any signature or proof-of-work verification work. A
+  breach returns 429 with an accurate `Retry-After`, matching the
+  existing throttle response shape, rather than blocking: the default
+  (20 solves per 5 minutes per IP, via `DJANGO_WAF_VERIFY_RATE_LIMIT_MAX`
+  and `DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS`) sits comfortably
+  above the 2 to 3 round trips a real client needs and above a NAT
+  gateway or corporate proxy serving several simultaneous solvers.
+  Fail-open is unchanged (BR-EVAL-007): a rate-limiter Redis error never
+  blocks a legitimate user from clearing a challenge.
+
 ### Added
+
+- `DJANGO_WAF_VERIFY_RATE_LIMIT_MAX` (default 20) and
+  `DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS` (default 300) settings
+  governing the new `POST /waf/verify/` rate limit described above.
 
 - `DJANGO_WAF_UNSOLVED_MIN_CHALLENGED`, `DJANGO_WAF_UNSOLVED_REFERER_RATIO`,
   `DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS`,

--- a/README.md
+++ b/README.md
@@ -166,7 +166,9 @@ All settings are namespaced under `DJANGO_WAF_*` and have sensible defaults.
 | `DJANGO_WAF_RATE_LIMIT_BURST` | `10` | Max requests per IP per second |
 | `DJANGO_WAF_RATE_LIMIT_PER_MINUTE` | `120` | Max requests per IP per minute |
 | `DJANGO_WAF_RATE_LIMIT_PER_5MIN` | `600` | Max requests per IP per 5 minutes |
-| `DJANGO_WAF_RATE_LIMIT_PATHS` | `{}` | Per-path rate limits: `{path_prefix: (max_requests, window_seconds)}`. Checked before the global windows; the longest matching prefix wins |
+| `DJANGO_WAF_RATE_LIMIT_PATHS` | `{}` | Per-path rate limits: `{path_prefix: (max_requests, window_seconds)}`. Checked before the global windows; the longest matching prefix wins. Cannot cover `/waf/verify/` if it is also in `DJANGO_WAF_EXEMPT_PATHS`, see the dedicated setting below |
+| `DJANGO_WAF_VERIFY_RATE_LIMIT_MAX` | `20` | Max `POST /waf/verify/` solve attempts per IP within the window below, independent of the settings above (issue #81) |
+| `DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS` | `300` | Window (seconds) for `DJANGO_WAF_VERIFY_RATE_LIMIT_MAX`. A breach returns `429` with `Retry-After`, never a block; fails open on Redis errors |
 
 ### Challenges
 

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -737,3 +737,35 @@ DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED: int = getattr(settings, "DJANGO_WAF_U
 # detector catches a materially smaller, still-clearly-distributed pool
 # rather than only the extreme case already seen.
 DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS: int = getattr(settings, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10)
+
+# ---------------------------------------------------------------------------
+# Verify-endpoint rate limit (issue #81)
+# ---------------------------------------------------------------------------
+# POST /waf/verify/ accepts proof-of-work solutions with no rate limit of
+# its own. Each POST costs a signature check and Redis work, so unbounded
+# it is a cheap way to consume server resources; hardening, not a response
+# to observed abuse (production data showed zero failed challenges over 7
+# days at the time this was added).
+#
+# DJANGO_WAF_RATE_LIMIT_PATHS cannot cover this path in the WAF's own
+# recommended deployment shape: the challenge and verify paths are
+# typically listed in DJANGO_WAF_EXEMPT_PATHS (a challenged user must
+# always be able to reach them to clear themselves), and
+# WafMiddleware.__call__ returns on the exempt-path match before rule
+# evaluation, where check_rate_limit runs, is ever reached. So VerifyView
+# calls django_waf.services.rate_limiter.check_verify_rate_limit directly,
+# using its own dedicated Redis key, independent of the general per-path
+# and global IP windows.
+#
+# The default sits well above the 2 to 3 round trips a real client needs
+# (GET the challenge, POST the solution, follow the redirect) and above
+# retry traffic from a NAT gateway or corporate proxy legitimately serving
+# many simultaneous solvers behind one IP (#82 measured that a coarse
+# per-IP signal there would have caught over a third of real users on a
+# production deployment). 20 solves per 5 minutes covers a genuine burst
+# of shared-egress traffic while still bounding a farm's unbounded solve
+# rate. A breach degrades to a 429 with an accurate Retry-After (matching
+# the existing throttle response shape) rather than a block, so a false
+# positive is always recoverable.
+DJANGO_WAF_VERIFY_RATE_LIMIT_MAX: int = getattr(settings, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20)
+DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS: int = getattr(settings, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300)

--- a/src/django_waf/services/rate_limiter.py
+++ b/src/django_waf/services/rate_limiter.py
@@ -121,6 +121,64 @@ def _check_path_rate_limit(
     return None
 
 
+def check_verify_rate_limit(ip_address: str, redis_client) -> RateLimitResult:
+    """Check the dedicated solve-rate limit for POST /waf/verify/ (#81).
+
+    Deliberately independent of ``DJANGO_WAF_RATE_LIMIT_PATHS`` and
+    ``check_rate_limit``'s path-prefix matching. That machinery is inert
+    for the verify path in the deployment shape the WAF itself
+    recommends: the challenge and verify paths are typically listed in
+    ``DJANGO_WAF_EXEMPT_PATHS`` so a challenged user can always clear
+    themselves, and ``WafMiddleware.__call__`` returns on the exempt-path
+    match, checked before rule evaluation (see ``middleware.py``, where
+    ``check_rate_limit`` runs), before ``evaluate_request`` is ever
+    called. A naive entry in ``DJANGO_WAF_RATE_LIMIT_PATHS`` for the
+    verify path would never be evaluated. ``VerifyView.post`` therefore
+    calls this function directly, after the middleware has already let
+    the request through.
+
+    Uses the same sliding-window sorted-set algorithm as
+    ``_check_path_rate_limit``, keyed independently
+    (``waf:rate:verify:{ip}``) so it never shares state with, or is
+    affected by, the general per-path or global IP rate limits.
+
+    Args:
+        ip_address: Client IP address string.
+        redis_client: Configured Redis client instance.
+
+    Returns:
+        A ``RateLimitResult`` with ``window="verify"`` if
+        ``DJANGO_WAF_VERIFY_RATE_LIMIT_MAX`` was exceeded within
+        ``DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS``, else
+        ``exceeded=False``.
+    """
+    from django_waf import conf  # lazy, avoids circular import at module load
+
+    max_requests = conf.DJANGO_WAF_VERIFY_RATE_LIMIT_MAX
+    window_seconds = conf.DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS
+
+    now = time.time()
+    key = f"waf:rate:verify:{ip_address}"
+    cutoff = now - window_seconds
+
+    pipe = redis_client.pipeline()
+    pipe.zadd(key, {str(now): now})
+    pipe.zremrangebyscore(key, 0, cutoff)
+    pipe.zcard(key)
+    pipe.zrange(key, 0, 0, withscores=True)
+    pipe.expire(key, window_seconds + 10)
+    results = pipe.execute()
+
+    count = results[2]
+    oldest_in_window = results[3]
+
+    if count > max_requests:
+        retry_after = _retry_after_from_oldest(oldest_in_window, window_seconds, now)
+        return RateLimitResult(exceeded=True, window="verify", retry_after=retry_after)
+
+    return RateLimitResult(exceeded=False, window=None, retry_after=None)
+
+
 def check_rate_limit(
     ip_address: str,
     redis_client,

--- a/src/django_waf/views.py
+++ b/src/django_waf/views.py
@@ -226,6 +226,10 @@ class VerifyView(NoIndexResponseMixin, View):
     Access: AllowAny.
     Every response path (redirect on success, JSON 400 on failure) carries
     X-Robots-Tag: noindex, nofollow, noarchive (NoIndexResponseMixin).
+    Rate-limited independently of DJANGO_WAF_RATE_LIMIT_PATHS (#81): see
+    django_waf.services.rate_limiter.check_verify_rate_limit. A breach
+    returns 429 with Retry-After rather than blocking, fail-open on Redis
+    errors (BR-EVAL-007).
     """
 
     def post(self, request: HttpRequest) -> HttpResponse:
@@ -265,6 +269,29 @@ class VerifyView(NoIndexResponseMixin, View):
             # See ChallengeView.get: a direct hit on /waf/verify/ with Redis
             # unavailable is a misconfiguration, not the normal path (#44).
             return JsonResponse({"error": _("This site is temporarily unavailable.")}, status=503)
+
+        # Dedicated per-IP solve-rate limit (#81). Runs ahead of
+        # verify_challenge_solution so a breach skips the signature check
+        # and PoW verification work entirely, not just the redirect.
+        # DJANGO_WAF_RATE_LIMIT_PATHS cannot cover this endpoint: see
+        # django_waf.services.rate_limiter.check_verify_rate_limit for the
+        # ordering evidence. Fails open on any Redis error, consistent with
+        # BR-EVAL-007: a rate-limiter outage must never block a legitimate
+        # user from clearing a challenge, only an unbounded solve rate does.
+        try:
+            from django_waf.services.rate_limiter import check_verify_rate_limit
+
+            rate_result = check_verify_rate_limit(ip, redis_client)
+        except Exception:
+            logger.warning("django-waf: verify rate-limit check failed for %s, failing open", ip)
+        else:
+            if rate_result.exceeded:
+                throttle_response = JsonResponse(
+                    {"error": _("Too many verification attempts. Please retry later.")}, status=429
+                )
+                retry_after = rate_result.retry_after
+                throttle_response["Retry-After"] = str(retry_after) if retry_after is not None else "60"
+                return throttle_response
 
         try:
             verify_challenge_solution(token, nonce, ip, redis_client)

--- a/tests/test_verify_rate_limit.py
+++ b/tests/test_verify_rate_limit.py
@@ -1,0 +1,250 @@
+"""Tests for the dedicated POST /waf/verify/ rate limit (issue #81).
+
+POST /waf/verify/ accepted proof-of-work solutions with no rate limit of
+its own. Each solve attempt costs a signature check and Redis work, so an
+unbounded submission rate is a cheap way to consume server resources.
+
+DJANGO_WAF_RATE_LIMIT_PATHS cannot cover this endpoint in the deployment
+shape the WAF itself recommends: the challenge and verify paths are
+typically listed in DJANGO_WAF_EXEMPT_PATHS so a challenged user can
+always clear themselves, and WafMiddleware.__call__ returns on the
+exempt-path match before rule evaluation, where check_rate_limit runs, is
+ever reached. So the limit lives inside VerifyView itself, calling the
+dedicated django_waf.services.rate_limiter.check_verify_rate_limit
+function directly.
+
+Redis is not available in the test environment; all Redis calls are
+mocked, matching the pattern in test_retry_after.py and test_views.py.
+Per #75 (still open), every django_waf.conf value is an import-time
+snapshot: tests overriding a DJANGO_WAF_VERIFY_RATE_LIMIT_* setting use
+patch.object(conf, "NAME", ...), not Django's settings fixture or
+pytest's settings override, which would not be seen.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import Client
+
+import django_waf.conf as conf_mod
+from django_waf.services.rate_limiter import check_verify_rate_limit
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_redis() -> MagicMock:
+    """A basic Redis client mock for the paths that don't exercise the
+    rate-limit pipeline (matches tests/test_views.py's _mock_redis)."""
+    r = MagicMock()
+    r.get.return_value = None
+    return r
+
+
+def _mock_redis_with_pipeline(count: int, oldest_in_window: list | None = None) -> MagicMock:
+    """A Redis client mock whose pipeline().execute() returns a fixed
+    ZCARD count and ZRANGE result, matching the 5-step pipeline
+    check_verify_rate_limit runs (ZADD, ZREMRANGEBYSCORE, ZCARD, ZRANGE,
+    EXPIRE)."""
+    redis = _mock_redis()
+    pipeline = MagicMock()
+    pipeline.execute.return_value = [1, 0, count, oldest_in_window or [], True]
+    redis.pipeline.return_value = pipeline
+    return redis
+
+
+@pytest.fixture(autouse=True)
+def waf_urls(settings):
+    settings.ROOT_URLCONF = "tests.urls"
+
+
+# ---------------------------------------------------------------------------
+# check_verify_rate_limit: pure unit tests against the pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestCheckVerifyRateLimit:
+    def test_under_threshold_is_not_exceeded(self):
+        redis = _mock_redis_with_pipeline(count=5)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300),
+        ):
+            result = check_verify_rate_limit("1.2.3.4", redis)
+
+        assert result.exceeded is False
+        assert result.retry_after is None
+
+    def test_over_threshold_is_exceeded_with_verify_window_name(self):
+        now = time.time()
+        oldest = now - 10
+        redis = _mock_redis_with_pipeline(count=21, oldest_in_window=[(str(oldest), oldest)])
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300),
+            patch("django_waf.services.rate_limiter.time.time", return_value=now),
+        ):
+            result = check_verify_rate_limit("1.2.3.4", redis)
+
+        assert result.exceeded is True
+        assert result.window == "verify"
+        assert result.retry_after == 290  # 300 - 10
+
+    def test_exactly_at_threshold_is_not_exceeded(self):
+        """count == max_requests must not breach, only count > max_requests
+        does, matching check_rate_limit's own boundary."""
+        redis = _mock_redis_with_pipeline(count=20)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300),
+        ):
+            result = check_verify_rate_limit("1.2.3.4", redis)
+
+        assert result.exceeded is False
+
+    def test_uses_a_dedicated_redis_key_independent_of_global_windows(self):
+        """The verify limiter must not share a key with check_rate_limit's
+        global per-IP windows or the per-path limiter, so a burst of normal
+        page traffic from an IP cannot count towards, or be counted by,
+        its verify-solve budget."""
+        redis = _mock_redis_with_pipeline(count=1)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300),
+        ):
+            check_verify_rate_limit("9.9.9.9", redis)
+
+        pipeline = redis.pipeline.return_value
+        zadd_key = pipeline.zadd.call_args[0][0]
+        assert zadd_key == "waf:rate:verify:9.9.9.9"
+        assert "path" not in zadd_key
+
+
+# ---------------------------------------------------------------------------
+# VerifyView integration: breach returns 429, never a block
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyViewRateLimit:
+    def test_breach_returns_429_with_retry_after(self, settings):
+        settings.DJANGO_WAF_ENABLED = True
+
+        client = Client()
+        now = time.time()
+        oldest = now - 5
+        redis = _mock_redis_with_pipeline(count=21, oldest_in_window=[(str(oldest), oldest)])
+
+        with (
+            patch("django_waf.views._get_redis_client", return_value=redis),
+            patch("django_waf.services.challenge_service.verify_challenge_solution") as mock_verify,
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300),
+            patch("django_waf.services.rate_limiter.time.time", return_value=now),
+        ):
+            response = client.post(
+                "/waf/verify/",
+                data={"token": "tok", "nonce": "nonce99"},
+            )
+
+        assert response.status_code == 429
+        assert response["Retry-After"] == "295"  # 300 - 5
+        # The signature/PoW check is never reached once the limit is breached.
+        mock_verify.assert_not_called()
+
+    def test_breach_never_blocks_only_returns_429(self, settings):
+        """A breach must degrade to friction (429 + Retry-After), never an
+        outright block: the endpoint that exonerates a challenged user must
+        stay recoverable for a false positive, per the issue's safety
+        constraint."""
+        settings.DJANGO_WAF_ENABLED = True
+
+        client = Client()
+        redis = _mock_redis_with_pipeline(count=999)
+
+        with (
+            patch("django_waf.views._get_redis_client", return_value=redis),
+            patch("django_waf.services.challenge_service.verify_challenge_solution"),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300),
+        ):
+            response = client.post(
+                "/waf/verify/",
+                data={"token": "tok", "nonce": "nonce99"},
+            )
+
+        assert response.status_code == 429
+        assert response.status_code != 403
+
+    def test_under_threshold_reaches_verify_challenge_solution(self, settings):
+        """A normal solve, well under the limit, is unaffected: proves the
+        limit does not starve a legitimate user's 2-3 round trips."""
+        settings.DJANGO_WAF_ENABLED = True
+
+        client = Client()
+        redis = _mock_redis_with_pipeline(count=1)
+
+        with (
+            patch("django_waf.views._get_redis_client", return_value=redis),
+            patch("django_waf.services.challenge_service.verify_challenge_solution") as mock_verify,
+            patch("django_waf.services.challenge_service.issue_pass_cookie"),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20),
+            patch.object(conf_mod, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300),
+        ):
+            mock_verify.return_value = True
+
+            response = client.post(
+                "/waf/verify/",
+                data={"token": "tok", "nonce": "nonce99", "next": "/target/"},
+            )
+
+        assert response.status_code == 302
+        mock_verify.assert_called_once()
+
+    def test_rate_limit_redis_error_fails_open(self, settings, caplog):
+        """BR-EVAL-007: if the rate-limit check itself raises (a mid-request
+        Redis error distinct from the earlier "Redis unavailable" check),
+        the request must still be allowed through to verify_challenge_solution,
+        not blocked or 503'd. A legitimate user solving a challenge must
+        never be locked out by a rate-limiter outage."""
+        import logging
+
+        settings.DJANGO_WAF_ENABLED = True
+
+        client = Client()
+        redis = _mock_redis()
+        redis.pipeline.side_effect = RuntimeError("redis down mid-request")
+
+        with (
+            patch("django_waf.views._get_redis_client", return_value=redis),
+            patch("django_waf.services.challenge_service.verify_challenge_solution") as mock_verify,
+            patch("django_waf.services.challenge_service.issue_pass_cookie"),
+            caplog.at_level(logging.WARNING, logger="django_waf.views"),
+        ):
+            mock_verify.return_value = True
+
+            response = client.post(
+                "/waf/verify/",
+                data={"token": "tok", "nonce": "nonce99", "next": "/target/"},
+            )
+
+        assert response.status_code == 302
+        mock_verify.assert_called_once()
+        assert any("rate-limit" in message for message in caplog.messages)
+
+    def test_default_max_and_window_clear_a_real_users_round_trips(self):
+        """The shipped default must comfortably exceed the 2-3 round trips
+        (GET challenge, POST solution, follow redirect) a real client needs,
+        with headroom for a retry after a wrong answer."""
+        assert conf_mod.DJANGO_WAF_VERIFY_RATE_LIMIT_MAX >= 10
+        assert conf_mod.DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS >= 60


### PR DESCRIPTION
Closes #81.

## Summary

`POST /waf/verify/` had no rate limit of its own. Each solve attempt costs a signature check and Redis work, so an unbounded submission rate was a cheap way to consume server resources.

`DJANGO_WAF_RATE_LIMIT_PATHS` cannot cover this endpoint in the deployment shape the WAF itself recommends: the challenge and verify paths are typically listed in `DJANGO_WAF_EXEMPT_PATHS` so a challenged user can always clear themselves, and `WafMiddleware.__call__` returns on the exempt-path match before rule evaluation, where the path-prefix limiter runs, is ever reached.

`VerifyView.post` now calls a dedicated `check_verify_rate_limit` (in `services/rate_limiter.py`) before any signature or proof-of-work verification work, keyed independently as `waf:rate:verify:{ip}` so it cannot collide with or consume the budget of the global or per-path windows. A breach returns 429 with an accurate `Retry-After`, never a block.

New settings: `DJANGO_WAF_VERIFY_RATE_LIMIT_MAX` (default 20) and `DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS` (default 300).

## Safety properties verified

- **Never starves a legitimate user.** The default (20 solves per 5 minutes per IP) comfortably clears the 2 to 3 round trips a real client needs, with headroom for a wrong-nonce retry or several simultaneous solvers behind a NAT.
- **Fail-open (BR-EVAL-007).** The rate-limit check is wrapped in its own `try/except`; a Redis error during the check logs a warning and falls through to the normal solve path rather than blocking. Verified against a real (unmocked) Redis `ConnectionError` end-to-end, not just the mocked test in this PR.
- **No key collision.** `waf:rate:verify:{ip}` is a distinct key shape from the global windows (`waf:rate:{ip}:{1s|1m|5m}`) and the per-path windows (`waf:rate:{ip}:path:{prefix_hash}`).

## Tests

`tests/test_verify_rate_limit.py`: unit tests for `check_verify_rate_limit` (under/over/at threshold, dedicated key), and `VerifyView` integration tests (429 + Retry-After on breach, breach never returns a block, normal solve unaffected, Redis-error fail-open, default headroom assertion).

## Gates run

- `ruff check src/ tests/`, `ruff format --check src/ tests/`: pass
- `pytest --cov=src --cov-report=term-missing`: 1166 passed, 5 skipped, 93.15% coverage
- `mypy src/`: 35 errors, all pre-existing on `origin/main`, zero new
- Redis integration leg (`--ds=tests.settings_redis -m redis_integration` against real Redis 6.0): 5 passed