### PR TITLE
fix: E004 respects DJANGO_WAF_ENABLED (#67)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`django_waf.E004` no longer fires when the WAF is switched off (#67).**
+  The check errored whenever `DJANGO_WAF_REDIS_ALIAS` was not a django-redis
+  backend, regardless of `DJANGO_WAF_ENABLED`, so any settings profile that
+  disables the WAF and uses a plain cache (a test or CI profile on
+  LocMemCache, typically) could not run `manage.py check` at all: the Error
+  aborts the command. A project that has switched the feature off is not
+  misconfigured for it. `django_waf.E005` already guarded this way, and its
+  own test cited #67 as the mistake not to repeat, but E004 itself had no
+  test of any kind, which is why the defect survived. It now has three,
+  including one that fails without the guard.
+
 ### Security
 
 - **`detect_subnet_burst`'s threshold was raised by the very botnet it

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -45,7 +45,8 @@ The trust-level check (``django_waf.W006``) warns when
 unrecognised value to ``"staff"``), so this is a Warning about an
 ineffective setting, not an Error about a lockout.
 
-The Redis backend check (``django_waf.E004``) errors when
+The Redis backend check (``django_waf.E004``) is silent when the WAF is
+disabled (``DJANGO_WAF_ENABLED = False``, #67), and otherwise errors when
 ``DJANGO_WAF_REDIS_ALIAS`` is not configured as a ``django-redis`` cache
 backend (#44). Rule evaluation, rate limiting, and challenge state have no
 safe equivalent on a generic Django cache backend (rate limiting alone uses
@@ -369,7 +370,7 @@ def check_trusted_cookie_trust_level(app_configs, **kwargs):
 @register()
 def check_redis_backend(app_configs, **kwargs):
     """Error (``django_waf.E004``) when ``DJANGO_WAF_REDIS_ALIAS`` is not a
-    django-redis cache backend (#44).
+    django-redis cache backend (#44), unless the WAF is disabled (#67).
 
     Only inspects ``settings.CACHES``, never opens a connection: this check
     must be cheap and side-effect-free like every other check in this
@@ -380,6 +381,16 @@ def check_redis_backend(app_configs, **kwargs):
     """
     from django_waf import conf
     from django_waf.services.redis_client import is_redis_backend
+
+    # Cheapest guard first, and the one #67 was filed for: a project that
+    # has switched the WAF off entirely is not misconfigured for having a
+    # non-Redis cache, it simply is not using the feature this check
+    # guards. Without this, E004 fires as a hard Error during
+    # `manage.py check` on any settings profile that disables the WAF, so a
+    # test or CI profile using LocMemCache cannot boot at all. django_waf.E005
+    # already guards this way; E004 predates it and did not.
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
 
     if is_redis_backend(conf.DJANGO_WAF_REDIS_ALIAS):
         return []

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -55,6 +55,12 @@ def _run_observe_only_detector_names_check():
     return check_observe_only_detector_names(app_configs=None)
 
 
+def _run_redis_backend_check():
+    from django_waf.checks import check_redis_backend
+
+    return check_redis_backend(app_configs=None)
+
+
 def _run_redis_version_check():
     from django_waf.checks import check_redis_version
 
@@ -417,6 +423,44 @@ class TestObserveOnlyDetectorNamesCheck:
 
         assert len(messages) == 1
         assert messages[0].id == "django_waf.W008"
+
+
+class TestRedisBackendCheck:
+    """django_waf.E004: the alias must be a django-redis backend."""
+
+    def test_errors_when_alias_is_not_a_redis_backend(self):
+        """The misconfiguration E004 exists to catch (#44)."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=False),
+        ):
+            messages = _run_redis_backend_check()
+
+        assert any(m.id == "django_waf.E004" for m in messages)
+
+    def test_silent_when_alias_is_a_redis_backend(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=True),
+        ):
+            assert _run_redis_backend_check() == []
+
+    def test_silent_when_waf_disabled(self):
+        """#67: E004 fired as a hard Error regardless of DJANGO_WAF_ENABLED,
+        so a settings profile that switches the WAF off and uses LocMemCache
+        could not run manage.py check at all. A project not using the feature
+        is not misconfigured for it."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=False),
+        ):
+            assert _run_redis_backend_check() == []
 
 
 class TestRedisVersionCheck:


### PR DESCRIPTION
Closes #67. Found while upgrading consumers to 2.0.0, where it is a live blocker.

## The defect

`check_redis_backend` errors whenever `DJANGO_WAF_REDIS_ALIAS` is not a django-redis backend, **regardless of `DJANGO_WAF_ENABLED`**. An `Error` aborts `manage.py check`, so any settings profile that switches the WAF off and uses a plain cache backend cannot boot at all.

A project that has disabled the feature is not misconfigured for having a non-Redis cache. It simply is not using the thing this check guards.

## Why it matters now

vendablyv3's pre-push `for_merchant` gate cannot run under `DJANGO_ENV=test` for exactly this reason, confirmed with fresh repro during the 2.0.0 pin upgrade (vendably/vendablyv3#1860, pushed with the hook's documented `SKIP_LOCAL_CI=1` escape hatch rather than routing around it silently).

This affects **any consumer upgrading from before 1.8.1**, where E004 was introduced. Several of the nine consumer upgrade PRs open today cross that boundary.

## Why it survived

This is the part worth recording.

`django_waf.E005` already guards this way. Its own test is named `test_silent_when_waf_disabled` and its docstring reads:

> "Guards against repeating #67: E004 fired regardless of DJANGO_WAF_ENABLED. E005 must not repeat that mistake."

The module docstring for E005 also cites #67 explicitly. So the defect was known, documented in a sibling check's docstring, and pinned by a sibling check's test.

**E004 itself had no test of any kind.** The guard against repeating the bug was written; the guard against the bug was not. That is the same shape as several defects found in this package recently: the mechanism exists, the documentation is accurate, and the thing it describes was never actually wired up or verified.

## The fix

A `DJANGO_WAF_ENABLED` guard as the cheapest early return, matching E005's ordering exactly. Docstrings updated so E004's own text states the guard rather than leaving it implicit in a sibling's.

## Tests

Three new, in a new `TestRedisBackendCheck` class, since E004 previously had none:

- errors when the alias is not a redis backend (the misconfiguration E004 exists to catch, #44)
- silent when the alias is a redis backend
- **silent when the WAF is disabled** (#67)

The third is confirmed falsifiable: removing the guard fails it with the other two still passing.

## Verification

| Gate | Result |
|---|---|
| `pytest` | **1178 passed, 5 skipped** |
| `ruff check` / `format --check` | clean, 139 files |

Branched from current `main` (`30fcea5`), after today's four detection fixes merged.