### PR TITLE
fix: give the subnet path of detect_unsolved_challenges its own window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   detection for any of them. `detect_subnet_burst` continues to create
   CHALLENGE rules on first detection, never BLOCK, unchanged.
 
+- **The subnet path of `detect_unsolved_challenges` could not fire at all
+  at the window it actually ran in.** Traced against the deployment #84
+  was built for (issue #93): the subnet thresholds
+  (`DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED` and
+  `DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS`) were calibrated against a seven-day
+  aggregate, but the subnet path shared the per-IP path's 60-minute window,
+  and a deliberately slow-drip attacker never produced enough volume in any
+  single hour to clear either threshold. Zero rules were created in 13
+  hours on that deployment. Measured live, varying only the window with
+  the thresholds unchanged: 42 subnets seen at 60 minutes (0 qualifying),
+  116 at 180 minutes (2 qualifying), 241 at 360 minutes (10 qualifying).
+  The subnet path now runs on its own, independently configurable window
+  (`DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES`, default 360), decoupled
+  from the per-IP path's `window_minutes`, which keeps its existing default
+  and behaviour unchanged: it is already producing correct BLOCK rules in
+  production. The (30, 10) thresholds themselves are unchanged; at a
+  360-minute window they already catch every subnet clearing the
+  distinct-IP floor. Every subnet that would have qualified at this window
+  in the traced sample carried zero allowed/passed requests, and all but
+  one had zero IPs that ever solved a challenge; the one exception was the
+  known JS-executing bot cohort from #77.
+
 ### Added
 
 - `DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT` setting (default
@@ -99,6 +121,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `referer_ratio` remain accepted keyword arguments on
   `detect_unsolved_challenges` and default to the new settings, so
   existing callers and the dry-run management command are unaffected.
+
+- `DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES` setting (default 360): the
+  time window, in minutes, the subnet path of `detect_unsolved_challenges`
+  aggregates over, independent of the per-IP path's `window_minutes`. See
+  the Security entry above for why this exists. `detect_unsolved_challenges`
+  also accepts a new `subnet_window_minutes` keyword argument, defaulting
+  to this setting, matching how the other four subnet-tuning settings
+  above are already exposed as overridable parameters.
 
 ### Fixed
 

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -766,6 +766,36 @@ DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED: int = getattr(settings, "DJANGO_WAF_U
 # rather than only the extreme case already seen.
 DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS: int = getattr(settings, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10)
 
+# Time window, in minutes, the subnet path of detect_unsolved_challenges
+# aggregates over. Deliberately separate from the per-IP path's window
+# (which stays on the function's own window_minutes parameter, default 60,
+# and must not be widened: it is already producing correct per-IP BLOCK
+# rules in production at that window). Issue #93 traced why the subnet path
+# needed its own, wider window: DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED
+# (30) and DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS (10) were calibrated in #84
+# against a SEVEN DAY aggregate, but the subnet path only ever ran inside
+# the per-IP detector's 60-minute window, so a deliberately slow-drip
+# attacker never produced enough volume in any single hour to clear either
+# threshold. Measured on the production deployment #93 was built for, same
+# (30, 10) gate, varying only the window:
+#
+#   window  60m:  42 subnets seen,   0 qualify
+#   window 180m: 116 subnets seen,   2 qualify
+#   window 360m: 241 subnets seen,  10 qualify
+#
+# 360 (6 hours) is the smallest of the measured windows at which the
+# existing thresholds catch every subnet clearing the distinct-IP floor,
+# so it is the default rather than a threshold change: two variables were
+# not moved at once. At a 360-minute window, all ten subnets that would
+# have qualified carried zero allowed/passed rows, and nine of the ten had
+# zero IPs that ever solved a challenge; the tenth was the known
+# JS-executing bot cohort from #77. No legitimate user traffic was found in
+# any of them. The wider scan is not a query-cost concern: on a table of
+# 1.5M RequestLog rows, a 360-minute scan runs in 0.006s against the
+# existing django_waf_rl_verdict_ts_idx index, indistinguishable in cost
+# from the 60-minute scan.
+DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES: int = getattr(settings, "DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES", 360)
+
 # ---------------------------------------------------------------------------
 # Verify-endpoint rate limit (issue #81)
 # ---------------------------------------------------------------------------

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -302,6 +302,7 @@ def detect_unsolved_challenges(
     window_minutes: int = 60,
     min_challenged: int | None = None,
     referer_ratio: float | None = None,
+    subnet_window_minutes: int | None = None,
     dry_run: bool = False,
 ) -> list:
     """Detect IPs, and subnets, that receive challenges but never solve them.
@@ -326,17 +327,32 @@ def detect_unsolved_challenges(
     Creates an IP-exact BLOCK rule directly (unchanged: an IP that clears
     all three per-IP signals is already high-confidence).
 
-    Subnet path (new, #84):
+    Subnet path (new in #84, given its own window in #93):
     1. The /24 (IPv4) or /48 (IPv6) subnet's total challenged-verdict count
-       across the window meets DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED,
-       AND the number of DISTINCT contributing IPs meets
-       DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS. Both are required so one noisy
-       host cannot escalate its neighbours: a single IP alone can never
-       cross the distinct-IP floor no matter its own challenge count.
+       across its OWN window (subnet_window_minutes, independent of the
+       per-IP path's window_minutes) meets
+       DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED, AND the number of
+       DISTINCT contributing IPs meets DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS.
+       Both are required so one noisy host cannot escalate its neighbours:
+       a single IP alone can never cross the distinct-IP floor no matter
+       its own challenge count.
     2. The subnet is exempted if any of its contributing IPs solved a
        challenge within the recency window (same bound as the per-IP path,
        for the same reason: an occasional solve from a rotating pool must
        not grant the whole /24 permanent immunity).
+
+    The two paths were sharing window_minutes until #93: the subnet
+    thresholds above were calibrated in #84 against a seven-day aggregate,
+    but the per-IP path's 60-minute default left the subnet path unable to
+    accumulate enough volume in an hour to ever clear them against a
+    deliberately slow-drip attacker (measured live: 42 subnets seen in 60
+    minutes, 0 qualifying; 241 subnets seen in 360 minutes, 10 qualifying,
+    with the existing thresholds unchanged). The per-IP path's window stays
+    at its existing default (it is already producing correct BLOCK rules in
+    production and widening it is out of scope); the subnet path now reads
+    its own window from subnet_window_minutes /
+    DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES (default 360). See conf.py for
+    the full measurement.
 
     The empty-referer requirement is deliberately NOT applied to the subnet
     path: it is evaluated per-IP against a specific IP's non-root request
@@ -357,12 +373,21 @@ def detect_unsolved_challenges(
     caught at least 35.6% real users on the same deployment.
 
     Args:
-        window_minutes: Time window to analyse (default 60).
+        window_minutes: Time window to analyse for the per-IP path (default
+                        60). Unchanged by #93: this path is already
+                        producing correct BLOCK rules in production at this
+                        window and widening it is out of scope.
         min_challenged: Minimum challenged verdicts for the per-IP path.
                         Defaults to DJANGO_WAF_UNSOLVED_MIN_CHALLENGED.
         referer_ratio: Fraction of non-root requests with empty referer
                        required to trigger the per-IP path. Defaults to
                        DJANGO_WAF_UNSOLVED_REFERER_RATIO.
+        subnet_window_minutes: Time window to analyse for the subnet path,
+                       independent of window_minutes. Defaults to
+                       DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES (360). See
+                       conf.py and this docstring's "Subnet path" section
+                       for why the subnet path needs a wider window than
+                       the per-IP path (#93).
         dry_run: When True (#38), collects what would be created without
                  writing any BlockRule or emitting the anomaly_detected signal.
 
@@ -378,13 +403,16 @@ def detect_unsolved_challenges(
 
     effective_min_challenged = min_challenged if min_challenged is not None else conf.DJANGO_WAF_UNSOLVED_MIN_CHALLENGED
     effective_referer_ratio = referer_ratio if referer_ratio is not None else conf.DJANGO_WAF_UNSOLVED_REFERER_RATIO
+    effective_subnet_window_minutes = (
+        subnet_window_minutes if subnet_window_minutes is not None else conf.DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES
+    )
 
     cutoff = timezone.now() - timedelta(minutes=window_minutes)
     solve_exemption_cutoff = timezone.now() - timedelta(hours=conf.DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS)
 
-    # All challenged verdicts in the window, per IP, with their counts.
-    # Scoped to source=middleware (#32): a nginx_log row's verdict is
-    # inferred from the access-log status code, not observed by
+    # All challenged verdicts in the per-IP window, per IP, with their
+    # counts. Scoped to source=middleware (#32): a nginx_log row's verdict
+    # is inferred from the access-log status code, not observed by
     # rule_engine.evaluate_request. The nginx access log records the same
     # request middleware already logged, so counting both would double the
     # apparent challenged_count for every IP and distort this detector's
@@ -399,12 +427,32 @@ def detect_unsolved_challenges(
         .annotate(challenged_count=Count("id"))
     )
 
-    all_challenged_ips = [row["ip_address"] for row in challenged_by_ip]
+    # The subnet path's own aggregation, over its own (wider) window (#93).
+    # A separate query rather than filtering challenged_by_ip: the per-IP
+    # window is a strict subset of the subnet window by default (60 vs 360
+    # minutes), so reusing challenged_by_ip would silently cap the subnet
+    # aggregate at whatever the per-IP path happened to see.
+    subnet_cutoff = timezone.now() - timedelta(minutes=effective_subnet_window_minutes)
+    challenged_by_ip_for_subnet = list(
+        RequestLog.objects.filter(
+            timestamp__gte=subnet_cutoff,
+            verdict=Verdict.CHALLENGED,
+            source=RequestLogSource.MIDDLEWARE,
+        )
+        .values("ip_address")
+        .annotate(challenged_count=Count("id"))
+    )
+
+    all_challenged_ips = {row["ip_address"] for row in challenged_by_ip} | {
+        row["ip_address"] for row in challenged_by_ip_for_subnet
+    }
 
     # IPs with a SOLVED ChallengeToken within the recency window (#84).
     # Before #84 this had no time bound at all, so a single solve at any
     # point in an IP's history granted permanent immunity; traced live,
-    # that removed half the candidates in a 60-minute window.
+    # that removed half the candidates in a 60-minute window. Computed once
+    # against the union of both paths' candidate IPs so the same recency
+    # bound applies identically regardless of which window surfaced the IP.
     # order_by() clears ChallengeToken.Meta.ordering (-issued_at) before
     # distinct(): without it, Django appends issued_at to the SELECT, so
     # DISTINCT applies to (ip_address, issued_at) and this returns one row
@@ -437,9 +485,9 @@ def detect_unsolved_challenges(
     )
     created_rules.extend(
         _detect_unsolved_challenges_by_subnet(
-            challenged_by_ip=challenged_by_ip,
+            challenged_by_ip=challenged_by_ip_for_subnet,
             solved_ips=solved_ips,
-            window_minutes=window_minutes,
+            window_minutes=effective_subnet_window_minutes,
             expiry=expiry,
             dry_run=dry_run,
         )
@@ -565,7 +613,9 @@ def _detect_unsolved_challenges_by_subnet(
 ) -> list:
     """The subnet half of detect_unsolved_challenges (#84). See that
     function's docstring for the two-signal, two-stage contract this
-    implements.
+    implements. ``challenged_by_ip`` and ``window_minutes`` here are already
+    scoped to the subnet path's own window (#93), independent of the per-IP
+    path's window.
     """
     from django_waf import conf
     from django_waf.enums import AnomalyType, RuleAction, RuleType
@@ -796,7 +846,12 @@ def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) 
             detector. ``None`` (the default) leaves each detector on its own
             configured default window. ``detect_challenge_farms`` takes its
             window in hours, so the value is converted (rounded up to the
-            nearest hour, minimum 1) before being forwarded to it.
+            nearest hour, minimum 1) before being forwarded to it. Forwarded
+            to ``detect_unsolved_challenges`` as its per-IP ``window_minutes``
+            only (#93): that detector's subnet path keeps its own,
+            independently configured window
+            (``DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES``) regardless of
+            this override, since the two paths were deliberately decoupled.
         dry_run: When True (#38), every detector collects what would be
             created and reports it in the return value without writing any
             BlockRule, activating anything, or emitting the

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3969,6 +3969,105 @@ class TestDetectUnsolvedChallenges:
         assert subnet_rules[0].action == RuleAction.CHALLENGE
         assert not BlockRule.objects.filter(pattern="203.0.115.0/24").exists()
 
+    @pytest.mark.django_db
+    def test_subnet_window_is_the_discriminator_for_a_slow_drip_spread(self):
+        """A slow-drip subnet that does NOT qualify inside a 60-minute
+        window DOES qualify once the subnet path is given its own wider
+        window (issue #93).
+
+        15 distinct IPs in one /24, 2 challenges each (30 total, clearing
+        DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED with exactly
+        DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS distinct IPs), spread evenly
+        across the last 300 minutes so no single 60-minute slice ever
+        contains more than a handful of them. This must fail if
+        subnet_window_minutes is ignored and the subnet path shares the
+        per-IP path's 60-minute window: at 60 minutes only the last couple
+        of IPs' traffic falls inside the window, clearing neither the count
+        nor the distinct-IP floor.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.models import BlockRule
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+        # Spread the 15 IPs' traffic across 0..300 minutes ago, 20 minutes
+        # apart, so a 60-minute window only ever catches the most recent 2-3
+        # IPs (well under both thresholds) while a 360-minute window catches
+        # all 15.
+        for i in range(15):
+            offset = timezone.timedelta(minutes=i * 20)
+            for _ in range(2):
+                RequestLogFactory(
+                    ip_address=f"203.0.116.{i}",
+                    verdict=Verdict.CHALLENGED,
+                    path="/page",
+                    referer="",
+                    timestamp=now - offset,
+                )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            # At the per-IP path's own 60-minute window, forced onto the
+            # subnet path too, the spread traffic cannot clear either gate.
+            rules_at_60m = detect_unsolved_challenges(
+                window_minutes=60,
+                min_challenged=999,
+                subnet_window_minutes=60,
+            )
+            assert [r for r in rules_at_60m if r.rule_type == RuleType.CIDR] == []
+
+            # The same data, with only the subnet window widened to 360
+            # minutes, qualifies: the existing (30, 10) thresholds are
+            # unchanged, only the window differs.
+            rules_at_360m = detect_unsolved_challenges(
+                window_minutes=60,
+                min_challenged=999,
+                subnet_window_minutes=360,
+            )
+
+        subnet_rules = [r for r in rules_at_360m if r.rule_type == RuleType.CIDR]
+        assert len(subnet_rules) == 1
+        assert subnet_rules[0].pattern == "203.0.116.0/24"
+        assert subnet_rules[0].action == RuleAction.CHALLENGE
+        assert BlockRule.objects.filter(pattern="203.0.116.0/24", is_active=True).exists()
+
+    @pytest.mark.django_db
+    def test_subnet_window_defaults_to_the_configured_setting(self):
+        """With subnet_window_minutes not passed, the subnet path reads
+        DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES, not the per-IP
+        window_minutes (issue #93's decoupling).
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+        # Traffic sits 200 minutes back: outside the per-IP path's 60-minute
+        # window (window_minutes stays default, unaffected) but inside the
+        # default 360-minute subnet window.
+        offset = timezone.timedelta(minutes=200)
+        for i in range(15):
+            for _ in range(2):
+                RequestLogFactory(
+                    ip_address=f"203.0.117.{i}",
+                    verdict=Verdict.CHALLENGED,
+                    path="/page",
+                    referer="",
+                    timestamp=now - offset,
+                )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES", 360),
+        ):
+            rules = detect_unsolved_challenges(window_minutes=60, min_challenged=999)
+
+        subnet_rules = [r for r in rules if r.rule_type == RuleType.CIDR]
+        assert len(subnet_rules) == 1
+        assert subnet_rules[0].pattern == "203.0.117.0/24"
+
 
 # ---------------------------------------------------------------------------
 # fingerprint


### PR DESCRIPTION
## Summary

The subnet aggregation from #87 produced zero rules in 13 hours on the deployment it was built for (#93). This fixes the second of the two causes: the subnet thresholds (`DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED=30`, `DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS=10`) were calibrated against a seven-day aggregate, but the subnet path shared the per-IP detector's 60-minute `window_minutes`, so a deliberately slow-drip attacker never produced enough volume in any single hour to clear either threshold.

Measured live, varying only the window with the gate unchanged:

```
window 60m:  42 subnets seen,  0 qualify
window 180m: 116 subnets seen,  2 qualify
window 360m: 241 subnets seen, 10 qualify
```

## Changes

- `DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES` setting (default 360), following conf.py's `getattr` idiom.
- `detect_unsolved_challenges` gains a `subnet_window_minutes` keyword argument, defaulting to the new setting, exactly matching how the other four subnet-tuning parameters are already exposed.
- The subnet path now runs its own `RequestLog` aggregation query over its own window, entirely decoupled from the per-IP path's `window_minutes`, which keeps its existing default (60) and behaviour unchanged; it is already producing correct BLOCK rules in production.
- Thresholds (30, 10) are unchanged: only the window moved, so this doesn't conflate two variables.
- `run_all_detectors(window_minutes=N)` continues to override only the per-IP window; the subnet path keeps its own setting-derived default regardless, since the two were deliberately decoupled.

## Expiry interaction

Checked `DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS` (default 24): a wider 6-hour detection window means a subnet stays *detectable* (re-qualifiable on a re-scan) for longer after going quiet, but `detect_anomalies` runs every 15 minutes and refreshes `expires_at` to `now + 24h` on every re-detection. The 24-hour default is about how long a rule survives after detection *stops* re-firing, which is a bounded ~6-hour increase, not a new failure mode. No change needed here.

## Tests

- `test_subnet_window_is_the_discriminator_for_a_slow_drip_spread`: 15 IPs spread over 300 minutes; fails to qualify when the subnet path is forced to a 60-minute window and qualifies at 360 minutes with the same (30, 10) thresholds. Fails if the window setting is ignored.
- `test_subnet_window_defaults_to_the_configured_setting`: confirms the subnet path reads `DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES` rather than the per-IP `window_minutes` when `subnet_window_minutes` is not passed explicitly.

## Spec note (not in this repo)

`docs/specs/django-waf/03-services.md` line 315 in the `oss` umbrella states that `run_all_detectors`'s `window_minutes` override applies to `detect_unsolved_challenges` "directly" — that line needs a follow-up to note the subnet path no longer moves with it. Reporting only, per the umbrella being a separate repo.

## Test plan

- [ ] Tester to run the full gate suite (pytest, ruff check/format, mypy) on this branch