### PR TITLE
2.2.0: call-time settings resolution, check gating, subnet promotion provenance, and a detector liveness probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `django_waf.E006`: a new system check that errors when
+  `DJANGO_WAF_ENABLED = True` but `WafMiddleware` (or a subclass of it,
+  matched by class name) is absent from `MIDDLEWARE` entirely (#101).
+  `django_waf.W004` only ever warns about ordering once `WafMiddleware`
+  is found in `MIDDLEWARE`; nothing previously checked for its outright
+  absence. A brickworkui.com production deployment had `django_waf`
+  installed and `DJANGO_WAF_ENABLED = True` with no `WafMiddleware` in
+  `MIDDLEWARE` for its entire deployed life, and `manage.py check` passed
+  throughout: the WAF inspected no traffic at all while reporting a clean
+  bill of health. This is an Error, matching `django_waf.E004`'s
+  rationale: a security control that reports healthy while blocking
+  nothing is worse than one that refuses to start.
+
 ### Fixed
 
 - `django_waf.E003` (the site-password gate, BR-SP-002), `django_waf.E001`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the hourly log line, not only on its content, since this package
   stays stateless and does not persist a last-run timestamp.
 
-### Added
-
 - `django_waf.E006`: a new system check that errors when
   `DJANGO_WAF_ENABLED = True` but `WafMiddleware` (or a subclass of it,
   matched by class name) is absent from `MIDDLEWARE` entirely (#101).
@@ -46,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bill of health. This is an Error, matching `django_waf.E004`'s
   rationale: a security control that reports healthy while blocking
   nothing is worse than one that refuses to start.
+
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Detector liveness probe** (BR-ANOM-012). Three defects this cycle (a
+  `getdel` call reporting success 40,936 times while doing nothing, the
+  2.0.0 subnet detector producing 0 rules for 13 hours, and #97's staging
+  skip) all passed tests, review and release. A scheduled probe asserting
+  the detectors still produce rules would have caught each within the
+  hour. `services.detector_probe.run_detector_probe()` builds synthetic
+  fixture traffic, shaped to provably cross every anomaly detector's own
+  configured threshold using RFC 5737 TEST-NET IP ranges, and reports
+  which detectors did (and did not) produce a rule against it. Real
+  recent traffic cannot be used for this: `run_all_detectors` returning
+  zero is the normal, healthy result on a quiet site, indistinguishable
+  from a dead detector. Everything runs inside a transaction that is
+  unconditionally rolled back, so no synthetic row is ever committed. New
+  `probe_detectors` Celery task (hourly) and `django_waf_probe_detectors`
+  management command (`--exercise-writes` for the opt-in real-write mode;
+  exits non-zero on a silent detector, for cron wrappers and k8s liveness
+  probes). No environment guard gates this probe, on the same principle
+  as #97's fix: a check silently inert in one environment is the next
+  regression, not a safety net for it. A dead Celery Beat entry for this
+  task produces no log line at all; consumers must alert on the absence
+  of the hourly log line, not only on its content, since this package
+  stays stateless and does not persist a last-run timestamp.
+
 ## [2.1.0] - 2026-08-29
 
 No breaking API changes and no migration in this release, unlike 2.0.0. If

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,82 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - 2.2.0
+
+### Fixed
+
+- **`django_waf.conf` now resolves every `DJANGO_WAF_*` setting at call
+  time instead of freezing it at import time** (closes #75). Every one of
+  the 92 settings was previously a module-level constant computed once
+  from `getattr(settings, "DJANGO_WAF_X", default)` when `conf.py` first
+  imported, despite the module's own docstring promising call-time
+  resolution. In practice this meant `override_settings` and the pytest
+  `settings` fixture silently had no effect on WAF behaviour, and any
+  consuming project whose own settings module touched `django_waf.conf`
+  during settings execution froze every constant at the package default
+  for the rest of the process. This was observed live: a site whose
+  `settings.DJANGO_WAF_ENABLED` was `False` still ran with the WAF
+  enabled, against the wrong Redis alias, because `conf.py` had imported
+  earlier in the settings module with the package defaults still in
+  effect. Every `DJANGO_WAF_*` name is now a private resolver function
+  behind a PEP 562 module `__getattr__`, so `conf.DJANGO_WAF_X` always
+  reflects the current `django.conf.settings` value.
+
+  **This is consumer-visible if your test suite relied on the WAF
+  ignoring `override_settings` or the pytest `settings` fixture.** A test
+  that sets `DJANGO_WAF_ENABLED = False` (by either mechanism) expecting
+  the WAF to keep running regardless will now see it actually disabled;
+  the same applies to every other `DJANGO_WAF_*` setting. If your suite
+  worked around the old defect with `importlib.reload(django_waf.conf)`,
+  that reload is now a harmless no-op and can be removed.
+
+  `DJANGO_WAF_SITE_PASSWORD_ENABLED`'s derived default (`bool(DJANGO_WAF_SITE_PASSWORD)`,
+  the one intra-conf cross-reference among all 92 settings) now recurses
+  through the resolver for `DJANGO_WAF_SITE_PASSWORD` rather than reading
+  a value frozen at import time, so BR-SP-002's fail-closed guarantee
+  (gate enabled, no password, deny every request) holds correctly when
+  the password is set or cleared after the process started.
+
+  `DJANGO_WAF_CELERY_BEAT_SCHEDULE` (and every other setting) resolves to
+  its documented default rather than raising `ImproperlyConfigured` when
+  `django.conf.settings` is not yet configured, which is what keeps the
+  README's documented consumer pattern, importing it directly from
+  inside a consuming project's own `settings.py` before that module has
+  finished running, safe.
+
+  `django_waf.services.blocklist_generator._activate_candidate` and
+  `_validate_nginx_config` now read `DJANGO_WAF_NGINX_VALIDATE` and
+  `DJANGO_WAF_NGINX_TEST_COMMAND` from `django_waf.conf` instead of
+  duplicating their own `getattr(django.conf.settings, ...)` reads and
+  defaults. `django_waf.urls` now reads `DJANGO_WAF_API_ENABLED` from
+  `django_waf.conf` instead of `django.conf.settings` directly; the
+  urlconf-import-time caveat this read carried (the mount decision is
+  still made once, at first URL dispatch for the whole process, not
+  re-evaluated per request) is unchanged and still documented in the
+  module docstring.
+
+- **`disable_waf` (the public `django_waf.testing.fixtures` pytest
+  fixture) no longer patches `django_waf.conf` directly.** It now sets
+  `settings.DJANGO_WAF_ENABLED = False` via the pytest `settings`
+  fixture. **Consumer-visible**: the fixture's signature changed from
+  `disable_waf(monkeypatch)` to `disable_waf(settings)`; a project that
+  depended on the exact patched object (rather than only on the WAF being
+  disabled for the duration of the test) should review its own tests.
+  This also removes a genuine hazard the old implementation carried:
+  `monkeypatch.setattr` restores a patched module attribute by calling
+  `setattr` with the pre-patch value on teardown, which, unlike
+  `unittest.mock.patch.object`'s `delattr`-based restore, would have
+  permanently shadowed live resolution in `django_waf.conf` for the rest
+  of the process once that module stopped freezing values at import
+  time.
+
+### Removed
+
+- `tests/conftest.py`'s `_reset_conf_module` autouse fixture and every
+  `importlib.reload(django_waf.conf)` call across the test suite (55
+  sites): both were workarounds for the import-time-snapshot defect
+  above and are no longer needed now that `conf.py` resolves live.
+
 ## [2.1.0] - 2026-08-29
 
 No breaking API changes and no migration in this release, unlike 2.0.0. If

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`detect_unsolved_challenges`'s subnet staging could not reach its own
+  CHALLENGE stage on a default deployment** (closes #97). The detector's
+  two-stage promotion (a first crossing of a subnet creates a CHALLENGE
+  rule; only a repeat crossing promotes to BLOCK) checked for a prior
+  active CHALLENGE rule by rule shape alone, not by which detector created
+  it. `detect_subnet_burst` and `detect_cloud_spray` both run by default
+  and both create AUTO/CIDR/CHALLENGE rules for the same subnet pattern,
+  so their rules were counted as `detect_unsolved_challenges`'s own prior
+  crossing: measured live, 9 of 10 subnet rules from this detector were
+  promoted straight to BLOCK instead of staging through CHALLENGE first.
+  This defeated the staging that exists specifically as a false-positive
+  control: issue #82 measured that blocking on this signal without
+  staging would have caught at least 35.6% real users, including genuine
+  Bingbot and Applebot, on the deployment it was measured against. A
+  subnet's two-stage promotion now recognises only a CHALLENGE rule
+  `detect_unsolved_challenges` itself created; another detector reaching
+  the same conclusion about a subnet no longer accelerates this
+  detector's own promotion to BLOCK.
+
+  **Migration note**: this fix adds a new field, `BlockRule.detectors`
+  (migration `0006_blockrule_detector`), recording which detector(s)
+  created or refreshed an auto-generated rule. It is a set, not a single
+  value: several detectors can independently target the same rule (most
+  commonly a shared subnet pattern), and a rule created by one detector
+  and later touched by another carries both names, never overwriting one
+  with the other. This is what lets `detect_unsolved_challenges`
+  recognise its own prior CHALLENGE rule even after a different detector
+  has since refreshed the same row. Existing rows backfill to blank.
+  Practical effect: for a subnet whose CHALLENGE rule already existed
+  before you upgrade, `detect_unsolved_challenges`'s next run against
+  that subnet will not recognise its own prior rule (since the backfilled
+  value cannot say who created it) and will create or refresh a CHALLENGE
+  rule again rather than promoting to BLOCK. This costs at most one extra
+  CHALLENGE stage per pre-existing subnet rule, once, and is intentional:
+  it fails safe toward the less disruptive action, consistent with the
+  discipline this fix restores.
+
 ## [2.1.0] - 2026-08-29
 
 No breaking API changes and no migration in this release, unlike 2.0.0. If

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `django_waf.E003` (the site-password gate, BR-SP-002), `django_waf.E001`,
+  `django_waf.E002`, `django_waf.W001`, `django_waf.W002` (challenge
+  difficulty), and `django_waf.W004` (middleware ordering) no longer fire
+  when `DJANGO_WAF_ENABLED = False` (#95). Every feature these checks
+  protect is dead at runtime when the master switch is off, so a
+  misconfiguration behind it was never a live lockout, only a boot-time
+  false positive. E003 mattered most: as an Error it aborted
+  `manage.py check` outright, and consumers personal-site and JOBU hit
+  this exact failure under a `LocMemCache` settings profile. This closes
+  the same class of defect `django_waf.E004` was fixed for in 2.0.0 (#67,
+  #92), for the checks that fix missed.
+  `django_waf.W006` (trusted-cookie trust level) is unchanged, and
+  deliberately not gated: it warns behind its own explicit opt-in flag
+  (`DJANGO_WAF_TRUSTED_COOKIE_ENABLED`) and, as a Warning, cannot abort
+  `manage.py check`. `django_waf.W005`, `django_waf.W007`, and
+  `django_waf.W008` are also unchanged: the features they cover (threat-feed
+  sync, the anomaly detectors) run on independent Celery schedules, not the
+  request path the master switch gates.
+
 ## [2.1.0] - 2026-08-29
 
 No breaking API changes and no migration in this release, unlike 2.0.0. If

--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ to get the full schedule:
 | `parse_access_log` | every 10 minutes |
 | `expire_rules` | every 30 minutes |
 | `update_ip_reputation` | every 6 hours |
+| `probe_detectors` | every hour |
 | `prune_request_logs` | daily 04:00 |
 | `prune_challenge_tokens` | daily 04:15 |
 | `sync_threat_feed` | daily 04:30 |
@@ -531,6 +532,16 @@ name) if you need different cadences.
 | `django_waf_sync_feed` | Fetch and import rules from the collective threat feed (`--dry-run`) |
 | `django_waf_export_rules` | Export `BlockRule`/`AllowRule` records to JSON (`--output`, `--source`, `--rule-type`) |
 | `django_waf_import_rules` | Import `BlockRule`/`AllowRule` records from JSON produced by `django_waf_export_rules` (`--merge`, `--replace`, `--dry-run`) |
+| `django_waf_probe_detectors` | Run the detector liveness probe against synthetic fixture traffic; exits non-zero if any detector is silent (`--exercise-writes`) |
+
+**A dead `probe_detectors` schedule is silent.** The task logs one line
+every hour: INFO when every detector is alive, WARNING naming any silent
+detector. This package is stateless and does not persist a last-run
+timestamp, so a paused Celery worker, a missing Beat entry, or a broken
+schedule produces no log line at all rather than a failure log. Alert on
+the *absence* of the hourly `django_waf.detector_probe` log line within
+your expected cadence, not only on its WARNING content: the probe cannot
+detect that it has stopped running from the inside.
 
 ## Dashboard
 

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -118,6 +118,30 @@ be made, since neither of those is the misconfiguration this check exists
 to catch (see issue #67, where ``django_waf.E004`` wrongly fired under
 ``DJANGO_WAF_ENABLED = False`` with no Redis available; this check guards
 against repeating that).
+
+The middleware-presence check (``django_waf.E006``) errors when
+``DJANGO_WAF_ENABLED = True`` but ``WafMiddleware`` (or a subclass of it,
+matched by class name -- see the function docstring) is absent from
+``MIDDLEWARE`` entirely (#101). ``check_middleware_ordering``
+(``django_waf.W004``) only ever inspects ordering: it returns ``[]``
+unconditionally the moment ``WafMiddleware`` is not found in
+``MIDDLEWARE``, on the reasoning that there is no ordering to warn about.
+That silence was never a deliberate finding of "nothing wrong here"; it was
+simply the absence case no check was written for. A brickworkui.com
+production deployment had ``django_waf`` installed, ``DJANGO_WAF_ENABLED =
+True``, and no ``WafMiddleware`` anywhere in ``MIDDLEWARE`` for its entire
+deployed life, and ``manage.py check`` passed throughout: the WAF inspected
+no traffic at all while reporting a clean bill of health. This is an
+Error, not a Warning, for the same reason ``django_waf.E004`` is: a
+security control that reports healthy while blocking nothing is worse than
+one that refuses to start, and an operator who believes the WAF is live
+when it has never evaluated a single request is worse off than one told
+plainly at boot that it is not wired up. Gated on ``DJANGO_WAF_ENABLED``
+being ``True``: a disabled WAF is not expected to be in ``MIDDLEWARE`` at
+all (BR-EVAL-002 already makes a present-but-enabled middleware a total
+pass-through), so the absence of a middleware nobody asked to run is not a
+misconfiguration, matching the gating rationale #95 established for every
+other check in this module.
 """
 
 from __future__ import annotations
@@ -338,6 +362,80 @@ def check_middleware_ordering(app_configs, **kwargs):
         ]
 
     return []
+
+
+@register()
+def check_middleware_present(app_configs, **kwargs):
+    """Error (``django_waf.E006``) when the WAF is enabled but
+    ``WafMiddleware`` is absent from ``MIDDLEWARE`` entirely (#101).
+
+    ``check_middleware_ordering`` (``django_waf.W004``) only ever warns
+    about *where* ``WafMiddleware`` sits relative to
+    ``AuthenticationMiddleware``; it returns ``[]`` the instant the
+    middleware is not found at all, because there is no ordering left to
+    judge. Nothing else registered in this module inspects ``MIDDLEWARE``
+    for the WAF's own presence, so a project that installs the app,
+    flips ``DJANGO_WAF_ENABLED = True``, and simply forgets the
+    ``MIDDLEWARE`` line gets a silent, fully inert WAF and a green
+    ``manage.py check`` -- exactly what happened on brickworkui.com for
+    its entire deployed life. A misordered WAF still inspects every
+    request; an absent one inspects none, which is the more serious
+    failure and the one this module had no check for.
+
+    Matching is by class name (the last dotted component ends with
+    ``"WafMiddleware"``), not exact dotted-path equality to
+    ``django_waf.middleware.WafMiddleware``. ``WafMiddleware`` is a plain
+    ``__init__``/``__call__`` class with no metaclass or registration
+    step, so subclassing it to add project-specific behaviour around
+    ``get_response`` is an ordinary, unremarkable way to use it, and such
+    a subclass is exactly as live as the base class: it still evaluates
+    every request. A subclass conventionally keeps ``WafMiddleware`` as a
+    suffix of its own name (``CustomWafMiddleware``, ``TenantWafMiddleware``)
+    rather than the exact name, so an equality match on the class name
+    would repeat the same false positive an exact dotted-path match would,
+    only one layer further out; a suffix match tolerates the rename a
+    subclass almost always makes. Matching by class name is cheap to state
+    and does not attempt to verify the subclass actually calls into
+    ``WafMiddleware`` behaviour (an ``isinstance`` check would need the
+    class imported and instantiated, which a system check must not do); a
+    project naming an unrelated class to end in ``WafMiddleware`` on
+    purpose is choosing a confusing name, not a case this check is obliged
+    to protect against.
+
+    Gated on ``DJANGO_WAF_ENABLED = True`` (#95's own precedent, and #95's
+    acceptance criterion for this exact case): when the WAF is switched
+    off, ``MIDDLEWARE`` is not expected to carry it at all, so absence is
+    not a misconfiguration to flag, only the enabled-but-inert combination
+    is.
+    """
+    from django.conf import settings
+
+    from django_waf import conf
+
+    # Cheapest guard first, matching every other check in this module: a
+    # disabled WAF has nothing to be inert about, so there is nothing here
+    # for #101 to catch.
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
+
+    middleware = list(getattr(settings, "MIDDLEWARE", []))
+    if any(entry.rsplit(".", 1)[-1].endswith("WafMiddleware") for entry in middleware):
+        return []
+
+    return [
+        Error(
+            "DJANGO_WAF_ENABLED is True but django_waf.middleware.WafMiddleware "
+            "(or a subclass of it) is not present in MIDDLEWARE -- the WAF is "
+            "installed and switched on but evaluates no traffic at all.",
+            hint=(
+                "Add 'django_waf.middleware.WafMiddleware' to MIDDLEWARE (see "
+                "the README for recommended placement), or set "
+                "DJANGO_WAF_ENABLED = False if this project is not meant to "
+                "run the WAF yet."
+            ),
+            id="django_waf.E006",
+        )
+    ]
 
 
 @register()

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -12,10 +12,16 @@ Expected attempts is ``2 ** difficulty``. Thresholds:
 * ``> 24`` (~16M hashes, ~5–20s on phones) — Warning.
 * ``< 8``  (256 hashes, no real bot deterrence) — Warning.
 
+Silent when the WAF is disabled (``DJANGO_WAF_ENABLED = False``, #95): the
+challenge flow this check protects never runs when the master switch is
+off, so a difficulty misconfiguration behind it is not a live lockout.
+
 The signing-key check (``django_waf.W003``) was added in v0.11.0 alongside
 the form-protection subsystem. It surfaces when the package is falling
-back to a ``SECRET_KEY``-derived signing key — fine for development but
-worth a deliberate decision in production.
+back to a ``SECRET_KEY``-derived signing key, fine for development but
+worth a deliberate decision in production. Silent when the WAF is disabled
+(#95): no WAF token is ever signed with this key when the master switch is
+off.
 
 The feed-URL scheme check (``django_waf.W005``) warns when the threat feed
 is enabled but its URL is not ``https://``. The feed drives BlockRule
@@ -28,14 +34,18 @@ The middleware-ordering check (``django_waf.W004``) warns when
 ``MIDDLEWARE``, or when ``AuthenticationMiddleware`` is missing entirely.
 ``request.user`` is not available at that point, so the staff bypass
 silently fails and staff/superuser accounts can be blocked or challenged
-like anonymous traffic.
+like anonymous traffic. Silent when the WAF is disabled (#95): the staff
+bypass this check protects has nothing to bypass when the middleware is
+not evaluating requests.
 
 The site-password check (``django_waf.E003``) errors when
 ``DJANGO_WAF_SITE_PASSWORD_ENABLED`` is truthy but
 ``DJANGO_WAF_SITE_PASSWORD`` is empty. Per BR-SP-002 the gate fails closed
 at runtime in this state (every request is denied), so this is an Error
 rather than a Warning -- it flags an operator's site as permanently locked
-rather than a soft misconfiguration.
+rather than a soft misconfiguration. Silent when the WAF is disabled (#95):
+the site-password gate is evaluated by ``WafMiddleware``, so it cannot
+fail closed on a request the middleware never evaluates.
 
 The trust-level check (``django_waf.W006``) warns when
 ``DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL`` is set to anything other than
@@ -44,6 +54,14 @@ The trust-level check (``django_waf.W006``) warns when
 (``django_waf.services.trusted_user_service.get_trust_level`` coerces an
 unrecognised value to ``"staff"``), so this is a Warning about an
 ineffective setting, not an Error about a lockout.
+
+Deliberately NOT gated on ``DJANGO_WAF_ENABLED`` (#95): the trusted-user
+cookie is purely a request-time feature with no independent Celery path,
+which is the same rationale gating the other four checks in this module.
+It stays ungated because it is a Warning behind its own explicit opt-in
+flag (``DJANGO_WAF_TRUSTED_COOKIE_ENABLED``), so a disabled WAF combined
+with the feature flag left on cannot abort ``manage.py check`` the way an
+Error can; this is a considered exception, not an oversight.
 
 The Redis backend check (``django_waf.E004``) is silent when the WAF is
 disabled (``DJANGO_WAF_ENABLED = False``, #67), and otherwise errors when
@@ -111,6 +129,15 @@ from django.core.checks import Error, Warning, register
 def check_challenge_difficulty(app_configs, **kwargs):
     from django_waf import conf
 
+    # #95: the PoW challenge flow this check protects never runs when the
+    # WAF is switched off, so a difficulty misconfiguration behind it is
+    # not a live lockout. Without this, a settings profile that disables
+    # the WAF (e.g. under LocMemCache in a test or CI profile) can still
+    # abort manage.py check on E001/E002, exactly the class of boot-time
+    # false positive #95 was filed to close.
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
+
     messages = []
     # (name, value, allow_none) — desktop/mobile may be None to fall through
     # to the single-value DJANGO_WAF_CHALLENGE_DIFFICULTY.
@@ -167,7 +194,7 @@ def check_challenge_difficulty(app_configs, **kwargs):
 @register()
 def check_signing_key(app_configs, **kwargs):
     """Warn when ``DJANGO_WAF_SIGNING_KEY`` is unset and the package falls back
-    to a ``SECRET_KEY``-derived value.
+    to a ``SECRET_KEY``-derived value, unless the WAF is disabled (#95).
 
     Falling back is supported — it's how v0.10.x → v0.11.0 upgrades stay
     seamless — but tying WAF signatures to ``SECRET_KEY`` means rotating
@@ -175,6 +202,12 @@ def check_signing_key(app_configs, **kwargs):
     warning nudges operators toward an explicit dedicated key.
     """
     from django_waf import conf
+
+    # #95: no WAF token (waf_pass, trusted-user cookie, form-protection
+    # render token) is ever signed with this key when the master switch is
+    # off, so an unset key is not a live weakness in that state.
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
 
     if not conf.DJANGO_WAF_SIGNING_KEY:
         return [
@@ -230,7 +263,7 @@ def check_feed_url_scheme(app_configs, **kwargs):
 @register()
 def check_middleware_ordering(app_configs, **kwargs):
     """Warn (``django_waf.W004``) when ``WafMiddleware`` runs before
-    Django's ``AuthenticationMiddleware``.
+    Django's ``AuthenticationMiddleware``, unless the WAF is disabled (#95).
 
     The staff dashboard bypass and any authenticated-user logic in the WAF
     middleware reads ``request.user``, which ``AuthenticationMiddleware``
@@ -262,6 +295,13 @@ def check_middleware_ordering(app_configs, **kwargs):
     from django.conf import settings
 
     from django_waf import conf
+
+    # #95: cheapest guard first. request.user has nothing to bypass when
+    # WafMiddleware never evaluates a request in the first place, so the
+    # ordering this check warns about is not a live defect when the WAF is
+    # switched off.
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
 
     if conf.DJANGO_WAF_TRUSTED_COOKIE_ENABLED:
         return []
@@ -303,7 +343,7 @@ def check_middleware_ordering(app_configs, **kwargs):
 @register()
 def check_site_password_configured(app_configs, **kwargs):
     """Error (``django_waf.E003``) when the site-password gate is enabled
-    with an empty password.
+    with an empty password, unless the WAF is disabled (#95).
 
     Per BR-SP-002, this configuration fails closed at runtime -- every
     gated request is denied, effectively taking the whole site offline.
@@ -311,6 +351,15 @@ def check_site_password_configured(app_configs, **kwargs):
     than merely weakening a defence.
     """
     from django_waf import conf
+
+    # #95: the site-password gate is evaluated by WafMiddleware (BR-SP-008),
+    # so it cannot fail closed on a request the middleware never evaluates.
+    # This is the same class of false positive #67 fixed for E004: a
+    # settings profile that switches the WAF off (a test or CI profile
+    # under LocMemCache, say) is not misconfigured for having no password
+    # set, it simply is not using the feature this check guards.
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
 
     if not conf.DJANGO_WAF_SITE_PASSWORD_ENABLED:
         return []
@@ -348,6 +397,12 @@ def check_trusted_cookie_trust_level(app_configs, **kwargs):
     """
     from django_waf import conf
 
+    # #95: NOT gated on DJANGO_WAF_ENABLED, unlike E001/E002/W001/W002/W003/
+    # E003. This is a considered exception, not an oversight: it is a
+    # Warning behind its own explicit opt-in flag
+    # (DJANGO_WAF_TRUSTED_COOKIE_ENABLED), so it cannot abort manage.py
+    # check the way an Error can, and the module docstring records why it
+    # stays ungated.
     if not conf.DJANGO_WAF_TRUSTED_COOKIE_ENABLED:
         return []
 

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -1,10 +1,32 @@
 """
 Package-level settings with defaults.
 
-All settings are namespaced under DJANGO_WAF_* and accessed via this module.
-Do not import these at module level into model methods — call getattr()
-at call time to respect pytest settings overrides.
+All settings are namespaced under DJANGO_WAF_* and resolved at call time via
+this module's ``__getattr__`` (PEP 562): ``django_waf.conf.DJANGO_WAF_X``
+looks exactly like a plain module attribute to a caller, but every read
+re-consults ``django.conf.settings`` rather than a value frozen at import
+time. This is what makes ``override_settings`` and the pytest ``settings``
+fixture work: neither reloads this module, so a constant computed once at
+import time would never see either override.
+
+Do not import these names directly into another module
+(``from django_waf.conf import X``) or capture them at class/module scope
+elsewhere in the package (``X = conf.Y`` or ``def f(x=conf.Y)``): either
+pattern freezes the value again, defeating the point of this module. Always
+read ``conf.X`` inside a function body, at the point of use.
+
+When ``django.conf.settings`` is not yet configured (for example, a
+consumer's own settings module importing a name from here before calling
+``settings.configure()``), every name in this module resolves to its
+documented default rather than raising ``ImproperlyConfigured``. This is a
+deliberate, uniform contract across all 92 settings, not a per-setting
+special case: see ``DJANGO_WAF_CELERY_BEAT_SCHEDULE`` below, which the
+README documents as importable directly from a consumer's ``settings.py``.
 """
+
+from __future__ import annotations
+
+from typing import Any
 
 from django.conf import settings
 
@@ -13,11 +35,29 @@ try:
 except ImportError:
     crontab = None  # type: ignore[assignment]
 
+
+def _get_setting(name: str, default: Any) -> Any:
+    """Resolve a single DJANGO_WAF_* setting at call time.
+
+    Returns ``default`` without touching ``settings`` at all when Django
+    settings are not yet configured, so importing this module (directly or
+    transitively) from inside a consumer's own settings module, before
+    ``settings.configure()`` / ``DJANGO_SETTINGS_MODULE`` has run, never
+    raises ``ImproperlyConfigured``. Once configured, this is a plain
+    ``getattr(settings, name, default)``.
+    """
+    if not settings.configured:
+        return default
+    return getattr(settings, name, default)
+
+
 # Enable or disable the WAF middleware entirely.
-DJANGO_WAF_ENABLED: bool = getattr(settings, "DJANGO_WAF_ENABLED", True)
+def _DJANGO_WAF_ENABLED() -> bool:
+    return _get_setting("DJANGO_WAF_ENABLED", True)
+
 
 # Package-wide HMAC signing secret. Used by every signed artefact the WAF
-# issues — form render tokens (v0.11.0), and any future signed verdicts
+# issues, form render tokens (v0.11.0), and any future signed verdicts
 # or challenge tokens that migrate off ``SECRET_KEY``. Kept deliberately
 # separate from Django's ``SECRET_KEY`` so operators can rotate WAF
 # signatures on a security-driven cadence without invalidating sessions.
@@ -28,7 +68,9 @@ DJANGO_WAF_ENABLED: bool = getattr(settings, "DJANGO_WAF_ENABLED", True)
 # check emits a warning at startup. In production, set this to a value
 # generated with ``python -c "import secrets; print(secrets.token_urlsafe(64))"``
 # and load it from environment.
-DJANGO_WAF_SIGNING_KEY: str = getattr(settings, "DJANGO_WAF_SIGNING_KEY", "")
+def _DJANGO_WAF_SIGNING_KEY() -> str:
+    return _get_setting("DJANGO_WAF_SIGNING_KEY", "")
+
 
 # ---------------------------------------------------------------------------
 # Form-protection subsystem (v0.11.0)
@@ -38,173 +80,241 @@ DJANGO_WAF_SIGNING_KEY: str = getattr(settings, "DJANGO_WAF_SIGNING_KEY", "")
 # ``ProtectedForm`` (or the decorator / template tag) to a form is the
 # opt-in step; until that happens these settings are inert.
 
+
 # Master kill switch for the form-protection subsystem. When False,
 # ``ProtectedForm.clean()`` and the decorator/template-tag short-circuit
 # to pass without running any defences. Useful for incident response.
-DJANGO_WAF_FORM_PROTECTION_ENABLED: bool = getattr(settings, "DJANGO_WAF_FORM_PROTECTION_ENABLED", True)
+def _DJANGO_WAF_FORM_PROTECTION_ENABLED() -> bool:
+    return _get_setting("DJANGO_WAF_FORM_PROTECTION_ENABLED", True)
+
 
 # Aggregate-score thresholds. The orchestrator sums ``flag`` scores;
 # crossing FLAG triggers logging + signal + (optionally) challenge
 # redirect; crossing BLOCK rejects the submission outright. A single
 # defence returning ``block`` short-circuits the chain regardless of
 # total.
-DJANGO_WAF_FORM_FLAG_THRESHOLD: float = getattr(settings, "DJANGO_WAF_FORM_FLAG_THRESHOLD", 2.0)
-DJANGO_WAF_FORM_BLOCK_THRESHOLD: float = getattr(settings, "DJANGO_WAF_FORM_BLOCK_THRESHOLD", 5.0)
+def _DJANGO_WAF_FORM_FLAG_THRESHOLD() -> float:
+    return _get_setting("DJANGO_WAF_FORM_FLAG_THRESHOLD", 2.0)
+
+
+def _DJANGO_WAF_FORM_BLOCK_THRESHOLD() -> float:
+    return _get_setting("DJANGO_WAF_FORM_BLOCK_THRESHOLD", 5.0)
+
 
 # Whether to redirect flagged submissions through the existing
 # /waf/challenge/ flow rather than rejecting them. When True (default)
 # false-positive users get a way through; when False they get a
 # generic form error.
-DJANGO_WAF_FORM_CHALLENGE_ON_FLAG: bool = getattr(settings, "DJANGO_WAF_FORM_CHALLENGE_ON_FLAG", True)
+def _DJANGO_WAF_FORM_CHALLENGE_ON_FLAG() -> bool:
+    return _get_setting("DJANGO_WAF_FORM_CHALLENGE_ON_FLAG", True)
+
 
 # Whether the orchestrator fires the ``form_submission_passed`` signal.
-# Off by default — busy sites have 1000× more passed submissions than
+# Off by default: busy sites have 1000x more passed submissions than
 # flagged/blocked ones and firing in the hot path is wasted work. The
 # structured log still records passes (sampled). Operators who want
 # pass-event analytics opt in here.
-DJANGO_WAF_FORM_EMIT_PASSED_SIGNAL: bool = getattr(settings, "DJANGO_WAF_FORM_EMIT_PASSED_SIGNAL", False)
+def _DJANGO_WAF_FORM_EMIT_PASSED_SIGNAL() -> bool:
+    return _get_setting("DJANGO_WAF_FORM_EMIT_PASSED_SIGNAL", False)
+
 
 # Lifetime of a render token. After this many seconds the token is
 # expired and the user gets a fresh one on the next render. Also the
 # TTL of the Redis marker that backs replay protection.
-DJANGO_WAF_FORM_TOKEN_TTL: int = getattr(settings, "DJANGO_WAF_FORM_TOKEN_TTL", 3600)
+def _DJANGO_WAF_FORM_TOKEN_TTL() -> int:
+    return _get_setting("DJANGO_WAF_FORM_TOKEN_TTL", 3600)
+
 
 # Honeypot field-name pool. The HoneypotDefence picks names from this
 # list by hashing form_id, so a given form gets a stable set of names
 # (cache-friendly) but different forms get different names (bots can't
 # learn one global set).
-DJANGO_WAF_FORM_HONEYPOT_FIELD_NAMES: list[str] = getattr(
-    settings,
-    "DJANGO_WAF_FORM_HONEYPOT_FIELD_NAMES",
-    ["url", "website", "homepage", "email_confirm"],
-)
+def _DJANGO_WAF_FORM_HONEYPOT_FIELD_NAMES() -> list[str]:
+    return _get_setting(
+        "DJANGO_WAF_FORM_HONEYPOT_FIELD_NAMES",
+        ["url", "website", "homepage", "email_confirm"],
+    )
+
 
 # Time-trap thresholds in seconds. Submissions faster than the min are
 # flagged; faster than 0.5s are blocked outright. Submissions older
 # than the max have either been sitting open too long (UA changed, IP
-# changed) or are replays — flagged either way.
-DJANGO_WAF_FORM_TIME_TRAP_MIN_SECONDS: float = getattr(settings, "DJANGO_WAF_FORM_TIME_TRAP_MIN_SECONDS", 1.5)
-DJANGO_WAF_FORM_TIME_TRAP_MAX_SECONDS: float = getattr(settings, "DJANGO_WAF_FORM_TIME_TRAP_MAX_SECONDS", 3600)
+# changed) or are replays: flagged either way.
+def _DJANGO_WAF_FORM_TIME_TRAP_MIN_SECONDS() -> float:
+    return _get_setting("DJANGO_WAF_FORM_TIME_TRAP_MIN_SECONDS", 1.5)
+
+
+def _DJANGO_WAF_FORM_TIME_TRAP_MAX_SECONDS() -> float:
+    return _get_setting("DJANGO_WAF_FORM_TIME_TRAP_MAX_SECONDS", 3600)
+
 
 # Credential-throttle settings. Per-IP threshold drives the visible
-# challenge (enumeration-safe — same behaviour whether the typed
+# challenge (enumeration-safe, same behaviour whether the typed
 # username exists). Per-account threshold drives an observation-only
 # ``credential_attack_observed`` signal so consumers can email the
 # legitimate owner.
-DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW: int = getattr(settings, "DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW", 900)
-DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT: int = getattr(settings, "DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT", 5)
-DJANGO_WAF_FORM_CREDENTIAL_IP_LIMIT: int = getattr(settings, "DJANGO_WAF_FORM_CREDENTIAL_IP_LIMIT", 20)
+def _DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW() -> int:
+    return _get_setting("DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW", 900)
+
+
+def _DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT() -> int:
+    return _get_setting("DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT", 5)
+
+
+def _DJANGO_WAF_FORM_CREDENTIAL_IP_LIMIT() -> int:
+    return _get_setting("DJANGO_WAF_FORM_CREDENTIAL_IP_LIMIT", 20)
+
 
 # Signup-velocity settings. Counts *successful* signups per IP, so the
 # user crossing the threshold sees a challenge on their *next* attempt.
-DJANGO_WAF_FORM_SIGNUP_VELOCITY_WINDOW: int = getattr(settings, "DJANGO_WAF_FORM_SIGNUP_VELOCITY_WINDOW", 86400)
-DJANGO_WAF_FORM_SIGNUP_VELOCITY_LIMIT: int = getattr(settings, "DJANGO_WAF_FORM_SIGNUP_VELOCITY_LIMIT", 5)
+def _DJANGO_WAF_FORM_SIGNUP_VELOCITY_WINDOW() -> int:
+    return _get_setting("DJANGO_WAF_FORM_SIGNUP_VELOCITY_WINDOW", 86400)
+
+
+def _DJANGO_WAF_FORM_SIGNUP_VELOCITY_LIMIT() -> int:
+    return _get_setting("DJANGO_WAF_FORM_SIGNUP_VELOCITY_LIMIT", 5)
+
 
 # Form-level PoW difficulty (leading zero bits). Lighter than the
 # page-level challenge because it runs per-submission rather than once
-# per session. 12 bits ≈ 4k SHA-256 hashes ≈ 50ms desktop, ~200ms
-# mobile. Reuses the same _digest_has_leading_zero_bits verifier as
-# the page challenge (no parallel implementation, no drift risk).
-DJANGO_WAF_FORM_POW_DIFFICULTY: int = getattr(settings, "DJANGO_WAF_FORM_POW_DIFFICULTY", 12)
+# per session. 12 bits is about 4k SHA-256 hashes, about 50ms desktop,
+# about 200ms mobile. Reuses the same _digest_has_leading_zero_bits
+# verifier as the page challenge (no parallel implementation, no drift
+# risk).
+def _DJANGO_WAF_FORM_POW_DIFFICULTY() -> int:
+    return _get_setting("DJANGO_WAF_FORM_POW_DIFFICULTY", 12)
+
 
 # Replay-store backend. ``session`` uses Django's session framework
 # (signed cookie + server-side data); ``redis`` uses the same Redis
 # the rest of the WAF talks to. Most sites use session.
-DJANGO_WAF_FORM_REPLAY_STORE: str = getattr(settings, "DJANGO_WAF_FORM_REPLAY_STORE", "session")
+def _DJANGO_WAF_FORM_REPLAY_STORE() -> str:
+    return _get_setting("DJANGO_WAF_FORM_REPLAY_STORE", "session")
+
 
 # Global per-defence score weights. Overridable per-form via the
 # ``defence_weights={...}`` kwarg on ``FormProtection``. The dict
 # collapses what would otherwise be eight separate weight settings
 # into one declaration.
-DJANGO_WAF_FORM_DEFENCE_WEIGHTS: dict[str, float] = getattr(
-    settings,
-    "DJANGO_WAF_FORM_DEFENCE_WEIGHTS",
-    {
-        "honeypot": 5.0,
-        "time_trap": 2.0,
-        "render_token": 5.0,
-        "ua_consistency": 2.0,
-        "js_touch": 1.5,
-        "credential_throttle": 5.0,
-        "signup_velocity": 5.0,
-        "pow_gate": 5.0,
-    },
-)
+def _DJANGO_WAF_FORM_DEFENCE_WEIGHTS() -> dict[str, float]:
+    return _get_setting(
+        "DJANGO_WAF_FORM_DEFENCE_WEIGHTS",
+        {
+            "honeypot": 5.0,
+            "time_trap": 2.0,
+            "render_token": 5.0,
+            "ua_consistency": 2.0,
+            "js_touch": 1.5,
+            "credential_throttle": 5.0,
+            "signup_velocity": 5.0,
+            "pow_gate": 5.0,
+        },
+    )
 
-# Proof-of-work challenge difficulty — number of leading zero **bits** the
+
+# Proof-of-work challenge difficulty: number of leading zero **bits** the
 # SHA-256(token + nonce) digest must contain. Average solve cost is
 # ``2 ** difficulty`` hashes. This single value is the default and is
 # authoritative unless an operator explicitly overrides a device band below.
-DJANGO_WAF_CHALLENGE_DIFFICULTY: int = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY", 16)
+def _DJANGO_WAF_CHALLENGE_DIFFICULTY() -> int:
+    return _get_setting("DJANGO_WAF_CHALLENGE_DIFFICULTY", 16)
+
 
 # Desktop-class clients. Defaults to ``None``, which falls back to
 # ``DJANGO_WAF_CHALLENGE_DIFFICULTY``. Set an explicit value only to give
 # desktop clients a different (typically higher) cost than mobile.
-DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP: int | None = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP", None)
+def _DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP() -> int | None:
+    return _get_setting("DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP", None)
+
 
 # Mobile-class clients. Defaults to ``None``, which falls back to
 # ``DJANGO_WAF_CHALLENGE_DIFFICULTY``. Set an explicit value only to give
 # budget devices a lower cost than desktop.
-DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE: int | None = getattr(settings, "DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE", None)
+def _DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE() -> int | None:
+    return _get_setting("DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE", None)
+
 
 # Optional literal-path overrides for the WAF's own challenge/verify URLs.
 # When set, the middleware uses these strings directly instead of calling
 # ``reverse()``. Recommended for projects using per-request urlconf routing
 # (django-hosts and similar) that don't mount django_waf URLs on every host.
-DJANGO_WAF_CHALLENGE_URL: str = getattr(settings, "DJANGO_WAF_CHALLENGE_URL", "")
-DJANGO_WAF_VERIFY_URL: str = getattr(settings, "DJANGO_WAF_VERIFY_URL", "")
+def _DJANGO_WAF_CHALLENGE_URL() -> str:
+    return _get_setting("DJANGO_WAF_CHALLENGE_URL", "")
+
+
+def _DJANGO_WAF_VERIFY_URL() -> str:
+    return _get_setting("DJANGO_WAF_VERIFY_URL", "")
+
 
 # TTL in seconds for a solved-challenge cookie.
-DJANGO_WAF_CHALLENGE_COOKIE_TTL: int = getattr(settings, "DJANGO_WAF_CHALLENGE_COOKIE_TTL", 86400)
+def _DJANGO_WAF_CHALLENGE_COOKIE_TTL() -> int:
+    return _get_setting("DJANGO_WAF_CHALLENGE_COOKIE_TTL", 86400)
+
 
 # Maximum requests per IP per minute before throttling.
-DJANGO_WAF_RATE_LIMIT_PER_MINUTE: int = getattr(settings, "DJANGO_WAF_RATE_LIMIT_PER_MINUTE", 120)
+def _DJANGO_WAF_RATE_LIMIT_PER_MINUTE() -> int:
+    return _get_setting("DJANGO_WAF_RATE_LIMIT_PER_MINUTE", 120)
+
 
 # Maximum requests per IP per 5 minutes before throttling.
-DJANGO_WAF_RATE_LIMIT_PER_5MIN: int = getattr(settings, "DJANGO_WAF_RATE_LIMIT_PER_5MIN", 600)
+def _DJANGO_WAF_RATE_LIMIT_PER_5MIN() -> int:
+    return _get_setting("DJANGO_WAF_RATE_LIMIT_PER_5MIN", 600)
 
-# Burst allowance — requests that may exceed the rate limit momentarily.
-DJANGO_WAF_RATE_LIMIT_BURST: int = getattr(settings, "DJANGO_WAF_RATE_LIMIT_BURST", 10)
 
-# Fraction of allowed requests to log (0.0–1.0). 1.0 = log everything.
-DJANGO_WAF_LOG_SAMPLE_RATE: float = getattr(settings, "DJANGO_WAF_LOG_SAMPLE_RATE", 0.01)
+# Burst allowance: requests that may exceed the rate limit momentarily.
+def _DJANGO_WAF_RATE_LIMIT_BURST() -> int:
+    return _get_setting("DJANGO_WAF_RATE_LIMIT_BURST", 10)
+
+
+# Fraction of allowed requests to log (0.0 to 1.0). 1.0 = log everything.
+def _DJANGO_WAF_LOG_SAMPLE_RATE() -> float:
+    return _get_setting("DJANGO_WAF_LOG_SAMPLE_RATE", 0.01)
+
 
 # Filesystem path for the generated nginx IP/UA blocklist include file.
-DJANGO_WAF_NGINX_BLOCKLIST_PATH: str = getattr(
-    settings,
-    "DJANGO_WAF_NGINX_BLOCKLIST_PATH",
-    "/etc/nginx/conf.d/django-waf-blocklist.conf",
-)
+def _DJANGO_WAF_NGINX_BLOCKLIST_PATH() -> str:
+    return _get_setting(
+        "DJANGO_WAF_NGINX_BLOCKLIST_PATH",
+        "/etc/nginx/conf.d/django-waf-blocklist.conf",
+    )
+
 
 # Path to the nginx access log file parsed by the log-analysis command.
-DJANGO_WAF_ACCESS_LOG_PATH: str = getattr(
-    settings,
-    "DJANGO_WAF_ACCESS_LOG_PATH",
-    "/var/log/nginx/access.log",
-)
+def _DJANGO_WAF_ACCESS_LOG_PATH() -> str:
+    return _get_setting(
+        "DJANGO_WAF_ACCESS_LOG_PATH",
+        "/var/log/nginx/access.log",
+    )
+
 
 # Number of distinct user-agents from a single IP that triggers a UA-rotation anomaly.
-DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS: int = getattr(settings, "DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS", 20)
+def _DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS() -> int:
+    return _get_setting("DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS", 20)
+
 
 # Hours after which auto-generated rules expire automatically.
-DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS: int = getattr(settings, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24)
+def _DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS() -> int:
+    return _get_setting("DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24)
+
 
 # URL path prefixes that bypass WAF evaluation entirely.
-DJANGO_WAF_EXEMPT_PATHS: list[str] = getattr(
-    settings,
-    "DJANGO_WAF_EXEMPT_PATHS",
-    ["/static/", "/media/", "/health/", "/favicon.ico"],
-)
+def _DJANGO_WAF_EXEMPT_PATHS() -> list[str]:
+    return _get_setting(
+        "DJANGO_WAF_EXEMPT_PATHS",
+        ["/static/", "/media/", "/health/", "/favicon.ico"],
+    )
+
 
 # Hostnames that bypass WAF evaluation entirely. Matching mirrors Django's
 # ALLOWED_HOSTS convention: an exact host match, or a leading-dot entry
 # (".example.com") that matches the domain and any subdomain. The port is
 # stripped before matching. Empty by default (no host is exempt).
-DJANGO_WAF_EXEMPT_HOSTS: list[str] = getattr(
-    settings,
-    "DJANGO_WAF_EXEMPT_HOSTS",
-    [],
-)
+def _DJANGO_WAF_EXEMPT_HOSTS() -> list[str]:
+    return _get_setting(
+        "DJANGO_WAF_EXEMPT_HOSTS",
+        [],
+    )
+
 
 # Guarantee active, rDNS-gated AllowRules for the major verified search
 # crawlers (Googlebot, Bingbot), seeded by migration 0003 (ADR-035,
@@ -213,103 +323,135 @@ DJANGO_WAF_EXEMPT_HOSTS: list[str] = getattr(
 # sends), never solves the JS proof-of-work challenge, and is silently
 # deindexed. Default True fixes that footgun out of the box. Set to False to
 # opt out, or deactivate the seeded AllowRule rows directly.
-DJANGO_WAF_ALLOW_VERIFIED_CRAWLERS: bool = getattr(settings, "DJANGO_WAF_ALLOW_VERIFIED_CRAWLERS", True)
+def _DJANGO_WAF_ALLOW_VERIFIED_CRAWLERS() -> bool:
+    return _get_setting("DJANGO_WAF_ALLOW_VERIFIED_CRAWLERS", True)
+
 
 # TTL in seconds for a NEGATIVE forward-confirmed reverse DNS (FCrDNS)
-# verification result — a PTR/hostname pattern match that then failed the
+# verification result: a PTR/hostname pattern match that then failed the
 # forward-resolution check, or any DNS error on either lookup (#34). Kept
 # short (5 minutes) rather than the 24-hour positive-result TTL, because a
 # negative result can come from a transient resolver outage, and a long
 # negative cache would suppress a legitimate crawler's AllowRule match for
 # a full day per IP on every hiccup. A positive FCrDNS verification is
-# always cached for 24 hours, unaffected by this setting — legitimate
+# always cached for 24 hours, unaffected by this setting: legitimate
 # crawler infrastructure's DNS records change rarely.
-DJANGO_WAF_RDNS_FAILURE_CACHE_TTL: int = getattr(settings, "DJANGO_WAF_RDNS_FAILURE_CACHE_TTL", 300)
+def _DJANGO_WAF_RDNS_FAILURE_CACHE_TTL() -> int:
+    return _get_setting("DJANGO_WAF_RDNS_FAILURE_CACHE_TTL", 300)
+
 
 # Trust the X-Forwarded-For header when extracting the real client IP.
-DJANGO_WAF_TRUST_X_FORWARDED_FOR: bool = getattr(settings, "DJANGO_WAF_TRUST_X_FORWARDED_FOR", False)
+def _DJANGO_WAF_TRUST_X_FORWARDED_FOR() -> bool:
+    return _get_setting("DJANGO_WAF_TRUST_X_FORWARDED_FOR", False)
+
 
 # Django cache alias used for Redis rate-limit counters and rule-version keys.
-DJANGO_WAF_REDIS_ALIAS: str = getattr(settings, "DJANGO_WAF_REDIS_ALIAS", "default")
+def _DJANGO_WAF_REDIS_ALIAS() -> str:
+    return _get_setting("DJANGO_WAF_REDIS_ALIAS", "default")
+
 
 # Enable syncing rules from the collective threat feed.
-DJANGO_WAF_FEED_ENABLED: bool = getattr(settings, "DJANGO_WAF_FEED_ENABLED", True)
+def _DJANGO_WAF_FEED_ENABLED() -> bool:
+    return _get_setting("DJANGO_WAF_FEED_ENABLED", True)
+
 
 # URL of the collective threat feed JSON endpoint. Points at the operated
 # feed server (threats.drystane.com); override for a self-hosted or
 # third-party compatible server.
-DJANGO_WAF_FEED_URL: str = getattr(settings, "DJANGO_WAF_FEED_URL", "https://threats.drystane.com/v1/feed.json")
+def _DJANGO_WAF_FEED_URL() -> str:
+    return _get_setting("DJANGO_WAF_FEED_URL", "https://threats.drystane.com/v1/feed.json")
 
-# Minimum confidence score (0.0–1.0) required to import a feed entry as a rule.
-DJANGO_WAF_FEED_MIN_CONFIDENCE: float = getattr(settings, "DJANGO_WAF_FEED_MIN_CONFIDENCE", 0.8)
+
+# Minimum confidence score (0.0 to 1.0) required to import a feed entry as a rule.
+def _DJANGO_WAF_FEED_MIN_CONFIDENCE() -> float:
+    return _get_setting("DJANGO_WAF_FEED_MIN_CONFIDENCE", 0.8)
+
 
 # Enable reporting local detections back to the collective feed. Opt-in by
 # design (ADR-021 point 4): telemetry is never sent unless an operator sets
 # this to True, regardless of whether DJANGO_WAF_FEED_REPORT_URL is
 # configured. Setting this to True is the only step a site needs to start
 # reporting.
-DJANGO_WAF_FEED_REPORT: bool = getattr(settings, "DJANGO_WAF_FEED_REPORT", False)
+def _DJANGO_WAF_FEED_REPORT() -> bool:
+    return _get_setting("DJANGO_WAF_FEED_REPORT", False)
+
 
 # URL for reporting detections to the collective feed. Points at the
 # operated feed server (threats.drystane.com); override for a self-hosted
 # or third-party compatible server.
-DJANGO_WAF_FEED_REPORT_URL: str = getattr(
-    settings, "DJANGO_WAF_FEED_REPORT_URL", "https://threats.drystane.com/v1/report"
-)
+def _DJANGO_WAF_FEED_REPORT_URL() -> str:
+    return _get_setting("DJANGO_WAF_FEED_REPORT_URL", "https://threats.drystane.com/v1/report")
+
 
 # API key for authenticating with the collective threat feed.
-DJANGO_WAF_FEED_API_KEY: str = getattr(settings, "DJANGO_WAF_FEED_API_KEY", "")
+def _DJANGO_WAF_FEED_API_KEY() -> str:
+    return _get_setting("DJANGO_WAF_FEED_API_KEY", "")
+
 
 # Number of days to retain RequestLog entries before purging.
-DJANGO_WAF_LOG_RETENTION_DAYS: int = getattr(settings, "DJANGO_WAF_LOG_RETENTION_DAYS", 30)
+def _DJANGO_WAF_LOG_RETENTION_DAYS() -> int:
+    return _get_setting("DJANGO_WAF_LOG_RETENTION_DAYS", 30)
+
 
 # Path to the nginx PID file. When set, reload_nginx() sends SIGHUP to the
-# master process directly — no subprocess, no sudo, no PATH required. Just
+# master process directly: no subprocess, no sudo, no PATH required. Just
 # needs read access to the PID file. Set to None to use the command fallback.
-DJANGO_WAF_NGINX_PID_PATH: str | None = getattr(
-    settings,
-    "DJANGO_WAF_NGINX_PID_PATH",
-    "/run/nginx.pid",
-)
+def _DJANGO_WAF_NGINX_PID_PATH() -> str | None:
+    return _get_setting(
+        "DJANGO_WAF_NGINX_PID_PATH",
+        "/run/nginx.pid",
+    )
+
 
 # Fallback command for nginx reload (used when DJANGO_WAF_NGINX_PID_PATH is None
 # or the PID file is unreadable).
-DJANGO_WAF_NGINX_RELOAD_COMMAND: list[str] = getattr(
-    settings,
-    "DJANGO_WAF_NGINX_RELOAD_COMMAND",
-    ["nginx", "-s", "reload"],
-)
+def _DJANGO_WAF_NGINX_RELOAD_COMMAND() -> list[str]:
+    return _get_setting(
+        "DJANGO_WAF_NGINX_RELOAD_COMMAND",
+        ["nginx", "-s", "reload"],
+    )
+
 
 # Path prefixes exempt from no-referer challenge (only evaluated when
 # DJANGO_WAF_CHALLENGE_NO_REFERER is True).
-DJANGO_WAF_CHALLENGE_NO_REFERER: bool = getattr(settings, "DJANGO_WAF_CHALLENGE_NO_REFERER", False)
-DJANGO_WAF_NO_REFERER_EXEMPT_PATHS: list[str] = getattr(
-    settings,
-    "DJANGO_WAF_NO_REFERER_EXEMPT_PATHS",
-    ["/", "/search/", "/robots.txt", "/sitemap.xml", "/favicon.ico"],
-)
+def _DJANGO_WAF_CHALLENGE_NO_REFERER() -> bool:
+    return _get_setting("DJANGO_WAF_CHALLENGE_NO_REFERER", False)
+
+
+def _DJANGO_WAF_NO_REFERER_EXEMPT_PATHS() -> list[str]:
+    return _get_setting(
+        "DJANGO_WAF_NO_REFERER_EXEMPT_PATHS",
+        ["/", "/search/", "/robots.txt", "/sitemap.xml", "/favicon.ico"],
+    )
+
 
 # Path to a MaxMind GeoLite2-Country.mmdb database for GeoIP lookups.
 # Set to None to disable GeoIP (default).
-DJANGO_WAF_GEOIP_PATH: str | None = getattr(settings, "DJANGO_WAF_GEOIP_PATH", None)
+def _DJANGO_WAF_GEOIP_PATH() -> str | None:
+    return _get_setting("DJANGO_WAF_GEOIP_PATH", None)
+
 
 # MaxMind licence key for downloading GeoLite2 databases via the
 # ``manage.py django_waf_install_geoip`` command or the
 # ``update_geoip_database`` Celery task. Sign up for a free key at
 # https://www.maxmind.com/en/geolite2/signup and load it from your
 # environment (e.g. ``os.environ.get("MAXMIND_LICENSE_KEY", "")``).
-DJANGO_WAF_MAXMIND_LICENSE_KEY: str = getattr(settings, "DJANGO_WAF_MAXMIND_LICENSE_KEY", "")
+def _DJANGO_WAF_MAXMIND_LICENSE_KEY() -> str:
+    return _get_setting("DJANGO_WAF_MAXMIND_LICENSE_KEY", "")
+
 
 # HTTP methods allowed through the WAF. Requests with other methods receive
 # a 405 response before any rule evaluation. Set to None to allow all methods.
-DJANGO_WAF_ALLOWED_METHODS: list[str] | None = getattr(settings, "DJANGO_WAF_ALLOWED_METHODS", None)
+def _DJANGO_WAF_ALLOWED_METHODS() -> list[str] | None:
+    return _get_setting("DJANGO_WAF_ALLOWED_METHODS", None)
+
 
 # Regex patterns for suspicious paths (credential probes, known webshells,
 # backup archives, and vendor-specific exploit targets).
 #
 # Each matched pattern adds DJANGO_WAF_SUSPICIOUS_PATH_SCORE to the request's
 # anomaly score. Patterns are picked so that a legitimate user on a Django
-# site is extremely unlikely to trigger them — any match is a strong signal.
+# site is extremely unlikely to trigger them: any match is a strong signal.
 #
 # Patterns that would overlap legitimate apps (``.ini``, ``.conf``, ``.aspx``,
 # ``.jsp``, ``/cgi-bin/``) are intentionally omitted to keep the
@@ -317,72 +459,81 @@ DJANGO_WAF_ALLOWED_METHODS: list[str] | None = getattr(settings, "DJANGO_WAF_ALL
 #
 # Patterns use re.search (anywhere-in-path, case-insensitive). Anchor with
 # ^ or $ when position matters.
-DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS: list[str] = getattr(
-    settings,
-    "DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS",
-    [
-        # Environment and secrets files
-        r"\.env",
-        r"\.aws",
-        r"\.ssh",
-        r"id_rsa",
-        r"id_dsa",
-        r"\.pem$",
-        r"\.key$",
-        r"credentials",
-        r"\.bash_history",
-        r"\.zsh_history",
-        # Config files (framework-specific — avoid broad ``.conf``/``.ini``)
-        r"wp-config\.php",
-        r"config\.php",
-        r"settings\.py",
-        r"/admin/config",
-        r"\.yml$",
-        r"\.yaml$",
-        # Version control exposure
-        r"\.git",
-        r"\.svn",
-        r"\.hg",
-        # Database and backup artefacts
-        r"\.sql$",
-        r"\.sql\.gz$",
-        r"\.bak$",
-        r"\.backup$",
-        r"dump\.sql",
-        r"backup\.zip",
-        r"db\.sqlite",
-        # WordPress exploit targets
-        r"wp-admin",
-        r"wp-login",
-        r"xmlrpc\.php",
-        # Generic webshells (named explicitly — avoid broad plugin/upload
-        # wildcards that would catch legitimate WP sites)
-        r"shell\.php",
-        r"alfa.*\.php",
-        r"r57\.php",
-        r"c99\.php",
-        r"filemanager\.php",
-        r"webshell",
-        r"cmd\.php",
-        r"/eval\.php",
-        # Information disclosure
-        r"phpinfo",
-        r"phpmyadmin",
-        r"/server-status",
-        r"/server-info",
-        # IoT / vendor exploits (path-anchored to avoid colliding with
-        # legitimate /onvif-meeting-room-booking etc.)
-        r"/onvif/",
-        r"/boaform/",
-        r"/HNAP1",
-        r"/goform/",
-    ],
-)
+def _DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS() -> list[str]:
+    return _get_setting(
+        "DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS",
+        [
+            # Environment and secrets files
+            r"\.env",
+            r"\.aws",
+            r"\.ssh",
+            r"id_rsa",
+            r"id_dsa",
+            r"\.pem$",
+            r"\.key$",
+            r"credentials",
+            r"\.bash_history",
+            r"\.zsh_history",
+            # Config files (framework-specific: avoid broad ``.conf``/``.ini``)
+            r"wp-config\.php",
+            r"config\.php",
+            r"settings\.py",
+            r"/admin/config",
+            r"\.yml$",
+            r"\.yaml$",
+            # Version control exposure
+            r"\.git",
+            r"\.svn",
+            r"\.hg",
+            # Database and backup artefacts
+            r"\.sql$",
+            r"\.sql\.gz$",
+            r"\.bak$",
+            r"\.backup$",
+            r"dump\.sql",
+            r"backup\.zip",
+            r"db\.sqlite",
+            # WordPress exploit targets
+            r"wp-admin",
+            r"wp-login",
+            r"xmlrpc\.php",
+            # Generic webshells (named explicitly: avoid broad plugin/upload
+            # wildcards that would catch legitimate WP sites)
+            r"shell\.php",
+            r"alfa.*\.php",
+            r"r57\.php",
+            r"c99\.php",
+            r"filemanager\.php",
+            r"webshell",
+            r"cmd\.php",
+            r"/eval\.php",
+            # Information disclosure
+            r"phpinfo",
+            r"phpmyadmin",
+            r"/server-status",
+            r"/server-info",
+            # IoT / vendor exploits (path-anchored to avoid colliding with
+            # legitimate /onvif-meeting-room-booking etc.)
+            r"/onvif/",
+            r"/boaform/",
+            r"/HNAP1",
+            r"/goform/",
+        ],
+    )
+
 
 # Anomaly score thresholds for verdict escalation.
-DJANGO_WAF_SCORE_THRESHOLD_LOG: float = getattr(settings, "DJANGO_WAF_SCORE_THRESHOLD_LOG", 3.0)
-DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE: float = getattr(settings, "DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE", 5.0)
-DJANGO_WAF_SCORE_THRESHOLD_BLOCK: float = getattr(settings, "DJANGO_WAF_SCORE_THRESHOLD_BLOCK", 7.0)
+def _DJANGO_WAF_SCORE_THRESHOLD_LOG() -> float:
+    return _get_setting("DJANGO_WAF_SCORE_THRESHOLD_LOG", 3.0)
+
+
+def _DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE() -> float:
+    return _get_setting("DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE", 5.0)
+
+
+def _DJANGO_WAF_SCORE_THRESHOLD_BLOCK() -> float:
+    return _get_setting("DJANGO_WAF_SCORE_THRESHOLD_BLOCK", 7.0)
+
 
 # Number of challenges from a single IP before auto-escalating from
 # challenge to block. From 2.0.0, this counts challenges issued to a
@@ -391,29 +542,46 @@ DJANGO_WAF_SCORE_THRESHOLD_BLOCK: float = getattr(settings, "DJANGO_WAF_SCORE_TH
 # CPU solves hashcash almost for free, so a bot that solves every challenge
 # no longer resets the count to zero. For every other fingerprint verdict,
 # a solved challenge still resets the count, unchanged from before 2.0.0.
-DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD: int = getattr(settings, "DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD", 10)
+def _DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD() -> int:
+    return _get_setting("DJANGO_WAF_CHALLENGE_ESCALATION_THRESHOLD", 10)
+
 
 # Score added per suspicious path match.
-DJANGO_WAF_SUSPICIOUS_PATH_SCORE: float = getattr(settings, "DJANGO_WAF_SUSPICIOUS_PATH_SCORE", 3.0)
+def _DJANGO_WAF_SUSPICIOUS_PATH_SCORE() -> float:
+    return _get_setting("DJANGO_WAF_SUSPICIOUS_PATH_SCORE", 3.0)
+
 
 # TTL in seconds for escalation blocks (challenges that were never solved).
-DJANGO_WAF_ESCALATION_BLOCK_TTL: int = getattr(settings, "DJANGO_WAF_ESCALATION_BLOCK_TTL", 3600)
+def _DJANGO_WAF_ESCALATION_BLOCK_TTL() -> int:
+    return _get_setting("DJANGO_WAF_ESCALATION_BLOCK_TTL", 3600)
+
 
 # Cloud spray detection: many distinct IPs with identical behaviour.
-DJANGO_WAF_CLOUD_SPRAY_MIN_IPS: int = getattr(settings, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 20)
-DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP: int = getattr(settings, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3)
+def _DJANGO_WAF_CLOUD_SPRAY_MIN_IPS() -> int:
+    return _get_setting("DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 20)
+
+
+def _DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP() -> int:
+    return _get_setting("DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3)
+
 
 # Per-path rate limits: {path_prefix: (max_requests, window_seconds)}.
 # Longest-prefix match wins; checked before the global IP windows.
-DJANGO_WAF_RATE_LIMIT_PATHS: dict = getattr(settings, "DJANGO_WAF_RATE_LIMIT_PATHS", {})
+def _DJANGO_WAF_RATE_LIMIT_PATHS() -> dict:
+    return _get_setting("DJANGO_WAF_RATE_LIMIT_PATHS", {})
+
 
 # ISO 3166-1 alpha-2 country codes to block outright (e.g. ["CN", "RU"]).
 # Empty disables country blocking. Requires a GeoIP database (see
 # django_waf_install_geoip); fails open when lookup is unavailable.
-DJANGO_WAF_BLOCKED_COUNTRIES: list = getattr(settings, "DJANGO_WAF_BLOCKED_COUNTRIES", [])
+def _DJANGO_WAF_BLOCKED_COUNTRIES() -> list:
+    return _get_setting("DJANGO_WAF_BLOCKED_COUNTRIES", [])
+
 
 # Enable the optional DRF API under waf/api/ (requires the [api] extra).
-DJANGO_WAF_API_ENABLED: bool = getattr(settings, "DJANGO_WAF_API_ENABLED", False)
+def _DJANGO_WAF_API_ENABLED() -> bool:
+    return _get_setting("DJANGO_WAF_API_ENABLED", False)
+
 
 # ---------------------------------------------------------------------------
 # Site password gate (BR-SP series)
@@ -422,51 +590,66 @@ DJANGO_WAF_API_ENABLED: bool = getattr(settings, "DJANGO_WAF_API_ENABLED", False
 # subdomain it serves) before any application view. See
 # docs/specs/site-password/PRD.md.
 
+
 # The shared password. Unset/empty means the gate is off (BR-SP-001).
 # Never rendered, never logged (BR-SP-005). Load from environment in
 # production.
-DJANGO_WAF_SITE_PASSWORD: str = getattr(settings, "DJANGO_WAF_SITE_PASSWORD", "")
+def _DJANGO_WAF_SITE_PASSWORD() -> str:
+    return _get_setting("DJANGO_WAF_SITE_PASSWORD", "")
+
 
 # Explicit on/off switch. Defaults to whether a password is set. Enabling
 # this with an empty password fails closed rather than opening the gate
-# (BR-SP-002) -- every gated request is denied and a system check warns at
+# (BR-SP-002): every gated request is denied and a system check warns at
 # boot (django_waf.checks.check_site_password_configured).
-DJANGO_WAF_SITE_PASSWORD_ENABLED: bool = getattr(
-    settings, "DJANGO_WAF_SITE_PASSWORD_ENABLED", bool(DJANGO_WAF_SITE_PASSWORD)
-)
+#
+# The default recurses through the resolver for DJANGO_WAF_SITE_PASSWORD
+# rather than reading a frozen value: this is the one intra-conf
+# cross-reference among all 92 settings, and it must reflect whatever
+# DJANGO_WAF_SITE_PASSWORD resolves to on THIS call, not whatever it
+# happened to resolve to at import time (BR-SP-002's fail-closed guarantee
+# depends on this).
+def _DJANGO_WAF_SITE_PASSWORD_ENABLED() -> bool:
+    return _get_setting("DJANGO_WAF_SITE_PASSWORD_ENABLED", bool(_DJANGO_WAF_SITE_PASSWORD()))
+
 
 # Verified-session lifetime in seconds. Default 12 hours (BR-SP-004).
-DJANGO_WAF_SITE_PASSWORD_TTL: int = getattr(settings, "DJANGO_WAF_SITE_PASSWORD_TTL", 43200)
+def _DJANGO_WAF_SITE_PASSWORD_TTL() -> int:
+    return _get_setting("DJANGO_WAF_SITE_PASSWORD_TTL", 43200)
+
 
 # Path prefixes that bypass the gate even when locked (BR-SP-003): health
 # checks, ACME/well-known probes, robots.txt, and the WAF's own
 # challenge/verify interstitials (so the WAF's existing defences keep
 # working and the site-password gate never traps its own prompt-and-verify
 # round trip in a loop).
-DJANGO_WAF_SITE_PASSWORD_EXEMPT_PATHS: list[str] = getattr(
-    settings,
-    "DJANGO_WAF_SITE_PASSWORD_EXEMPT_PATHS",
-    ["/health/", "/.well-known/", "/robots.txt", "/waf/challenge/", "/waf/verify/"],
-)
+def _DJANGO_WAF_SITE_PASSWORD_EXEMPT_PATHS() -> list[str]:
+    return _get_setting(
+        "DJANGO_WAF_SITE_PASSWORD_EXEMPT_PATHS",
+        ["/health/", "/.well-known/", "/robots.txt", "/waf/challenge/", "/waf/verify/"],
+    )
+
 
 # Path the prompt form posts to. The middleware intercepts POSTs to this
 # path directly (before URL resolution), so it works even on hosts that
-# don't mount django_waf.urls -- but the same path is also routed in
+# don't mount django_waf.urls, but the same path is also routed in
 # urls.py so reverse() and direct access resolve to a real view.
-DJANGO_WAF_SITE_PASSWORD_VERIFY_PATH: str = getattr(
-    settings, "DJANGO_WAF_SITE_PASSWORD_VERIFY_PATH", "/waf/site-password/"
-)
+def _DJANGO_WAF_SITE_PASSWORD_VERIFY_PATH() -> str:
+    return _get_setting("DJANGO_WAF_SITE_PASSWORD_VERIFY_PATH", "/waf/site-password/")
+
 
 # Domain for the gate's own verified-flag cookie (see
-# django_waf.services.site_password_service -- the gate uses its own signed
+# django_waf.services.site_password_service, the gate uses its own signed
 # cookie, not Django's session, because WafMiddleware runs before
 # SessionMiddleware). Defaults to None, which means
 # site_password_service.set_verified_cookie() falls back to
-# settings.SESSION_COOKIE_DOMAIN at call time -- so a site that already sets
+# settings.SESSION_COOKIE_DOMAIN at call time, so a site that already sets
 # SESSION_COOKIE_DOMAIN=".example.com" for subdomain coverage gets the same
 # coverage on this cookie without configuring it twice. Set explicitly only
 # when the gate's subdomain scope must differ from the session cookie's.
-DJANGO_WAF_SITE_PASSWORD_COOKIE_DOMAIN: str | None = getattr(settings, "DJANGO_WAF_SITE_PASSWORD_COOKIE_DOMAIN", None)
+def _DJANGO_WAF_SITE_PASSWORD_COOKIE_DOMAIN() -> str | None:
+    return _get_setting("DJANGO_WAF_SITE_PASSWORD_COOKIE_DOMAIN", None)
+
 
 # ---------------------------------------------------------------------------
 # Celery Beat schedule helper
@@ -540,24 +723,34 @@ if crontab is not None:
         },
     }
 else:
-    # celery is not installed — the cron-time entries above need
+    # celery is not installed: the cron-time entries above need
     # crontab() to build a schedule, so they are omitted rather than
     # guessed at with a plain interval. The */N minute entries above still
     # work fine as they don't touch crontab at all.
     _CELERY_BEAT_CRON_ENTRIES = {}
 
+
 # Ready-made CELERY_BEAT_SCHEDULE fragment covering every periodic
 # django-waf task. See the module docstring above this block for usage.
-DJANGO_WAF_CELERY_BEAT_SCHEDULE: dict = getattr(
-    settings,
-    "DJANGO_WAF_CELERY_BEAT_SCHEDULE",
-    {**_CELERY_BEAT_INTERVAL_ENTRIES, **_CELERY_BEAT_CRON_ENTRIES},
-)
+#
+# Resolves to the merged default whenever Django settings are not yet
+# configured (the general contract documented at the top of this module),
+# which is what makes the README's documented consumer pattern,
+# ``from django_waf.conf import DJANGO_WAF_CELERY_BEAT_SCHEDULE`` inside a
+# settings module, before that settings module has finished executing,
+# safe rather than a hard ``ImproperlyConfigured`` boot failure.
+def _DJANGO_WAF_CELERY_BEAT_SCHEDULE() -> dict:
+    return _get_setting(
+        "DJANGO_WAF_CELERY_BEAT_SCHEDULE",
+        {**_CELERY_BEAT_INTERVAL_ENTRIES, **_CELERY_BEAT_CRON_ENTRIES},
+    )
+
 
 # ---------------------------------------------------------------------------
 # Client IP resolution (#29)
 # ---------------------------------------------------------------------------
 # See django_waf.services.client_ip for the resolver these settings feed.
+
 
 # CIDR strings identifying reverse proxies allowed to set X-Forwarded-For.
 # When REMOTE_ADDR falls inside one of these ranges, the resolver honours
@@ -568,13 +761,17 @@ DJANGO_WAF_CELERY_BEAT_SCHEDULE: dict = getattr(
 # replacement for that setting and should be preferred in any deployment
 # that sits behind a known reverse-proxy layer (e.g. ["10.0.0.0/8"] for an
 # internal load balancer, or the exact /32 of a single fronting proxy).
-DJANGO_WAF_TRUSTED_PROXIES: list[str] = getattr(settings, "DJANGO_WAF_TRUSTED_PROXIES", [])
+def _DJANGO_WAF_TRUSTED_PROXIES() -> list[str]:
+    return _get_setting("DJANGO_WAF_TRUSTED_PROXIES", [])
+
 
 # Trust an empty REMOTE_ADDR from a unix-socket WSGI peer as the direct proxy
 # hop. This is deliberately opt-in: an operator must ensure that only their
 # reverse proxy can connect to the socket before the X-Forwarded-For header is
 # honoured.
-DJANGO_WAF_TRUSTED_UNIX_SOCKET: bool = getattr(settings, "DJANGO_WAF_TRUSTED_UNIX_SOCKET", False)
+def _DJANGO_WAF_TRUSTED_UNIX_SOCKET() -> bool:
+    return _get_setting("DJANGO_WAF_TRUSTED_UNIX_SOCKET", False)
+
 
 # ---------------------------------------------------------------------------
 # Threat-feed import constraints (#33)
@@ -583,7 +780,9 @@ DJANGO_WAF_TRUSTED_UNIX_SOCKET: bool = getattr(settings, "DJANGO_WAF_TRUSTED_UNI
 # imported inactive (is_active=False), so a compromised or mistaken feed
 # cannot open an exemption without an operator confirming it. Set False only
 # if you fully trust the feed source to publish allow rules.
-DJANGO_WAF_FEED_QUARANTINE_ALLOW_RULES: bool = getattr(settings, "DJANGO_WAF_FEED_QUARANTINE_ALLOW_RULES", True)
+def _DJANGO_WAF_FEED_QUARANTINE_ALLOW_RULES() -> bool:
+    return _get_setting("DJANGO_WAF_FEED_QUARANTINE_ALLOW_RULES", True)
+
 
 # ---------------------------------------------------------------------------
 # nginx blocklist export validation (#31)
@@ -594,12 +793,16 @@ DJANGO_WAF_FEED_QUARANTINE_ALLOW_RULES: bool = getattr(settings, "DJANGO_WAF_FEE
 # generated file cannot break a later full nginx restart. If the nginx
 # binary is absent the validation step is skipped gracefully. Set False to
 # restore the pre-1.7.0 write-then-reload behaviour without validation.
-DJANGO_WAF_NGINX_VALIDATE: bool = getattr(settings, "DJANGO_WAF_NGINX_VALIDATE", True)
+def _DJANGO_WAF_NGINX_VALIDATE() -> bool:
+    return _get_setting("DJANGO_WAF_NGINX_VALIDATE", True)
+
 
 # The command run to validate the candidate configuration. Defaults to a
 # plain syntax check; override if nginx is not on PATH or needs a specific
 # prefix (e.g. ["sudo", "nginx", "-t"]).
-DJANGO_WAF_NGINX_TEST_COMMAND: list[str] = getattr(settings, "DJANGO_WAF_NGINX_TEST_COMMAND", ["nginx", "-t"])
+def _DJANGO_WAF_NGINX_TEST_COMMAND() -> list[str]:
+    return _get_setting("DJANGO_WAF_NGINX_TEST_COMMAND", ["nginx", "-t"])
+
 
 # ---------------------------------------------------------------------------
 # Anomaly detector review-before-enforce (#45/#46/#47/#48)
@@ -614,7 +817,9 @@ DJANGO_WAF_NGINX_TEST_COMMAND: list[str] = getattr(settings, "DJANGO_WAF_NGINX_T
 # quarantine-first would silently stop enforcement on every upgrade with no
 # code change on the consumer's side. A site that wants approve-before-
 # enforce sets this explicitly.
-DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES: bool = getattr(settings, "DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES", False)
+def _DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES() -> bool:
+    return _get_setting("DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES", False)
+
 
 # Detector function names (e.g. ["detect_cloud_spray"]) that must always
 # create quarantined rules (is_active=False, review_status=PENDING),
@@ -624,9 +829,9 @@ DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES: bool = getattr(settings, "DJANGO_WAF_A
 # caught at boot by django_waf.checks.check_observe_only_detector_names
 # (django_waf.W008), so a detector rename cannot silently desync this list
 # from the functions it names.
-DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS: list[str] = getattr(
-    settings, "DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS", []
-)
+def _DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS() -> list[str]:
+    return _get_setting("DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS", [])
+
 
 # ---------------------------------------------------------------------------
 # Trusted-user cookie (#23)
@@ -634,12 +839,13 @@ DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS: list[str] = getattr(
 # A signed, WAF-owned cookie that carries "this request is from a trusted
 # (staff) user" independently of request.user, so the staff/superuser bypass
 # (BR-RATE-003, django_waf.middleware._is_staff_user) works even when
-# WafMiddleware runs before django.contrib.auth.middleware.AuthenticationMiddleware
-# -- the security-first ordering the WAF's own README recommends, and the
+# WafMiddleware runs before django.contrib.auth.middleware.AuthenticationMiddleware,
+# the security-first ordering the WAF's own README recommends, and the
 # ordering django_waf.checks.check_middleware_ordering (django_waf.W004) has
 # historically warned against. See docs/DESIGN-trusted-user-cookie.md and
 # django_waf.services.trusted_user_service, which mirrors
 # django_waf.services.site_password_service's TimestampSigner pattern.
+
 
 # Master switch. Off by default (opt-in): existing sites see no behaviour
 # change, and no stray cookie can grant the bypass, until a project both
@@ -647,7 +853,9 @@ DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS: list[str] = getattr(
 # django_waf.receivers / DjangoWafConfig.ready()). Read live (not cached) by
 # django_waf.services.trusted_user_service.is_feature_enabled() so tests can
 # toggle it with patch.object without a module reload.
-DJANGO_WAF_TRUSTED_COOKIE_ENABLED: bool = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_ENABLED", False)
+def _DJANGO_WAF_TRUSTED_COOKIE_ENABLED() -> bool:
+    return _get_setting("DJANGO_WAF_TRUSTED_COOKIE_ENABLED", False)
+
 
 # Which users the login receiver issues the cookie to. "staff" (default)
 # limits the bypass to the same population the pre-existing request.user
@@ -657,9 +865,11 @@ DJANGO_WAF_TRUSTED_COOKIE_ENABLED: bool = getattr(settings, "DJANGO_WAF_TRUSTED_
 # other value is treated as "staff" by the receiver (fails to the narrower,
 # safer population) and is flagged by a system check
 # (django_waf.checks.check_trusted_cookie_trust_level, django_waf.W006).
-DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL: str = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL", "staff")
+def _DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL() -> str:
+    return _get_setting("DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL", "staff")
 
-# Cookie lifetime in seconds. Default 3600 (1 hour) -- deliberately SHORT.
+
+# Cookie lifetime in seconds. Default 3600 (1 hour), deliberately SHORT.
 # Unlike the site-password verified cookie (a low-value "is this visitor
 # allowed to see the site at all" flag with a 12-hour default), this cookie
 # grants a security-relevant bypass of WAF evaluation, so a stolen cookie is
@@ -667,16 +877,20 @@ DJANGO_WAF_TRUSTED_COOKIE_TRUST_LEVEL: str = getattr(settings, "DJANGO_WAF_TRUST
 # cookie also binds to the client IP (see trusted_user_service), which
 # further limits a stolen cookie's value but does not eliminate it entirely
 # on shared/NAT'd networks, hence the short TTL as the primary control.
-DJANGO_WAF_TRUSTED_COOKIE_TTL: int = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_TTL", 3600)
+def _DJANGO_WAF_TRUSTED_COOKIE_TTL() -> int:
+    return _get_setting("DJANGO_WAF_TRUSTED_COOKIE_TTL", 3600)
+
 
 # Domain for the trusted-user cookie. Defaults to None, which means
 # trusted_user_service.set_trusted_cookie() falls back to
-# settings.SESSION_COOKIE_DOMAIN at call time -- the same fallback
+# settings.SESSION_COOKIE_DOMAIN at call time, the same fallback
 # convention as DJANGO_WAF_SITE_PASSWORD_COOKIE_DOMAIN, so a site that
 # already sets SESSION_COOKIE_DOMAIN for subdomain coverage gets the same
 # coverage on this cookie without configuring it twice. Set explicitly only
 # when this cookie's subdomain scope must differ from the session cookie's.
-DJANGO_WAF_TRUSTED_COOKIE_DOMAIN: str | None = getattr(settings, "DJANGO_WAF_TRUSTED_COOKIE_DOMAIN", None)
+def _DJANGO_WAF_TRUSTED_COOKIE_DOMAIN() -> str | None:
+    return _get_setting("DJANGO_WAF_TRUSTED_COOKIE_DOMAIN", None)
+
 
 # ---------------------------------------------------------------------------
 # detect_subnet_burst (issue #80)
@@ -704,9 +918,10 @@ DJANGO_WAF_TRUSTED_COOKIE_DOMAIN: str | None = getattr(settings, "DJANGO_WAF_TRU
 # default window's typical single-subnet volume on a low-traffic
 # deployment, while still requiring more than a handful of incidental
 # requests before a subnet can be flagged at all.
-DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT: int = getattr(
-    settings, "DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT", 30
-)
+def _DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT() -> int:
+    return _get_setting("DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT", 30)
+
+
 # detect_unsolved_challenges (issue #84)
 # ---------------------------------------------------------------------------
 # Traced against a live deployment: an attacker rotating roughly 120
@@ -714,9 +929,10 @@ DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT: int = getattr(
 # at a rate that is unmistakable in aggregate but invisible per IP. Reading
 # these values from settings, not only the function's own parameter
 # defaults, lets an operator tune the detector without calling it directly.
-# Per #75 (still open), every value here is a conf.py import-time snapshot:
-# tests overriding it must use patch.object(conf, "NAME", ...), not
-# override_settings, or the override will not be seen.
+# From #75, every value here is resolved at call time like every other
+# setting in this module: an override via override_settings or the pytest
+# settings fixture is seen without any reload.
+
 
 # Minimum challenged verdicts a single IP must accumulate within the
 # detection window before it is considered a candidate. Unchanged from the
@@ -724,14 +940,18 @@ DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT: int = getattr(
 # bottleneck for the IPs that reached it (3 of 3 survivors passed every
 # later check). The problem is that almost no individual IP reaches it at
 # all when the attacker spreads across a /24.
-DJANGO_WAF_UNSOLVED_MIN_CHALLENGED: int = getattr(settings, "DJANGO_WAF_UNSOLVED_MIN_CHALLENGED", 3)
+def _DJANGO_WAF_UNSOLVED_MIN_CHALLENGED() -> int:
+    return _get_setting("DJANGO_WAF_UNSOLVED_MIN_CHALLENGED", 3)
+
 
 # Fraction of an IP's non-root requests that must carry an empty referer
 # before the per-IP path flags it. Unchanged from the pre-#84 function
 # default: traced live, this rejected nobody among the survivors, so it is
 # not the current bottleneck (kept as a safety margin for when the
 # candidate pool grows, per the issue's false-positive discipline).
-DJANGO_WAF_UNSOLVED_REFERER_RATIO: float = getattr(settings, "DJANGO_WAF_UNSOLVED_REFERER_RATIO", 0.8)
+def _DJANGO_WAF_UNSOLVED_REFERER_RATIO() -> float:
+    return _get_setting("DJANGO_WAF_UNSOLVED_REFERER_RATIO", 0.8)
+
 
 # How far back to look for a SOLVED ChallengeToken before granting an IP (or
 # a subnet, see DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS below) permanent immunity
@@ -742,9 +962,9 @@ DJANGO_WAF_UNSOLVED_REFERER_RATIO: float = getattr(settings, "DJANGO_WAF_UNSOLVE
 # detector's own 60-minute default window (a recent, deliberate solve still
 # exempts the IP for a full day) while no longer letting a solve from weeks
 # or months ago paper over current abandonment behaviour.
-DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS: int = getattr(
-    settings, "DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS", 24
-)
+def _DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS() -> int:
+    return _get_setting("DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS", 24)
+
 
 # Minimum total challenged-verdict count across an entire /24 (IPv4) or /48
 # (IPv6) subnet before the subnet itself becomes a candidate. Necessarily
@@ -754,7 +974,9 @@ DJANGO_WAF_UNSOLVED_SOLVE_EXEMPTION_WINDOW_HOURS: int = getattr(
 # challenged 3 times each (the per-IP threshold) would already qualify,
 # while a handful of genuine visitors sharing a /24 who each abandon one
 # or two challenges does not.
-DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED: int = getattr(settings, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30)
+def _DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED() -> int:
+    return _get_setting("DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30)
+
 
 # Minimum number of DISTINCT contributing IPs within the subnet, required
 # alongside DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED. This is the guard
@@ -764,7 +986,9 @@ DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED: int = getattr(settings, "DJANGO_WAF_U
 # carried 100+ distinct contributing IPs; 10 is set far below that so the
 # detector catches a materially smaller, still-clearly-distributed pool
 # rather than only the extreme case already seen.
-DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS: int = getattr(settings, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10)
+def _DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS() -> int:
+    return _get_setting("DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10)
+
 
 # Time window, in minutes, the subnet path of detect_unsolved_challenges
 # aggregates over. Deliberately separate from the per-IP path's window
@@ -794,7 +1018,9 @@ DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS: int = getattr(settings, "DJANGO_WAF_UNSOLVED
 # 1.5M RequestLog rows, a 360-minute scan runs in 0.006s against the
 # existing django_waf_rl_verdict_ts_idx index, indistinguishable in cost
 # from the 60-minute scan.
-DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES: int = getattr(settings, "DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES", 360)
+def _DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES() -> int:
+    return _get_setting("DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES", 360)
+
 
 # ---------------------------------------------------------------------------
 # Verify-endpoint rate limit (issue #81)
@@ -825,5 +1051,50 @@ DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES: int = getattr(settings, "DJANGO_WAF_U
 # rate. A breach degrades to a 429 with an accurate Retry-After (matching
 # the existing throttle response shape) rather than a block, so a false
 # positive is always recoverable.
-DJANGO_WAF_VERIFY_RATE_LIMIT_MAX: int = getattr(settings, "DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20)
-DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS: int = getattr(settings, "DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300)
+def _DJANGO_WAF_VERIFY_RATE_LIMIT_MAX() -> int:
+    return _get_setting("DJANGO_WAF_VERIFY_RATE_LIMIT_MAX", 20)
+
+
+def _DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS() -> int:
+    return _get_setting("DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS", 300)
+
+
+# ---------------------------------------------------------------------------
+# PEP 562 module-level __getattr__ / __dir__: call-time resolution (#75)
+# ---------------------------------------------------------------------------
+# Every DJANGO_WAF_* name above is a private ``_NAME()`` resolver function,
+# never a module-level constant, specifically so that ``conf.DJANGO_WAF_X``
+# re-consults django.conf.settings on every access rather than freezing a
+# value read once at import time. __getattr__ is only called by Python when
+# normal attribute lookup fails (i.e. the name is not in this module's
+# __dict__), which is exactly what a bare module-level function definition
+# never populates for these names, so a test using
+# unittest.mock.patch.object(django_waf.conf, "DJANGO_WAF_X", value) still
+# works exactly as it would against a plain module attribute: entering the
+# patch calls setattr (writing the name into this module's __dict__ for the
+# duration), and exiting calls delattr (removing it again), which restores
+# __getattr__ resolution rather than shadowing it. This module intentionally
+# does NOT reassign __class__ to a custom ModuleType subclass with its own
+# __setattr__/__delattr__: doing so cannot fix pytest's monkeypatch.setattr,
+# whose restore-on-teardown path is itself a plain setattr call carrying the
+# pre-patch value, indistinguishable from a fresh override by any override
+# store this module could maintain. The ambiguity is inherent to Python
+# attribute semantics, not a gap this module's mechanism leaves open. Do not
+# use monkeypatch.setattr(conf, "NAME", ...) in a consumer's own tests for
+# this reason; use unittest.mock.patch.object (as this package's own test
+# suite does throughout) or override_settings instead.
+_RESOLVERS: dict[str, Any] = {
+    name[1:]: func for name, func in list(globals().items()) if name.startswith("_DJANGO_WAF_") and callable(func)
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        resolver = _RESOLVERS[name]
+    except KeyError:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+    return resolver()
+
+
+def __dir__() -> list[str]:
+    return sorted({*globals().keys(), *_RESOLVERS.keys()})

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -514,6 +514,10 @@ _CELERY_BEAT_INTERVAL_ENTRIES: dict = {
         "task": "django_waf.tasks.update_ip_reputation",
         "schedule": 21600.0,  # every 6 hours
     },
+    "django-waf-probe-detectors": {
+        "task": "django_waf.tasks.probe_detectors",
+        "schedule": 3600.0,  # every hour (BR-ANOM-012)
+    },
 }
 
 if crontab is not None:

--- a/src/django_waf/management/commands/django_waf_probe_detectors.py
+++ b/src/django_waf/management/commands/django_waf_probe_detectors.py
@@ -1,0 +1,68 @@
+"""
+Management command: django_waf_probe_detectors
+
+Runs the detector liveness probe (BR-ANOM-012) against synthetic fixture
+traffic and reports which anomaly detectors are alive. Useful for manual
+invocation outside the Celery schedule, incident response, or a
+readiness/liveness probe wired to an external monitor.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Run the WAF detector liveness probe against synthetic fixture traffic."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--exercise-writes",
+            action="store_true",
+            default=False,
+            help=(
+                "Report with real detector writes rather than each detector's own "
+                "read-only dry-run mode (default: dry-run). No synthetic row is ever "
+                "committed either way (the whole run is wrapped in a rolled-back "
+                "transaction), but --exercise-writes DOES fire the anomaly_detected "
+                "signal for real, for a synthetic event: any receiver a consuming "
+                "project has wired to it (paging, a webhook, a metrics counter) "
+                "fires on this synthetic data. Use only when you specifically need "
+                "to exercise the write path (quarantine logic, the review_status "
+                "guard, dedup-retry), which dry-run mode cannot reach."
+            ),
+        )
+
+    def handle(self, *args, **options) -> None:
+        from django_waf.services.detector_probe import run_detector_probe
+
+        exercise_writes: bool = options["exercise_writes"]
+
+        if exercise_writes:
+            self.stdout.write(
+                self.style.WARNING(
+                    "[exercise-writes] Running detectors for real against synthetic fixture "
+                    "traffic. anomaly_detected WILL fire for this synthetic event."
+                )
+            )
+
+        try:
+            result = run_detector_probe(dry_run=not exercise_writes)
+        except Exception as exc:
+            raise CommandError(f"Detector probe failed to run: {exc}") from exc
+
+        for detector_name in sorted(result):
+            if detector_name in ("all_alive", "silent_detectors", "dry_run"):
+                continue
+            status = result[detector_name]
+            state = "alive" if status["alive"] else "SILENT"
+            self.stdout.write(f"  {detector_name}: {state} (rules_reported={status['rules_reported']})")
+
+        if result["all_alive"]:
+            self.stdout.write(self.style.SUCCESS("All detectors alive."))
+            return
+
+        # Non-zero exit on a bad result, unlike most commands in this
+        # package: this command is meant to be wired into a cron wrapper
+        # or a k8s liveness/readiness probe that keys off exit status, so a
+        # silent detector must fail the process, not just print a warning.
+        silent = ", ".join(result["silent_detectors"])
+        raise CommandError(f"Detectors silent: {silent}")

--- a/src/django_waf/migrations/0006_blockrule_detectors.py
+++ b/src/django_waf/migrations/0006_blockrule_detectors.py
@@ -1,0 +1,33 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("django_waf", "0005_blockrule_review_status"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="blockrule",
+            name="detectors",
+            field=models.CharField(
+                blank=True,
+                db_index=True,
+                default="",
+                help_text=(
+                    "Comma-separated, sorted set of anomaly detector names that have ever "
+                    "caused a write to this row (e.g. 'detect_cloud_spray,"
+                    "detect_unsolved_challenges'). Additive, never overwritten: multiple "
+                    "detectors can independently target the same (rule_type, pattern, "
+                    "source=AUTO, action) shape, most commonly a shared subnet pattern, and "
+                    "each detector's own write only adds its name rather than replacing the "
+                    "set. Blank for admin and feed-sourced rules, and for auto-generated rules "
+                    "created before this field existed. Lets a detector's own promotion logic "
+                    "recognise a rule it has itself previously written, even after another "
+                    "detector has since written to the same row (#97)."
+                ),
+                max_length=255,
+                verbose_name="detectors",
+            ),
+        ),
+    ]

--- a/src/django_waf/models.py
+++ b/src/django_waf/models.py
@@ -227,6 +227,23 @@ class BlockRule(BaseModel):
         verbose_name=_("reviewed at"),
         help_text=_("Set when review_status transitions to confirmed or rejected."),
     )
+    detectors = models.CharField(
+        max_length=255,
+        blank=True,
+        db_index=True,
+        verbose_name=_("detectors"),
+        help_text=_(
+            "Comma-separated, sorted set of anomaly detector names that have ever caused a "
+            "write to this row (e.g. 'detect_cloud_spray,detect_unsolved_challenges'). Additive, "
+            "never overwritten: multiple detectors can independently target the same "
+            "(rule_type, pattern, source=AUTO, action) shape, most commonly a shared subnet "
+            "pattern, and each detector's own write only adds its name rather than replacing "
+            "the set. Blank for admin and feed-sourced rules, and for auto-generated rules "
+            "created before this field existed. Lets a detector's own promotion logic recognise "
+            "a rule it has itself previously written, even after another detector has since "
+            "written to the same row (#97)."
+        ),
+    )
 
     objects = BlockRuleManager()
 

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -40,6 +40,22 @@ DETECTOR_NAMES = frozenset(
     }
 )
 
+# Maps each DETECTOR_NAMES entry to its corresponding key in run_all_detectors'
+# result dict. The two vocabularies differ on purpose (a function name reads
+# naturally in code; a result key reads naturally in a report) and there is
+# no other mapping between them today, so django_waf.services.detector_probe
+# keys its per-detector liveness report on DETECTOR_NAMES and looks up the
+# matching count via this dict rather than guessing a naming convention. Kept
+# next to DETECTOR_NAMES so a detector rename or addition cannot desync the
+# two silently: update both in the same change.
+DETECTOR_NAME_TO_RESULT_KEY = {
+    "detect_ua_rotation": "ua_rotation_rules",
+    "detect_subnet_burst": "subnet_burst_rules",
+    "detect_challenge_farms": "challenge_farm_rules",
+    "detect_unsolved_challenges": "unsolved_challenge_rules",
+    "detect_cloud_spray": "cloud_spray_rules",
+}
+
 
 def detect_ua_rotation(
     window_minutes: int = 5,

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -365,12 +365,15 @@ def detect_unsolved_challenges(
     A subnet clearing its threshold is never blocked directly: the first
     crossing creates (or refreshes) a CHALLENGE rule. Only a REPEAT
     crossing, detected by an already-active auto CHALLENGE rule for the
-    same subnet, promotes it to BLOCK. This matters more here than for the
-    per-IP path because abandonment has a legitimate cause: a real user who
-    closes the tab or whose JavaScript is blocked abandons a challenge
-    exactly as a bot does, so a single crossing is not enough evidence to
-    block outright. Issue #82 measured that a coarse signal here would have
-    caught at least 35.6% real users on the same deployment.
+    same subnet that THIS detector itself created (own-provenance-only,
+    #97; another detector's CHALLENGE rule of the same shape, e.g. from
+    detect_subnet_burst or detect_cloud_spray, does not count), promotes
+    it to BLOCK. This matters more here than for the per-IP path because
+    abandonment has a legitimate cause: a real user who closes the tab or
+    whose JavaScript is blocked abandons a challenge exactly as a bot
+    does, so a single crossing is not enough evidence to block outright.
+    Issue #82 measured that a coarse signal here would have caught at
+    least 35.6% real users on the same deployment.
 
     Args:
         window_minutes: Time window to analyse for the per-IP path (default
@@ -668,18 +671,50 @@ def _detect_unsolved_challenges_by_subnet(
         # Two-stage promotion (#84, issue #82's false-positive discipline):
         # a subnet never goes straight to BLOCK on one crossing. Detect a
         # repeat crossing as "this subnet already has an active auto
-        # CHALLENGE rule from this detector" and promote to BLOCK only
+        # CHALLENGE rule from THIS detector" and promote to BLOCK only
         # then; a first crossing creates (or refreshes) the CHALLENGE rule.
         # This existence check is a read, so it runs identically under
         # dry_run: BR-ANOM-006 requires a dry run to report what a real run
         # WOULD do, and only the write below is conditioned on dry_run.
-        already_challenged = BlockRule.objects.filter(
+        #
+        # own-provenance-only (#97): membership in detectors is checked in
+        # Python, not via a database filter on the raw comma-joined string,
+        # so "detect_unsolved_challenges" cannot false-match as a substring
+        # of some other, longer detector name. A CHALLENGE rule created by
+        # detect_subnet_burst or detect_cloud_spray, which target the same
+        # rule_type/pattern/source/action shape via the same
+        # _get_subnet_prefix, does not count as this detector's own prior
+        # crossing merely because it exists; this detector's own name must
+        # actually be present in the set. Before the detectors field
+        # existed, rule_type/pattern/source/action alone could not
+        # distinguish "this detector already challenged this subnet" from
+        # "some other detector already did", and because both of those
+        # detectors run by default, this detector's own first crossing
+        # almost never reached CHALLENGE: a default deployment measured 9
+        # of 10 subnet rules promoted straight to BLOCK. The owner ruled
+        # against cross-detector acceleration: another detector's rule does
+        # not promote this one.
+        #
+        # detectors is additive (see _merge_detector_names), so even
+        # though detect_cloud_spray runs after this detector on every
+        # run_all_detectors pass and also targets this same subnet shape,
+        # its write only adds "detect_cloud_spray" to the set rather than
+        # replacing "detect_unsolved_challenges" already in it. Without
+        # that additive guarantee, this membership check would still fail:
+        # the next pass would find this detector's own name missing from a
+        # row a sibling detector had since overwritten, and the two-stage
+        # promotion would never reach BLOCK for exactly the subnets
+        # multiple detectors independently flag.
+        existing_subnet_rule = BlockRule.objects.filter(
             rule_type=RuleType.CIDR,
             pattern=subnet,
             source=RuleSource.AUTO,
             action=RuleAction.CHALLENGE,
             is_active=True,
-        ).exists()
+        ).first()
+        already_challenged = existing_subnet_rule is not None and "detect_unsolved_challenges" in (
+            existing_subnet_rule.detectors.split(",")
+        )
         stage_action = RuleAction.BLOCK if already_challenged else RuleAction.CHALLENGE
 
         rule, created = _get_or_create_auto_rule(
@@ -1084,6 +1119,33 @@ def _get_or_create_auto_rule(
     corresponding argument is omitted, so a caller not yet passing them sees
     unchanged behaviour.
 
+    Provenance (#97): ``detector_name`` (when non-empty) is added to
+    ``BlockRule.detectors``, a comma-separated, sorted SET of every detector
+    that has ever written to this row, not only used for the observe-only
+    membership test above. This lets a detector that does its own promotion
+    between actions, currently only ``detect_unsolved_challenges``'s subnet
+    path, recognise a prior rule it created itself even after a *different*
+    detector has since written to the same row. ``detectors`` sits in
+    ``defaults`` (via the merge performed in ``_update_or_create_auto_rule``,
+    not here), never in ``lookup``, so it does not affect the dedup key: two
+    detectors that independently target the same (rule_type, pattern,
+    source=AUTO, action) still update_or_create the same single row.
+
+    The set must be additive, not last-writer-wins, because three detectors
+    (``detect_subnet_burst``, ``detect_unsolved_challenges``'s subnet path,
+    ``detect_cloud_spray``) can all independently target the identical
+    (CIDR, subnet, AUTO, CHALLENGE) key when they share a subnet via
+    ``_get_subnet_prefix``, and ``run_all_detectors`` runs all three, in
+    that order, on every pass. A plain overwrite would mean
+    ``detect_cloud_spray``, which always runs last, clobbers
+    ``detect_unsolved_challenges``'s own stamp at the end of every pass; on
+    the next pass that detector would no longer recognise its own prior
+    rule, and its two-stage promotion would get stuck at stage one forever
+    for exactly the subnets multiple detectors independently flag, which are
+    the most suspicious ones. This does not reintroduce #97 (it fails safe
+    toward CHALLENGE, never a wrong BLOCK), but it silently defeats the
+    promotion mechanism, so the set must accumulate rather than replace.
+
     Re-detection guard (BR-ANOM-007, mirrors threat_feed.sync_feed's
     survive-later-syncs guarantee for feed-sourced allow rules): before
     writing, the existing row's review_status (if any) is read. When it is
@@ -1130,11 +1192,12 @@ def _get_or_create_auto_rule(
         existing = BlockRule.objects.filter(**lookup).first()
         if existing is not None:
             return existing, False
+        defaults["detectors"] = _merge_detector_names("", detector_name)
         return BlockRule(**lookup, **defaults), True
 
     try:
         with transaction.atomic():
-            rule, created = _update_or_create_auto_rule(lookup, defaults)
+            rule, created = _update_or_create_auto_rule(lookup, defaults, detector_name)
         return rule, created
     except BlockRule.MultipleObjectsReturned:
         logger.warning(
@@ -1144,11 +1207,27 @@ def _get_or_create_auto_rule(
         )
         _deduplicate_block_rules(**lookup)
         with transaction.atomic():
-            rule, created = _update_or_create_auto_rule(lookup, defaults)
+            rule, created = _update_or_create_auto_rule(lookup, defaults, detector_name)
         return rule, created
 
 
-def _update_or_create_auto_rule(lookup: dict, defaults: dict) -> tuple:
+def _merge_detector_names(existing_value: str, detector_name: str) -> str:
+    """Add ``detector_name`` to the existing comma-separated detector set.
+
+    Returns a sorted, comma-joined, deduplicated string. Additive by design
+    (#97): the set only ever grows, so a later detector's write cannot
+    remove a name a prior detector's write already added. An empty
+    ``detector_name`` is a no-op (some callers, e.g. tests exercising
+    _get_or_create_auto_rule directly, do not pass one), and never
+    contributes an empty entry to the set.
+    """
+    names = {name for name in existing_value.split(",") if name}
+    if detector_name:
+        names.add(detector_name)
+    return ",".join(sorted(names))
+
+
+def _update_or_create_auto_rule(lookup: dict, defaults: dict, detector_name: str = "") -> tuple:
     """Read-before-write wrapper around BlockRule.objects.update_or_create.
 
     A plain single-shot update_or_create would let a later detector run
@@ -1159,6 +1238,15 @@ def _update_or_create_auto_rule(lookup: dict, defaults: dict) -> tuple:
     review_status exactly as the operator last set them. This mirrors
     threat_feed.sync_feed's equivalent guarantee for feed-sourced allow
     rules (services/threat_feed.py).
+
+    ``detectors`` (#97) is merged here, not passed pre-computed in
+    ``defaults``, because computing it correctly requires the existing
+    row's current value, which is only fetched here under
+    ``select_for_update()``. Merging happens unconditionally, including
+    when the review-status guard below strips ``is_active``/
+    ``review_status``: provenance is not a review decision, so a
+    CONFIRMED/REJECTED rule's detector set still accumulates on
+    re-detection exactly as an unreviewed rule's does.
 
     Must run inside the same transaction.atomic() block as its caller so the
     read and the write are consistent.
@@ -1171,6 +1259,11 @@ def _update_or_create_auto_rule(lookup: dict, defaults: dict) -> tuple:
     if existing is not None and existing.review_status in (ReviewStatus.CONFIRMED, ReviewStatus.REJECTED):
         write_defaults.pop("is_active", None)
         write_defaults.pop("review_status", None)
+
+    write_defaults["detectors"] = _merge_detector_names(
+        existing.detectors if existing is not None else "",
+        detector_name,
+    )
 
     return BlockRule.objects.update_or_create(**lookup, defaults=write_defaults)
 

--- a/src/django_waf/services/blocklist_generator.py
+++ b/src/django_waf/services/blocklist_generator.py
@@ -172,9 +172,9 @@ def _activate_candidate(tmp_path: str, dest: str) -> None:
     here" and logged, not as a validation failure, the candidate is
     activated exactly as if validation were disabled.
     """
-    from django.conf import settings
+    from django_waf import conf
 
-    validate = getattr(settings, "DJANGO_WAF_NGINX_VALIDATE", True)
+    validate = conf.DJANGO_WAF_NGINX_VALIDATE
 
     if not validate:
         os.rename(tmp_path, dest)
@@ -217,9 +217,9 @@ def _validate_nginx_config() -> bool | None:
         attempted at all (test command binary not on PATH), callers must
         treat None as "skip", not as a failure.
     """
-    from django.conf import settings
+    from django_waf import conf
 
-    command = getattr(settings, "DJANGO_WAF_NGINX_TEST_COMMAND", ["nginx", "-t"])
+    command = conf.DJANGO_WAF_NGINX_TEST_COMMAND
 
     try:
         result = subprocess.run(command, capture_output=True, text=True, timeout=10)

--- a/src/django_waf/services/detector_probe.py
+++ b/src/django_waf/services/detector_probe.py
@@ -1,0 +1,400 @@
+"""
+Detector liveness probe for django-waf.
+
+Runs every anomaly detector against synthetic fixture traffic, shaped to
+provably cross each detector's own configured threshold, and reports which
+detectors did (and did not) produce a rule. This is not a dry-run against
+real recent traffic: ``run_all_detectors`` returning ``total_rules_created:
+0`` is the normal, healthy, overwhelmingly common result on a quiet site,
+which is indistinguishable from a dead detector returning 0 against
+anything. Three real defects this cycle (a ``getdel`` call reporting
+success 40,936 times while doing nothing, 2.0.0's subnet feature producing
+0 rules for 13 hours, and #97's staging skip) all passed tests, review and
+release, and a probe built on real traffic would have stayed green
+throughout each of them, reproducing the exact failure it exists to catch.
+Building fixture rows that are guaranteed to cross a threshold makes zero
+an unambiguous defect signal instead.
+
+No environment guard of any kind gates this module. #97's staging skip was
+exactly that class of defect: a probe that quietly does nothing in some
+environments is the next one.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db import transaction
+from django.utils import timezone
+
+logger = logging.getLogger("django_waf.detector_probe")
+
+# TEST-NET ranges (RFC 5737 documentation ranges), one distinct block per
+# detector, so a leftover real BlockRule for the same pattern shape cannot
+# make _get_or_create_auto_rule report created=False (a false red) or,
+# under an inverted assertion, a false green. Real production traffic is
+# never sourced from these ranges, so a collision here can only be this
+# probe's own prior run (uncommitted, per the forced rollback below),
+# never live traffic.
+#
+# Sub-ranges within the three /24s are chosen so each detector's synthetic
+# IPs are disjoint from every other detector's, even though detect_subnet_burst
+# aggregates ALL RequestLog rows within its window regardless of which
+# detector's fixture wrote them: its floor check (count >= configured
+# minimum) is population-independent by construction (see its own
+# docstring), so the presence of other detectors' fixture rows in the same
+# probe run cannot dilute or falsely trip it, provided its own subnet stays
+# disjoint from any other detector's IPs that might otherwise land in the
+# same /24 and change ITS count.
+#
+# These same octets also appear as literal fixtures scattered across this
+# package's own test suite (test_commands.py, test_review_workflow.py,
+# and others use addresses inside the same three /24s, including
+# 203.0.113.10). This is not a collision risk: every test in this suite
+# runs inside pytest-django's own per-test transaction, rolled back at
+# teardown, and this module's transaction.atomic()/set_rollback(True) gives
+# a real (non-test) invocation the same guarantee, so no test, and no probe
+# run, can ever leave a persisted row behind for a later run to trip over.
+_UA_ROTATION_IP = "192.0.2.10"
+_UNSOLVED_CHALLENGE_IP = "192.0.2.50"
+_SUBNET_BURST_SUBNET_BASE = "198.51.100."  # .10-.15 used below
+_CHALLENGE_FARM_IP = "203.0.113.10"
+_CLOUD_SPRAY_SUBNET_BASE = "203.0.113."  # .20-.40 used below (21 IPs)
+
+_PROBE_UA = "django-waf-detector-probe/1.0"
+
+
+def run_detector_probe(dry_run: bool = True) -> dict:
+    """Run every anomaly detector against synthetic fixture traffic.
+
+    Builds fixture ``RequestLog`` (and, for ``detect_challenge_farms``,
+    ``IPReputation``) rows shaped to cross each detector's own configured
+    threshold, derived from the documented business rules (``02-business-
+    rules.md`` BR-ANOM-001 through BR-ANOM-003, BR-ANOM-002a) and the
+    current ``conf.DJANGO_WAF_*`` settings, not by reading the detector's
+    own query: deriving fixtures from the query would only prove the query
+    still does what the query does, not that it does what the business
+    rule requires.
+
+    Everything runs inside a single ``transaction.atomic()`` block that is
+    unconditionally rolled back before returning: no synthetic ``RequestLog``,
+    ``IPReputation``, or ``BlockRule`` row is ever left committed, regardless
+    of ``dry_run``. This is the single biggest risk in this module's design:
+    a leaked synthetic row would corrupt dashboard counters, ``update_ip_
+    reputation``'s next run, the real detectors' next run, and would ship a
+    fake subnet to the collective threat feed via
+    ``threat_feed.build_telemetry_payload``.
+
+    Args:
+        dry_run: Forwarded to every detector's own ``dry_run`` keyword
+            (BR-ANOM-006). ``True`` (the default) makes every detector
+            perform its read-only existence check only: no ``BlockRule`` is
+            written or activated, and ``anomaly_detected`` is never
+            emitted. ``True`` is the safe default because dry-run's
+            no-writes contract is unconditional and detector-independent,
+            so a probe run can never itself create an enforcing rule,
+            however briefly, even before the surrounding rollback.
+
+            ``False`` ("exercise writes") is an explicit, deliberate
+            opt-in: it makes every detector run for real, which still
+            cannot commit anything (the rollback is unconditional) but
+            DOES fire ``anomaly_detected``. That signal is not
+            transactional and is not covered by the rollback: any receiver
+            a consumer has wired to it (paging, an external webhook, a
+            metrics counter) fires for real, for a synthetic event, the
+            moment a real detector call happens to create a rule. The
+            package cannot know what a consuming project wired to that
+            signal, so this is opt-in rather than the default. It exists
+            because dry-run mode cannot reach defects in the write path
+            itself (quarantine logic, the review_status guard, or the
+            dedup-retry path), which only a real ``update_or_create`` call
+            exercises.
+
+    Returns:
+        Dict with keys:
+            - one key per name in ``anomaly_detector.DETECTOR_NAMES``,
+              each mapping to a per-detector dict with ``alive`` (bool)
+              and ``rules_reported`` (int, the count
+              ``run_all_detectors`` attributed to that detector for this
+              run).
+            - ``all_alive`` (bool): True only when every detector reported
+              at least one rule against its own fixture.
+            - ``silent_detectors`` (list[str]): names of any detector that
+              reported zero, empty when ``all_alive`` is True.
+            - ``dry_run`` (bool): echoes the argument, so a caller does not
+              need to thread it through separately to interpret the result.
+    """
+    from django_waf.services.anomaly_detector import (
+        DETECTOR_NAME_TO_RESULT_KEY,
+        DETECTOR_NAMES,
+        run_all_detectors,
+    )
+
+    with transaction.atomic():
+        try:
+            _build_fixture_traffic()
+            # window_minutes=None (the default) is deliberate: run_all_detectors
+            # forwards an explicit override to every detector uniformly except
+            # detect_unsolved_challenges's subnet path, which always keeps its
+            # own DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES regardless (#93).
+            # Passing None here means every detector, including that subnet
+            # path, evaluates on its own real configured window, which is
+            # exactly the window the fixture timestamps below are built
+            # against. A probe passing a small override would silently
+            # exercise a different window than it thinks for that one path.
+            result = run_all_detectors(dry_run=dry_run)
+        finally:
+            # Unconditional: even if fixture construction or detection raises,
+            # nothing synthetic may survive this function. No branch below
+            # this point may skip the rollback.
+            transaction.set_rollback(True)
+
+    report: dict = {}
+    silent_detectors: list[str] = []
+    for detector_name in sorted(DETECTOR_NAMES):
+        result_key = DETECTOR_NAME_TO_RESULT_KEY[detector_name]
+        rules_reported = result.get(result_key, 0)
+        alive = rules_reported > 0
+        report[detector_name] = {"alive": alive, "rules_reported": rules_reported}
+        if not alive:
+            silent_detectors.append(detector_name)
+
+    all_alive = not silent_detectors
+    if all_alive:
+        # No extra={} structured fields: WafStructuredFormatter's
+        # _OPTIONAL_FIELDS (logging.py) is shaped for a single request event
+        # (ip, verdict, rule_id, path, method, ...), and no existing call site
+        # in this package populates it via extra= today. This line summarises
+        # a multi-detector run rather than one event, so a "detector" /
+        # "count" field would not fit that schema's shape (a per-request
+        # dimension) even if it were in use, and would land alone as the only
+        # populated field on this line while every existing field stayed
+        # absent. The message text carries the full detail (detector names,
+        # per-detector rules_reported) instead; see the module docstring's
+        # freshness note for the consumer-side alerting contract this line
+        # backs.
+        logger.info(
+            "django-waf: detector probe, all %d detectors alive",
+            len(DETECTOR_NAMES),
+        )
+    else:
+        logger.warning(
+            "django-waf: detector probe, silent detectors: %s",
+            ", ".join(silent_detectors),
+        )
+
+    report["all_alive"] = all_alive
+    report["silent_detectors"] = silent_detectors
+    report["dry_run"] = dry_run
+    return report
+
+
+def _build_fixture_traffic() -> None:
+    """Insert synthetic RequestLog/IPReputation rows shaped to cross every
+    detector's configured threshold. Must run inside the caller's
+    transaction.atomic() block, which is unconditionally rolled back.
+    """
+    from django_waf import conf
+
+    now = timezone.now()
+
+    _build_ua_rotation_fixture(now=now, conf=conf)
+    _build_subnet_burst_fixture(now=now, conf=conf)
+    _build_challenge_farm_fixture(now=now, conf=conf)
+    _build_unsolved_challenge_fixture(now=now, conf=conf)
+    _build_cloud_spray_fixture(now=now, conf=conf)
+
+
+def _build_ua_rotation_fixture(*, now, conf, distinct_ua_count: int | None = None) -> None:
+    """BR-ANOM-001: more than DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS
+    (default 20) distinct UAs from the same IP within a 5-minute window
+    (detect_ua_rotation's default window_minutes=5).
+
+    ``distinct_ua_count`` defaults to ``conf.DJANGO_WAF_ANOMALY_THRESHOLD_
+    DISTINCT_UAS + 1``, which survives an operator retuning the threshold on
+    the normal (non-test) path. Falsifiability tests that need to raise the
+    threshold past a FIXED fixture size, so the real query can genuinely
+    fail to match, must pass an explicit literal here: reading ``conf``
+    for BOTH the fixture size and the threshold the query compares against
+    means raising the threshold alone can never break anything, since the
+    fixture silently grows to stay one above whatever the threshold now is.
+    """
+    from django_waf.enums import Verdict
+    from django_waf.models import RequestLog
+
+    if distinct_ua_count is None:
+        distinct_ua_count = conf.DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS + 1
+
+    RequestLog.objects.bulk_create(
+        [
+            RequestLog(
+                timestamp=now,
+                ip_address=_UA_ROTATION_IP,
+                user_agent=f"{_PROBE_UA} (ua-rotation-fixture-{i})",
+                path="/",
+                method="GET",
+                verdict=Verdict.ALLOWED,
+            )
+            for i in range(distinct_ua_count)
+        ]
+    )
+
+
+def _build_subnet_burst_fixture(*, now, conf, total_requests: int | None = None) -> None:
+    """BR-ANOM-002 (amended #80): a subnet's request count meeting the
+    absolute floor, DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT
+    (default 30), is sufficient on its own (an OR, not an AND, with the
+    3x-median ratio check), specifically so this floor can never be diluted
+    by how many other subnets are present in the window. One request over
+    the floor, from a handful of IPs in one /24, inside detect_subnet_
+    burst's default 15-minute window.
+
+    ``total_requests`` defaults to ``conf.DJANGO_WAF_ANOMALY_THRESHOLD_
+    SUBNET_BURST_MIN_COUNT + 1``, for the same reason as
+    ``_build_ua_rotation_fixture``: a falsifiability test that wants to
+    raise the threshold past a fixed fixture size must pass an explicit
+    literal, or the fixture grows in lockstep with the threshold and the
+    detector keeps matching regardless of how high it is raised.
+    """
+    from django_waf.enums import Verdict
+    from django_waf.models import RequestLog
+
+    if total_requests is None:
+        total_requests = conf.DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT + 1
+    fixture_ips = [f"{_SUBNET_BURST_SUBNET_BASE}{10 + (i % 6)}" for i in range(total_requests)]
+
+    RequestLog.objects.bulk_create(
+        [
+            RequestLog(
+                timestamp=now,
+                ip_address=ip,
+                user_agent=_PROBE_UA,
+                path="/",
+                method="GET",
+                verdict=Verdict.ALLOWED,
+            )
+            for ip in fixture_ips
+        ]
+    )
+
+
+def _build_challenge_farm_fixture(
+    *, now, conf, challenge_failures: int = 11, challenge_passes: int = 0
+) -> None:
+    """BR-ANOM-003: a single IP with more than 10 challenge failures and
+    fewer than 2 passes within a 24-hour window (detect_challenge_farms'
+    default window_hours=24). Sourced from IPReputation, not RequestLog.
+
+    ``conf`` is accepted but unused: BR-ANOM-003's 10/2 thresholds are fixed
+    in the detector itself (``challenge_failures__gt=10,
+    challenge_passes__lt=2``), not settings-driven, unlike every other
+    fixture builder in this module. There is therefore no conf setting a
+    falsifiability test could raise to defeat this fixture the way the
+    other four detectors' tests do; the coupling trap those four had does
+    not exist here because nothing self-adjusts against a hardcoded
+    literal. Instead, ``challenge_failures``/``challenge_passes`` default to
+    values that clear the detector's own hardcoded thresholds (11 > 10,
+    0 < 2) and a falsifiability test passes values that do not (e.g.
+    ``challenge_failures=10``, which fails ``__gt=10``), proving the real
+    query genuinely finds nothing.
+    """
+    from django_waf.models import IPReputation
+
+    IPReputation.objects.create(
+        ip_address=_CHALLENGE_FARM_IP,
+        total_requests=20,
+        blocked_requests=0,
+        challenged_requests=20,
+        challenge_passes=challenge_passes,
+        challenge_failures=challenge_failures,
+        distinct_ua_count=1,
+        last_seen_at=now,
+    )
+
+
+def _build_unsolved_challenge_fixture(*, now, conf, challenged_count: int | None = None) -> None:
+    """BR-ANOM-006 / the per-IP path of detect_unsolved_challenges: an IP
+    with at least DJANGO_WAF_UNSOLVED_MIN_CHALLENGED (default 3) challenged
+    verdicts in the window, no solved ChallengeToken in the recency window,
+    and at least DJANGO_WAF_UNSOLVED_REFERER_RATIO (default 0.8) of its
+    non-root requests carrying an empty referer. source=middleware
+    explicitly (BR-LOG-006): the detector scopes its challenged-verdict
+    count to that source and would not see nginx_log rows.
+
+    Only the per-IP path is targeted here, not the subnet path: the subnet
+    path's own thresholds (DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED=30,
+    DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS=10) would require materially more
+    fixture rows for one more detector alive/dead signal that the per-IP
+    path already provides for the same detector function and the same
+    DETECTOR_NAMES entry (detect_unsolved_challenges covers both paths, but
+    run_all_detectors' result dict does not distinguish which path
+    contributed a rule). This fixture's single IP never reaches the
+    subnet path's DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS=10 distinct-IP floor
+    regardless of DJANGO_WAF_UNSOLVED_MIN_CHALLENGED, so raising the
+    per-IP setting to falsify this fixture cannot accidentally trip the
+    subnet path instead.
+
+    ``challenged_count`` defaults to ``conf.DJANGO_WAF_UNSOLVED_MIN_
+    CHALLENGED + 1``, for the same reason as the other config-derived
+    fixtures above: raising the threshold alone cannot falsify a fixture
+    that grows to match it.
+    """
+    from django_waf.enums import RequestLogSource, Verdict
+    from django_waf.models import RequestLog
+
+    if challenged_count is None:
+        challenged_count = conf.DJANGO_WAF_UNSOLVED_MIN_CHALLENGED + 1
+
+    RequestLog.objects.bulk_create(
+        [
+            RequestLog(
+                timestamp=now,
+                ip_address=_UNSOLVED_CHALLENGE_IP,
+                user_agent=_PROBE_UA,
+                path=f"/fixture-path-{i}/",
+                method="GET",
+                verdict=Verdict.CHALLENGED,
+                source=RequestLogSource.MIDDLEWARE,
+                referer="",
+            )
+            for i in range(challenged_count)
+        ]
+    )
+
+
+def _build_cloud_spray_fixture(*, now, conf, distinct_ip_count: int | None = None) -> None:
+    """BR-ANOM-002a / detect_cloud_spray: a UA shared by at least
+    DJANGO_WAF_CLOUD_SPRAY_MIN_IPS (default 20) distinct IPs, each with no
+    more than DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP (default 3)
+    requests and no referer, inside detect_cloud_spray's default 30-minute
+    window. All IPs share one /24 so the subsequent per-subnet aggregation
+    (count >= 2) is satisfied trivially.
+
+    ``distinct_ip_count`` defaults to ``conf.DJANGO_WAF_CLOUD_SPRAY_MIN_IPS
+    + 1``, for the same reason as the other config-derived fixtures above:
+    raising the threshold alone cannot falsify a fixture that grows to
+    match it. The detector gates on this same setting twice (the UA-level
+    distinct-IP aggregation, and the subsequent per-IP recheck), so a
+    pinned literal here defeats both in one move.
+    """
+    from django_waf.enums import Verdict
+    from django_waf.models import RequestLog
+
+    if distinct_ip_count is None:
+        distinct_ip_count = conf.DJANGO_WAF_CLOUD_SPRAY_MIN_IPS + 1
+    shared_ua = f"{_PROBE_UA} (cloud-spray-fixture)"
+
+    RequestLog.objects.bulk_create(
+        [
+            RequestLog(
+                timestamp=now,
+                ip_address=f"{_CLOUD_SPRAY_SUBNET_BASE}{20 + i}",
+                user_agent=shared_ua,
+                path="/",
+                method="GET",
+                verdict=Verdict.ALLOWED,
+                referer="",
+            )
+            for i in range(distinct_ip_count)
+        ]
+    )

--- a/src/django_waf/services/detector_probe.py
+++ b/src/django_waf/services/detector_probe.py
@@ -278,9 +278,7 @@ def _build_subnet_burst_fixture(*, now, conf, total_requests: int | None = None)
     )
 
 
-def _build_challenge_farm_fixture(
-    *, now, conf, challenge_failures: int = 11, challenge_passes: int = 0
-) -> None:
+def _build_challenge_farm_fixture(*, now, conf, challenge_failures: int = 11, challenge_passes: int = 0) -> None:
     """BR-ANOM-003: a single IP with more than 10 challenge failures and
     fewer than 2 passes within a 24-hour window (detect_challenge_farms'
     default window_hours=24). Sourced from IPReputation, not RequestLog.

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -16,6 +16,7 @@ Scheduled tasks (Celery Beat):
   - sync_threat_feed        — daily 04:30
   - report_threat_telemetry — daily 05:00
   - update_geoip_database   — weekly (Sunday 03:00 UTC recommended)
+  - probe_detectors: hourly (BR-ANOM-012)
 """
 
 from __future__ import annotations
@@ -573,6 +574,74 @@ def update_geoip_database() -> dict:
     except GeoIPError as exc:
         logger.warning("django-waf: update_geoip_database skipped — %s", exc)
         return {"skipped": True, "error": str(exc)}
+
+
+@shared_task
+def probe_detectors() -> dict:
+    """Run the detector liveness probe (BR-ANOM-012) and report the result.
+
+    Delegates to ``services.detector_probe.run_detector_probe``, which
+    builds synthetic fixture traffic guaranteed to cross every anomaly
+    detector's own configured threshold and reports which detectors did,
+    and did not, produce a rule against it. Real recent traffic cannot be
+    used for this: ``run_all_detectors`` returning zero is the normal,
+    healthy, overwhelmingly common result on a quiet site, indistinguishable
+    from a dead detector, which is exactly how 2.0.0's subnet-detection
+    regression went unnoticed for 13 hours.
+
+    Freshness of this task's OWN execution is the consumer's job, not this
+    package's: a dead Celery Beat entry, a paused worker, or a broken
+    schedule produces no log line at all, which looks identical to "the
+    task has simply never needed to run" from inside this function. This
+    package stays stateless (CHK-OPEN-005) and does not persist a last-run
+    timestamp, so a consumer wiring alerting to this probe MUST alert on
+    the ABSENCE of the structured log line below within the expected
+    cadence, not only on its WARNING content: a probe that cannot itself
+    detect that it stopped running is not a safety net for that failure
+    mode, only for a detector that runs and returns nothing.
+
+    Runs with ``dry_run=True`` (the default from ``run_detector_probe``):
+    no ``BlockRule`` is ever created, activated, or refreshed, and the
+    ``anomaly_detected`` signal is never emitted from a scheduled run. Use
+    the ``django_waf_probe_detectors --exercise-writes`` management command
+    for the opt-in real-write mode; this task deliberately does not expose
+    it, since a signal wired to a paging system firing on a schedule from
+    synthetic data would be a self-inflicted incident.
+
+    This task never raises: unlike most tasks in this module, its entire
+    purpose is unattended liveness reporting, so a task that itself crashes
+    defeats the reason it exists (a crashed Celery task is a silent no-op
+    to Beat in the same way a missing log line is, from an operator's
+    perspective, unless task-failure alerting is separately wired). Any
+    exception is logged at ERROR with the traceback and reported as a
+    failure result rather than propagated.
+
+    Returns:
+        On success, the dict ``run_detector_probe`` returns (BR-ANOM-012):
+        one key per detector name with ``alive``/``rules_reported``, plus
+        ``all_alive``, ``silent_detectors``, and ``dry_run``. On failure,
+        ``{"all_alive": False, "silent_detectors": [...], "error": ...}``,
+        with every named detector reported as not alive by omission: a
+        probe that could not run proves liveness for nothing.
+
+    Scheduled: hourly.
+    """
+    from django_waf.services.anomaly_detector import DETECTOR_NAMES
+    from django_waf.services.detector_probe import run_detector_probe
+
+    try:
+        # run_detector_probe itself logs the all-alive INFO line or the
+        # silent-detectors WARNING line; this task does not re-log the same
+        # outcome, mirroring detect_anomalies's thin delegation to
+        # run_all_detectors (which likewise does its own logging).
+        return run_detector_probe(dry_run=True)
+    except Exception:
+        logger.exception("django-waf: probe_detectors failed to run")
+        return {
+            "all_alive": False,
+            "silent_detectors": sorted(DETECTOR_NAMES),
+            "error": "probe_detectors raised; see traceback in the preceding log record",
+        }
 
 
 @shared_task(bind=True, ignore_result=True)

--- a/src/django_waf/testing/factories.py
+++ b/src/django_waf/testing/factories.py
@@ -44,6 +44,7 @@ class BlockRuleFactory(factory.django.DjangoModelFactory):
     notes = ""
     review_status = ReviewStatus.NOT_APPLICABLE
     reviewed_at = None
+    detectors = ""
 
     class Meta:
         model = "django_waf.BlockRule"

--- a/src/django_waf/testing/fixtures.py
+++ b/src/django_waf/testing/fixtures.py
@@ -20,15 +20,24 @@ if TYPE_CHECKING:
 
 
 @pytest.fixture
-def disable_waf(monkeypatch: pytest.MonkeyPatch):
+def disable_waf(settings):
     """Disable the WAF middleware for the duration of a test.
 
-    Patches ``django_waf.conf.DJANGO_WAF_ENABLED`` to ``False``. Restored
-    automatically by ``monkeypatch`` at teardown.
-    """
-    from django_waf import conf
+    Sets ``settings.DJANGO_WAF_ENABLED`` to ``False``. Restored
+    automatically by the ``settings`` fixture at teardown.
 
-    monkeypatch.setattr(conf, "DJANGO_WAF_ENABLED", False)
+    Public-behaviour change (django-waf 2.2.0): this fixture previously
+    patched ``django_waf.conf.DJANGO_WAF_ENABLED`` directly via
+    ``monkeypatch.setattr``. ``django_waf.conf`` now resolves every
+    ``DJANGO_WAF_*`` setting at call time (issue #75), so patching the
+    conf module directly is no longer necessary, and ``monkeypatch.setattr``
+    against it is no longer safe (its restore-on-teardown path can
+    permanently shadow live resolution for the rest of the process; see the
+    module docstring in ``django_waf.conf``). Using the ``settings`` fixture
+    here is both the fix and the recommended pattern for a consuming
+    project's own tests.
+    """
+    settings.DJANGO_WAF_ENABLED = False
     yield
 
 

--- a/src/django_waf/urls.py
+++ b/src/django_waf/urls.py
@@ -9,17 +9,13 @@ The namespace must be "django_waf" to match reverse() calls throughout the packa
 
 The optional DRF API is mounted under waf/api/ only when
 DJANGO_WAF_API_ENABLED is true. This is read once, at urlconf-import time,
-which is the Django norm for urlpatterns — matches how ROOT_URLCONF itself
+which is the Django norm for urlpatterns: matches how ROOT_URLCONF itself
 is only re-evaluated on process restart or explicit urlconf-cache clearing.
-
-The flag is read directly from django.conf.settings here rather than from
-the cached django_waf.conf.DJANGO_WAF_API_ENABLED constant. Django resolves
-a urlconf lazily, on first URL dispatch, not at ROOT_URLCONF assignment —
-so this module's body can execute at an arbitrary later point in a process
-(e.g. mid-test, inside another test's mock.patch of django_waf.conf). Reading
-straight off settings here means the mount decision reflects the settings
-that were active for the whole process, not whatever happened to be patched
-onto django_waf.conf at the moment something first triggered a dispatch.
+Django resolves a urlconf lazily, on first URL dispatch, not at
+ROOT_URLCONF assignment, so this module's body can execute at an arbitrary
+later point in a process (e.g. mid-test). Whatever DJANGO_WAF_API_ENABLED
+resolves to at that one moment decides the mount for the rest of the
+process; a later settings change does not remount the routes.
 
 Importing this module with the API disabled never imports rest_framework,
 keeping djangorestframework an optional dependency (the [api] extra).
@@ -27,10 +23,9 @@ keeping djangorestframework an optional dependency (the [api] extra).
 
 import logging
 
-from django.conf import settings
 from django.urls import include, path
 
-from django_waf import views
+from django_waf import conf, views
 
 app_name = "django_waf"
 
@@ -76,7 +71,7 @@ urlpatterns = [
 # -----------------------------------------------------------------------
 # Optional DRF API — off by default, requires django-waf[api]
 # -----------------------------------------------------------------------
-if getattr(settings, "DJANGO_WAF_API_ENABLED", False):
+if conf.DJANGO_WAF_API_ENABLED:
     try:
         from django_waf.api import urls as api_urls
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,31 +15,6 @@ def _clear_rule_cache():
     re_mod._process_cache_version = -1
 
 
-@pytest.fixture(autouse=True)
-def _reset_conf_module():
-    """Reload the conf module after each test to ensure settings overrides are picked up.
-
-    Tests that use @override_settings or modify django.conf.settings directly
-    need the conf module reloaded so its module-level constants reflect the
-    current settings. This fixture ensures that regardless of test execution
-    order or whether individual tests remember to reload conf, every test
-    starts with a conf module synchronized to the current settings.
-
-    Note: this only guarantees a clean starting state. A test that mutates
-    settings.DJANGO_WAF_* mid-test still needs its own
-    ``importlib.reload(conf_mod)`` immediately after the mutation (see the
-    pattern in test_api.py / test_middleware.py) — this fixture's reload
-    runs once at teardown, after the test body (and its assertions) have
-    already executed.
-    """
-    import importlib
-
-    import django_waf.conf as conf_mod
-
-    yield
-    importlib.reload(conf_mod)
-
-
 def pytest_configure(config):
     """Ensure django_waf is in INSTALLED_APPS when running from the project root."""
     from django.conf import settings

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -56,22 +56,9 @@ def _disable_waf_middleware(settings):
     These tests exercise the DRF API layer (permissions, serializers,
     viewsets), not WAF request evaluation, so there's no need to route
     through the real evaluator (and its Redis-only cache writes) at all.
-
-    django_waf.conf.DJANGO_WAF_ENABLED is a module-level constant read once
-    at conf.py's first import, so flipping settings.DJANGO_WAF_ENABLED alone
-    doesn't reach WafMiddleware (which reads conf.DJANGO_WAF_ENABLED, not
-    django.conf.settings directly). Reload conf to pick up the override, and
-    reload again on teardown to restore it for other test modules — same
-    pattern used throughout test_middleware.py.
     """
-    import importlib
-
-    import django_waf.conf as conf_mod
-
     settings.DJANGO_WAF_ENABLED = False
-    importlib.reload(conf_mod)
     yield
-    importlib.reload(conf_mod)
 
 
 # ---------------------------------------------------------------------------
@@ -108,9 +95,23 @@ def _waf_admin_user(**kwargs):
 
 class TestApiDisabled:
     def test_returns_503_when_disabled(self):
+        """The per-request WafApiEnabledMixin gate, not the urlconf mount.
+
+        django_waf.urls reads DJANGO_WAF_API_ENABLED once, at first URL
+        dispatch for the whole process (see the module docstring in
+        django_waf/urls.py): if that dispatch happened to be THIS test's
+        own patched-False request, the routes would never mount at all and
+        this would 404 rather than 503, testing the wrong layer entirely.
+        A throwaway unpatched request first guarantees the routes are
+        already mounted (from a real, unpatched DJANGO_WAF_API_ENABLED),
+        so the patch below can only affect the per-request 503 gate in
+        api/viewsets.py, the thing this test actually exercises.
+        """
         superuser = _make_user(username="super1", is_staff=True, is_superuser=True)
         client = APIClient()
         client.force_authenticate(user=superuser)
+
+        client.get("/waf/api/block-rules/")
 
         with patch("django_waf.conf.DJANGO_WAF_API_ENABLED", False):
             response = client.get("/waf/api/block-rules/")

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -8,8 +8,11 @@ users out. The check refuses settings that would reproduce that lockout.
 
 from __future__ import annotations
 
+import importlib
 from unittest.mock import patch
 
+from django.core.management import call_command
+from django.core.management.base import SystemCheckError
 from django.test import override_settings
 
 
@@ -65,6 +68,12 @@ def _run_redis_version_check():
     from django_waf.checks import check_redis_version
 
     return check_redis_version(app_configs=None)
+
+
+def _run_site_password_configured_check():
+    from django_waf.checks import check_site_password_configured
+
+    return check_site_password_configured(app_configs=None)
 
 
 class TestChallengeDifficultyCheck:
@@ -138,6 +147,23 @@ class TestChallengeDifficultyCheck:
 
         assert any(m.id == "django_waf.E001" for m in messages)
 
+    def test_silent_when_waf_disabled(self):
+        """#95: the PoW challenge flow never runs when the WAF is switched
+        off, so a difficulty misconfiguration behind it is not a live
+        lockout. Uses the same over-28 config as
+        test_difficulty_over_28_errors, which fires E002 when the WAF is
+        enabled: proof this guard, not an unrelated default, is silencing
+        it."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+            patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_DIFFICULTY", 32),
+            patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_DIFFICULTY_DESKTOP", 22),
+            patch.object(conf_mod, "DJANGO_WAF_CHALLENGE_DIFFICULTY_MOBILE", 18),
+        ):
+            assert _run_checks() == []
+
 
 class TestSigningKeyCheck:
     """W003 — warns when DJANGO_WAF_SIGNING_KEY is unset.
@@ -166,6 +192,20 @@ class TestSigningKeyCheck:
         # part of the message so future edits don't lose the remediation.
         assert "secrets.token_urlsafe" in messages[0].hint
         assert "DJANGO_WAF_SIGNING_KEY" in messages[0].hint
+
+    def test_silent_when_waf_disabled(self):
+        """#95: no WAF token is ever signed with this key when the master
+        switch is off, so an unset key is not a live weakness in that
+        state. Uses the same empty-key config as
+        test_empty_key_emits_w003_warning, which fires W003 when the WAF
+        is enabled."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+            patch.object(conf_mod, "DJANGO_WAF_SIGNING_KEY", ""),
+        ):
+            assert _run_signing_key_check() == []
 
 
 class TestFeedUrlSchemeCheck:
@@ -305,6 +345,26 @@ class TestMiddlewareOrderingCheck:
 
         assert len(messages) == 1
         assert messages[0].id == "django_waf.W004"
+
+    def test_silent_when_waf_disabled(self):
+        """#95: request.user has nothing to bypass when WafMiddleware never
+        evaluates a request in the first place. Uses the same bad ordering
+        as test_warns_when_waf_runs_before_auth, which fires W004 when the
+        WAF is enabled."""
+        import django_waf.conf as conf_mod
+
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django_waf.middleware.WafMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+        ]
+
+        with (
+            override_settings(MIDDLEWARE=middleware),
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+        ):
+            assert _run_middleware_ordering_check() == []
 
 
 class TestTrustedCookieTrustLevelCheck:
@@ -528,3 +588,154 @@ class TestRedisVersionCheck:
             patch("django_waf.services.redis_client.get_redis_server_version", return_value=None),
         ):
             assert _run_redis_version_check() == []
+
+
+class TestSitePasswordConfiguredCheck:
+    """django_waf.E003: errors when the site-password gate is enabled with
+    an empty password (issue #40, BR-SP-002), unless the WAF is disabled
+    (#95).
+
+    This check had no test coverage at all before #95: no runner helper,
+    no test class. That gap is what let the E003-fires-when-WAF-disabled
+    defect survive as long as it did, the same class of gap #92 closed
+    for E004.
+    """
+
+    def test_enabled_with_password_produces_no_messages(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_SITE_PASSWORD_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_SITE_PASSWORD", "correct-horse-battery-staple"),
+        ):
+            assert _run_site_password_configured_check() == []
+
+    def test_disabled_gate_produces_no_messages(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_SITE_PASSWORD_ENABLED", False),
+            patch.object(conf_mod, "DJANGO_WAF_SITE_PASSWORD", ""),
+        ):
+            assert _run_site_password_configured_check() == []
+
+    def test_enabled_with_empty_password_emits_e003_error(self):
+        """The BR-SP-002 lockout class: the gate fails closed and denies
+        every gated request. This is the exact misconfiguration #95 exists
+        for; without a WAF-disabled guard, it also fires on a settings
+        profile that has switched the WAF off entirely."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_SITE_PASSWORD_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_SITE_PASSWORD", ""),
+        ):
+            messages = _run_site_password_configured_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.E003"
+        assert "DJANGO_WAF_SITE_PASSWORD" in messages[0].hint
+
+    def test_silent_when_waf_disabled(self):
+        """#95: the site-password gate is evaluated by WafMiddleware
+        (BR-SP-008), so it cannot fail closed on a request the middleware
+        never evaluates. Uses the same misconfigured combination as
+        test_enabled_with_empty_password_emits_e003_error, which fires
+        E003 when the WAF is enabled: proof this guard, not an unrelated
+        default, is silencing it. Consumers personal-site and JOBU hit
+        this exact combination under LocMemCache."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+            patch.object(conf_mod, "DJANGO_WAF_SITE_PASSWORD_ENABLED", True),
+            patch.object(conf_mod, "DJANGO_WAF_SITE_PASSWORD", ""),
+        ):
+            assert _run_site_password_configured_check() == []
+
+
+class TestManagePyCheckWithWafDisabled:
+    """End-to-end regression for #95: every other test in this module calls
+    a check function directly with app_configs=None, patching
+    django_waf.conf attributes. That never exercises the registry path
+    Django's own ``check`` framework uses, or the behaviour that an Error
+    aborts ``manage.py check`` outright (``SystemCheckError``) rather than
+    just being returned as a value in a list. Consumers personal-site and
+    JOBU hit this exact failure under LocMemCache: DJANGO_WAF_ENABLED=False
+    with an empty DJANGO_WAF_SITE_PASSWORD and DJANGO_WAF_SITE_PASSWORD_ENABLED
+    left at its True default aborted ``manage.py check`` via E003, and a
+    misconfigured DJANGO_WAF_REDIS_ALIAS under a non-Redis test cache did
+    the same via E004 before #92.
+
+    tests/conftest.py's pytest_configure sets DJANGO_WAF_ENABLED=True as a
+    fallback default (only applied via setattr when the attribute is
+    absent), and tests/settings.py sets it True explicitly, so this test
+    must override it itself rather than relying on either.
+
+    django_waf.conf.DJANGO_WAF_ENABLED is a module-level constant read once
+    at conf.py's first import (see test_api.py's disabled_waf fixture for
+    the same note): settings.DJANGO_WAF_ENABLED is set directly and
+    django_waf.conf is reloaded so every check function reads the disabled
+    value, exactly as a real settings module would produce it at process
+    start. override_settings alone would not reach conf on this branch
+    (issue #75, not yet merged here). See the docstring note below on what
+    changes once it lands.
+    """
+
+    def test_check_command_completes_with_waf_disabled_and_locmem_cache(self):
+        from django.conf import settings
+
+        import django_waf.conf as conf_mod
+
+        # tests/settings.py's CACHES["default"] is already LocMemCache
+        # (never a django-redis backend), and DJANGO_WAF_SITE_PASSWORD is
+        # unset there, so DJANGO_WAF_SITE_PASSWORD_ENABLED resolves False
+        # by BR-SP-001's own default rule. The only override this test
+        # needs is the master switch itself.
+        previous = getattr(settings, "DJANGO_WAF_ENABLED", True)
+        settings.DJANGO_WAF_ENABLED = False
+        importlib.reload(conf_mod)
+        try:
+            # call_command("check") raises SystemCheckError (not a return
+            # value) the instant any registered check returns an Error.
+            # Before #95's guards, E003 (and, before #92, E004) would
+            # raise here on this exact profile; a clean return is the
+            # regression assertion.
+            call_command("check")
+        finally:
+            settings.DJANGO_WAF_ENABLED = previous
+            importlib.reload(conf_mod)
+
+    def test_check_command_aborts_when_site_password_misconfigured_even_disabled_guard_removed(self):
+        """Sanity check that this test harness can actually detect the
+        SystemCheckError abort this module guards against, so a silent
+        assertion-that-never-fails is not hiding a broken test. Exercises
+        the registry path with the WAF enabled and the exact BR-SP-002
+        misconfiguration, without touching the disabled-WAF guard itself."""
+        from django.conf import settings
+
+        import django_waf.conf as conf_mod
+
+        previous_enabled = getattr(settings, "DJANGO_WAF_ENABLED", True)
+        previous_pw_enabled = getattr(settings, "DJANGO_WAF_SITE_PASSWORD_ENABLED", False)
+        previous_pw = getattr(settings, "DJANGO_WAF_SITE_PASSWORD", "")
+        settings.DJANGO_WAF_ENABLED = True
+        settings.DJANGO_WAF_SITE_PASSWORD_ENABLED = True
+        settings.DJANGO_WAF_SITE_PASSWORD = ""
+        importlib.reload(conf_mod)
+        try:
+            with patch("django_waf.services.redis_client.is_redis_backend", return_value=True):
+                try:
+                    call_command("check")
+                except SystemCheckError as exc:
+                    assert "django_waf.E003" in str(exc)
+                else:
+                    raise AssertionError("expected SystemCheckError from django_waf.E003")
+        finally:
+            settings.DJANGO_WAF_ENABLED = previous_enabled
+            settings.DJANGO_WAF_SITE_PASSWORD_ENABLED = previous_pw_enabled
+            settings.DJANGO_WAF_SITE_PASSWORD = previous_pw
+            importlib.reload(conf_mod)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -75,6 +75,12 @@ def _run_site_password_configured_check():
     return check_site_password_configured(app_configs=None)
 
 
+def _run_middleware_present_check():
+    from django_waf.checks import check_middleware_present
+
+    return check_middleware_present(app_configs=None)
+
+
 class TestChallengeDifficultyCheck:
     def test_recommended_defaults_produce_no_messages(self):
         import django_waf.conf as conf_mod
@@ -364,6 +370,104 @@ class TestMiddlewareOrderingCheck:
             patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
         ):
             assert _run_middleware_ordering_check() == []
+
+
+class TestMiddlewarePresentCheck:
+    """django_waf.E006 -- errors when the WAF is enabled but WafMiddleware
+    (or a subclass, matched by class name) is absent from MIDDLEWARE
+    entirely (#101). Unlike W004, which only warns about ordering once the
+    middleware is found, this check is the one that catches it not being
+    there at all."""
+
+    def test_present_and_enabled_is_silent(self):
+        import django_waf.conf as conf_mod
+
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "django_waf.middleware.WafMiddleware",
+        ]
+
+        with (
+            override_settings(MIDDLEWARE=middleware),
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+        ):
+            assert _run_middleware_present_check() == []
+
+    def test_absent_and_disabled_is_silent(self):
+        """A disabled WAF is not expected to carry the middleware at all
+        (#95's own gating rationale) -- absence here is not a
+        misconfiguration."""
+        import django_waf.conf as conf_mod
+
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+        ]
+
+        with (
+            override_settings(MIDDLEWARE=middleware),
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+        ):
+            assert _run_middleware_present_check() == []
+
+    def test_present_with_engine_off_is_silent(self):
+        """The middleware is wired in but the master switch is off: still
+        silent, the same disabled-WAF precondition as the fully-absent
+        case above, just with the line still present in MIDDLEWARE."""
+        import django_waf.conf as conf_mod
+
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "django_waf.middleware.WafMiddleware",
+        ]
+
+        with (
+            override_settings(MIDDLEWARE=middleware),
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+        ):
+            assert _run_middleware_present_check() == []
+
+    def test_subclass_matched_by_class_name_is_silent(self):
+        """A subclass under a different dotted path is exactly as live as
+        the base class -- it must not be flagged as absent."""
+        import django_waf.conf as conf_mod
+
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+            "myproject.middleware.CustomWafMiddleware",
+        ]
+
+        with (
+            override_settings(MIDDLEWARE=middleware),
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+        ):
+            assert _run_middleware_present_check() == []
+
+    def test_absent_and_enabled_emits_e006_error(self):
+        """The #101 blackout class: WafMiddleware genuinely absent
+        from MIDDLEWARE while the WAF is switched on. This is the exact
+        brickworkui.com production state: installed, enabled, and
+        completely inert with manage.py check passing throughout."""
+        import django_waf.conf as conf_mod
+
+        middleware = [
+            "django.middleware.security.SecurityMiddleware",
+            "django.contrib.sessions.middleware.SessionMiddleware",
+            "django.contrib.auth.middleware.AuthenticationMiddleware",
+        ]
+
+        with (
+            override_settings(MIDDLEWARE=middleware),
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+        ):
+            messages = _run_middleware_present_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.E006"
+        assert "MIDDLEWARE" in messages[0].hint
 
 
 class TestTrustedCookieTrustLevelCheck:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -8,7 +8,6 @@ users out. The check refuses settings that would reproduce that lockout.
 
 from __future__ import annotations
 
-import importlib
 from unittest.mock import patch
 
 from django.core.management import call_command
@@ -675,39 +674,30 @@ class TestManagePyCheckWithWafDisabled:
     absent), and tests/settings.py sets it True explicitly, so this test
     must override it itself rather than relying on either.
 
-    django_waf.conf.DJANGO_WAF_ENABLED is a module-level constant read once
-    at conf.py's first import (see test_api.py's disabled_waf fixture for
-    the same note): settings.DJANGO_WAF_ENABLED is set directly and
-    django_waf.conf is reloaded so every check function reads the disabled
-    value, exactly as a real settings module would produce it at process
-    start. override_settings alone would not reach conf on this branch
-    (issue #75, not yet merged here). See the docstring note below on what
-    changes once it lands.
+    Uses ``override_settings`` rather than mutating ``django.conf.settings``
+    directly: since #75, ``django_waf.conf`` resolves every DJANGO_WAF_* name
+    at call time via module-level ``__getattr__``, so ``override_settings``
+    reaches it with no reload required. Before #75, conf.py's names were
+    plain module constants frozen at first import, so this test predated
+    that fix and reload was the only way to force a fresh snapshot; that
+    idiom leaked state on manual restore. ``override_settings`` deletes any
+    attribute it added and restores any it shadowed, whichever is
+    correct, avoiding that leak.
     """
 
     def test_check_command_completes_with_waf_disabled_and_locmem_cache(self):
-        from django.conf import settings
-
-        import django_waf.conf as conf_mod
-
         # tests/settings.py's CACHES["default"] is already LocMemCache
         # (never a django-redis backend), and DJANGO_WAF_SITE_PASSWORD is
         # unset there, so DJANGO_WAF_SITE_PASSWORD_ENABLED resolves False
         # by BR-SP-001's own default rule. The only override this test
         # needs is the master switch itself.
-        previous = getattr(settings, "DJANGO_WAF_ENABLED", True)
-        settings.DJANGO_WAF_ENABLED = False
-        importlib.reload(conf_mod)
-        try:
+        with override_settings(DJANGO_WAF_ENABLED=False):
             # call_command("check") raises SystemCheckError (not a return
             # value) the instant any registered check returns an Error.
             # Before #95's guards, E003 (and, before #92, E004) would
             # raise here on this exact profile; a clean return is the
             # regression assertion.
             call_command("check")
-        finally:
-            settings.DJANGO_WAF_ENABLED = previous
-            importlib.reload(conf_mod)
 
     def test_check_command_aborts_when_site_password_misconfigured_even_disabled_guard_removed(self):
         """Sanity check that this test harness can actually detect the
@@ -715,27 +705,17 @@ class TestManagePyCheckWithWafDisabled:
         assertion-that-never-fails is not hiding a broken test. Exercises
         the registry path with the WAF enabled and the exact BR-SP-002
         misconfiguration, without touching the disabled-WAF guard itself."""
-        from django.conf import settings
-
-        import django_waf.conf as conf_mod
-
-        previous_enabled = getattr(settings, "DJANGO_WAF_ENABLED", True)
-        previous_pw_enabled = getattr(settings, "DJANGO_WAF_SITE_PASSWORD_ENABLED", False)
-        previous_pw = getattr(settings, "DJANGO_WAF_SITE_PASSWORD", "")
-        settings.DJANGO_WAF_ENABLED = True
-        settings.DJANGO_WAF_SITE_PASSWORD_ENABLED = True
-        settings.DJANGO_WAF_SITE_PASSWORD = ""
-        importlib.reload(conf_mod)
-        try:
-            with patch("django_waf.services.redis_client.is_redis_backend", return_value=True):
-                try:
-                    call_command("check")
-                except SystemCheckError as exc:
-                    assert "django_waf.E003" in str(exc)
-                else:
-                    raise AssertionError("expected SystemCheckError from django_waf.E003")
-        finally:
-            settings.DJANGO_WAF_ENABLED = previous_enabled
-            settings.DJANGO_WAF_SITE_PASSWORD_ENABLED = previous_pw_enabled
-            settings.DJANGO_WAF_SITE_PASSWORD = previous_pw
-            importlib.reload(conf_mod)
+        with (
+            override_settings(
+                DJANGO_WAF_ENABLED=True,
+                DJANGO_WAF_SITE_PASSWORD_ENABLED=True,
+                DJANGO_WAF_SITE_PASSWORD="",
+            ),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=True),
+        ):
+            try:
+                call_command("check")
+            except SystemCheckError as exc:
+                assert "django_waf.E003" in str(exc)
+            else:
+                raise AssertionError("expected SystemCheckError from django_waf.E003")

--- a/tests/test_client_ip.py
+++ b/tests/test_client_ip.py
@@ -16,16 +16,7 @@ Covers the trusted-proxy resolution contract:
 
 from __future__ import annotations
 
-import importlib
-
 from django.test import RequestFactory, override_settings
-
-import django_waf.conf as conf_mod
-
-
-def _reload_conf():
-    importlib.reload(conf_mod)
-
 
 # ---------------------------------------------------------------------------
 # No trusted proxies configured (default) -- legacy / safe-default behaviour
@@ -36,7 +27,6 @@ class TestNoTrustedProxiesConfigured:
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=[], DJANGO_WAF_TRUST_X_FORWARDED_FOR=False)
     def test_spoofed_xff_from_untrusted_peer_is_ignored(self):
         """With no trusted proxies and the legacy trust flag off, XFF is never honoured."""
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -52,7 +42,6 @@ class TestNoTrustedProxiesConfigured:
     def test_legacy_trust_flag_preserves_leftmost_behaviour(self):
         """Legacy DJANGO_WAF_TRUST_X_FORWARDED_FOR=True with no trusted proxies
         preserves the old leftmost-XFF behaviour for backwards compatibility."""
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -66,7 +55,6 @@ class TestNoTrustedProxiesConfigured:
 
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=[], DJANGO_WAF_TRUST_X_FORWARDED_FOR=False)
     def test_no_xff_header_returns_remote_addr(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -85,7 +73,6 @@ class TestTrustedProxiesConfigured:
     def test_xff_honoured_only_when_remote_addr_is_trusted_proxy(self):
         """A request from an untrusted REMOTE_ADDR never gets XFF honoured,
         even with trusted proxies configured."""
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -100,7 +87,6 @@ class TestTrustedProxiesConfigured:
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"])
     def test_xff_honoured_when_remote_addr_is_trusted_proxy(self):
         """REMOTE_ADDR inside the trusted range -> rightmost non-proxy hop returned."""
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -116,7 +102,6 @@ class TestTrustedProxiesConfigured:
     def test_multiple_chained_trusted_proxies_resolve_to_real_client(self):
         """A chain of trusted proxies is walked right-to-left, skipping trusted
         hops, until the real (untrusted) client IP is found."""
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -134,7 +119,6 @@ class TestTrustedProxiesConfigured:
         """A client behind a trusted proxy cannot spoof by injecting a fake
         leftmost XFF entry -- only the rightmost non-proxy hop is trusted,
         so a forged entry ahead of the proxy-appended real IP is ignored."""
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -150,7 +134,6 @@ class TestTrustedProxiesConfigured:
 
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"])
     def test_all_hops_trusted_falls_back_to_remote_addr(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -171,7 +154,6 @@ class TestTrustedProxiesConfigured:
 class TestTrustedUnixSocket:
     @override_settings(DJANGO_WAF_TRUSTED_UNIX_SOCKET=False)
     def test_empty_remote_addr_does_not_trust_xff_by_default(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         request = RequestFactory().get(
@@ -184,7 +166,6 @@ class TestTrustedUnixSocket:
 
     @override_settings(DJANGO_WAF_TRUSTED_UNIX_SOCKET=True)
     def test_empty_remote_addr_uses_hardened_xff_walk(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         request = RequestFactory().get(
@@ -197,7 +178,6 @@ class TestTrustedUnixSocket:
 
     @override_settings(DJANGO_WAF_TRUSTED_UNIX_SOCKET=True)
     def test_empty_remote_addr_with_no_valid_xff_remains_empty(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         request = RequestFactory().get(
@@ -213,7 +193,6 @@ class TestTrustedUnixSocket:
         DJANGO_WAF_TRUSTED_UNIX_SOCKET=True,
     )
     def test_nonempty_untrusted_remote_addr_still_ignores_xff(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         request = RequestFactory().get(
@@ -233,7 +212,6 @@ class TestTrustedUnixSocket:
 class TestMalformedForwardedFor:
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"])
     def test_malformed_entries_are_skipped(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -247,7 +225,6 @@ class TestMalformedForwardedFor:
 
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"])
     def test_empty_entries_are_skipped(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -261,7 +238,6 @@ class TestMalformedForwardedFor:
 
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"])
     def test_empty_header_falls_back_to_remote_addr(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -271,7 +247,6 @@ class TestMalformedForwardedFor:
 
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"])
     def test_entirely_malformed_header_falls_back_to_remote_addr(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -288,7 +263,6 @@ class TestMalformedForwardedFor:
 class TestIPv6:
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["fd00::/8"])
     def test_ipv6_trusted_proxy_and_ipv6_client(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -302,7 +276,6 @@ class TestIPv6:
 
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"])
     def test_ipv4_trusted_proxy_with_ipv6_client(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -316,7 +289,6 @@ class TestIPv6:
 
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["fd00::/8"])
     def test_ipv6_remote_addr_not_in_trusted_range_ignores_xff(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()
@@ -338,7 +310,6 @@ class TestIPv6:
 class TestCrossSubsystemConsistency:
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["10.0.0.0/8"])
     def test_middleware_views_and_forms_defence_agree(self):
-        _reload_conf()
         from django_waf.forms.defences.render_token import _extract_ip as forms_extract_ip
         from django_waf.middleware import _extract_ip as middleware_extract_ip
         from django_waf.services.client_ip import resolve_client_ip
@@ -359,7 +330,6 @@ class TestCrossSubsystemConsistency:
 
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=[], DJANGO_WAF_TRUST_X_FORWARDED_FOR=False)
     def test_agree_on_spoofed_untrusted_request_too(self):
-        _reload_conf()
         from django_waf.forms.defences.render_token import _extract_ip as forms_extract_ip
         from django_waf.middleware import _extract_ip as middleware_extract_ip
         from django_waf.services.client_ip import resolve_client_ip
@@ -387,7 +357,6 @@ class TestCrossSubsystemConsistency:
 class TestInvalidTrustedProxyEntries:
     @override_settings(DJANGO_WAF_TRUSTED_PROXIES=["not-a-cidr"])
     def test_invalid_cidr_entry_is_skipped_not_fatal(self):
-        _reload_conf()
         from django_waf.services.client_ip import resolve_client_ip
 
         factory = RequestFactory()

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -57,6 +57,7 @@ class TestCeleryBeatScheduleDefault:
             "django_waf.tasks.sync_threat_feed",
             "django_waf.tasks.report_threat_telemetry",
             "django_waf.tasks.update_geoip_database",
+            "django_waf.tasks.probe_detectors",
         }
         actual_tasks = {entry["task"] for entry in conf_mod.DJANGO_WAF_CELERY_BEAT_SCHEDULE.values()}
         assert actual_tasks == expected_tasks

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -1,4 +1,4 @@
-"""Tests for django_waf.conf default values.
+"""Tests for django_waf.conf default values and call-time resolution (#75).
 
 Focused on settings whose defaults carry operational meaning (the threat-feed
 URLs point at a real operated server; telemetry stays opt-in) rather than
@@ -6,6 +6,12 @@ exhaustively re-asserting every setting in the module.
 """
 
 from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+from django.conf import LazySettings
+from django.test import override_settings
 
 import django_waf.conf as conf_mod
 
@@ -94,3 +100,170 @@ class TestCeleryBeatScheduleDefault:
             builtins.__import__ = real_import
             importlib.reload(conf_mod)
             sys.modules["django_waf.conf"] = conf_mod
+
+
+class TestCallTimeResolution:
+    """Every DJANGO_WAF_* name resolves live against django.conf.settings (#75).
+
+    Regression: before this fix, every setting was a module-level constant
+    computed once, at conf.py's first import, from ``getattr(settings, ...)``.
+    ``override_settings`` and the pytest ``settings`` fixture both mutate
+    ``django.conf.settings`` without reloading ``django_waf.conf``, so
+    neither had any effect on a value already frozen at import time. These
+    tests are written to fail against that old behaviour: each one asserts
+    an override takes effect with no reload anywhere in the test body.
+    """
+
+    def test_override_settings_takes_effect_without_reload(self):
+        before = conf_mod.DJANGO_WAF_LOG_SAMPLE_RATE
+        with override_settings(DJANGO_WAF_LOG_SAMPLE_RATE=0.5):
+            assert conf_mod.DJANGO_WAF_LOG_SAMPLE_RATE == 0.5
+        assert before == conf_mod.DJANGO_WAF_LOG_SAMPLE_RATE
+
+    def test_pytest_settings_fixture_takes_effect_without_reload(self, settings):
+        settings.DJANGO_WAF_LOG_SAMPLE_RATE = 0.75
+        assert conf_mod.DJANGO_WAF_LOG_SAMPLE_RATE == 0.75
+
+    def test_redis_alias_resolves_live(self, settings):
+        """The reported production defect: conf.DJANGO_WAF_REDIS_ALIAS must
+        track settings.DJANGO_WAF_REDIS_ALIAS, not the alias frozen at
+        whatever moment conf.py first imported.
+        """
+        assert conf_mod.DJANGO_WAF_REDIS_ALIAS == "default"
+        settings.DJANGO_WAF_REDIS_ALIAS = "waf"
+        assert conf_mod.DJANGO_WAF_REDIS_ALIAS == "waf"
+
+    def test_patch_object_round_trips_through_the_resolver(self, settings):
+        """mock.patch.object(conf_mod, ...) still works exactly as it would
+        against a plain module attribute (HAZARD 1): entering the patch
+        shadows the resolver, exiting restores live resolution rather than
+        permanently freezing the patched value. This is the guard against a
+        module-level ``def __getattr__`` that only round-trips today because
+        the reload-on-teardown fixture masked the alternative: this test
+        proves the resolver is genuinely consulted again after the patch
+        exits, not merely that no exception was raised.
+        """
+        settings.DJANGO_WAF_ENABLED = "live-value-one"
+        assert conf_mod.DJANGO_WAF_ENABLED == "live-value-one"
+
+        with mock.patch.object(conf_mod, "DJANGO_WAF_ENABLED", "patched-value"):
+            assert conf_mod.DJANGO_WAF_ENABLED == "patched-value"
+
+        # Proves the resolver is consulted again, not that a stale __dict__
+        # entry happens to match: change the live setting and confirm the
+        # NEW value is seen, which a permanently shadowed name could not do.
+        assert conf_mod.DJANGO_WAF_ENABLED == "live-value-one"
+        settings.DJANGO_WAF_ENABLED = "live-value-two"
+        assert conf_mod.DJANGO_WAF_ENABLED == "live-value-two"
+
+    def test_dir_includes_setting_names(self):
+        """__dir__ (PEP 562) so dir() and tab-completion still see the
+        settings names, since they are no longer plain module attributes.
+        """
+        names = dir(conf_mod)
+        assert "DJANGO_WAF_ENABLED" in names
+        assert "DJANGO_WAF_SITE_PASSWORD_ENABLED" in names
+
+    def test_unknown_name_raises_attribute_error(self):
+        with pytest.raises(AttributeError):
+            _ = conf_mod.DJANGO_WAF_NOT_A_REAL_SETTING
+
+
+class TestSitePasswordEnabledDerivation:
+    """DJANGO_WAF_SITE_PASSWORD_ENABLED recurses through the resolver for
+    DJANGO_WAF_SITE_PASSWORD (HAZARD 2), the one intra-conf cross-reference
+    among all 92 settings. BR-SP-001/BR-SP-002 (docs/specs/django-waf/
+    02-business-rules.md) require this default to reflect the CURRENT
+    password setting, not a value frozen at import time, since BR-SP-002's
+    fail-closed guarantee (gate enabled, no password, deny every request)
+    depends on the derived default seeing a password that is cleared or set
+    after conf.py first imported.
+    """
+
+    def test_defaults_false_when_no_password_is_set(self, settings):
+        settings.DJANGO_WAF_SITE_PASSWORD = ""
+        assert conf_mod.DJANGO_WAF_SITE_PASSWORD_ENABLED is False
+
+    def test_defaults_true_once_a_password_is_set_after_import(self, settings):
+        """The fail-open direction: setting a password after conf.py's
+        import must be enough on its own to flip the derived default, with
+        no explicit DJANGO_WAF_SITE_PASSWORD_ENABLED override.
+        """
+        settings.DJANGO_WAF_SITE_PASSWORD = "hunter2"
+        assert conf_mod.DJANGO_WAF_SITE_PASSWORD_ENABLED is True
+
+    def test_reverts_to_false_when_the_password_is_cleared(self, settings):
+        """The fail-closed direction: clearing the password after it was
+        set must revert the derived default, not leave it stuck True from
+        an earlier resolution.
+        """
+        settings.DJANGO_WAF_SITE_PASSWORD = "hunter2"
+        assert conf_mod.DJANGO_WAF_SITE_PASSWORD_ENABLED is True
+        settings.DJANGO_WAF_SITE_PASSWORD = ""
+        assert conf_mod.DJANGO_WAF_SITE_PASSWORD_ENABLED is False
+
+    def test_explicit_override_wins_over_the_derived_default(self, settings):
+        """An explicit DJANGO_WAF_SITE_PASSWORD_ENABLED setting still takes
+        priority over the derived default, in both directions.
+        """
+        settings.DJANGO_WAF_SITE_PASSWORD = "hunter2"
+        settings.DJANGO_WAF_SITE_PASSWORD_ENABLED = False
+        assert conf_mod.DJANGO_WAF_SITE_PASSWORD_ENABLED is False
+
+        settings.DJANGO_WAF_SITE_PASSWORD = ""
+        settings.DJANGO_WAF_SITE_PASSWORD_ENABLED = True
+        assert conf_mod.DJANGO_WAF_SITE_PASSWORD_ENABLED is True
+
+
+class TestUnconfiguredSettingsContract:
+    """Every DJANGO_WAF_* name resolves to its documented default, never
+    raising ImproperlyConfigured, when django.conf.settings is not yet
+    configured (#75, hazard 3).
+
+    This is what the README's documented consumer pattern relies on::
+
+        from django_waf.conf import DJANGO_WAF_CELERY_BEAT_SCHEDULE
+
+    executed from inside a consumer's own settings module, before that
+    settings module has finished running ``settings.configure()`` /
+    ``DJANGO_SETTINGS_MODULE`` resolution. A lazy resolver that unconditionally
+    called ``getattr(django.conf.settings, name, default)`` would raise
+    ImproperlyConfigured there, turning today's silent import-time-snapshot
+    defect into a hard boot failure for anyone following the documented API.
+
+    Honesty note: this test suite runs under pytest-django, which configures
+    Django settings once for the whole session, so genuinely un-configuring
+    settings mid-suite is not possible without corrupting every other test.
+    Instead this patches ``django.conf.LazySettings.configured`` (the real
+    property django_waf.conf._get_setting reads) to report ``False`` for the
+    duration of the block, which exercises the exact branch
+    ``_get_setting`` takes when settings truly are unconfigured, without
+    touching ``settings._wrapped`` or any other test's configured state.
+    """
+
+    def test_celery_beat_schedule_resolves_to_default_when_unconfigured(self):
+        with mock.patch.object(LazySettings, "configured", new_callable=mock.PropertyMock, return_value=False):
+            schedule = conf_mod.DJANGO_WAF_CELERY_BEAT_SCHEDULE
+        assert "django-waf-generate-blocklist" in schedule
+        assert schedule["django-waf-generate-blocklist"]["task"] == "django_waf.tasks.generate_blocklist"
+
+    def test_a_plain_setting_resolves_to_its_default_when_unconfigured(self):
+        with mock.patch.object(LazySettings, "configured", new_callable=mock.PropertyMock, return_value=False):
+            assert conf_mod.DJANGO_WAF_ENABLED is True
+
+    def test_resolving_while_unconfigured_does_not_touch_settings_at_all(self):
+        """A regression against a resolver that reads settings.configured
+        but then falls through to getattr(settings, ...) anyway: that would
+        still work by accident here (pytest-django keeps settings genuinely
+        configured underneath the patch), so this additionally proves
+        _get_setting takes the early-return branch by confirming its
+        result is the literal default object even when the live settings
+        value has been overridden to something else entirely.
+        """
+        with (
+            override_settings(DJANGO_WAF_ENABLED=False),
+            mock.patch.object(LazySettings, "configured", new_callable=mock.PropertyMock, return_value=False),
+        ):
+            # settings.DJANGO_WAF_ENABLED is False here, but _get_setting
+            # must never reach it once settings.configured reports False.
+            assert conf_mod.DJANGO_WAF_ENABLED is True

--- a/tests/test_detector_probe.py
+++ b/tests/test_detector_probe.py
@@ -1,0 +1,611 @@
+"""Tests for the detector liveness probe (BR-ANOM-012).
+
+Covers ``services.detector_probe.run_detector_probe``, the ``probe_detectors``
+Celery task, and the ``django_waf_probe_detectors`` management command.
+
+House discipline: mocked-service tests plus an explicit end-to-end test
+against the real (unmocked) anomaly detectors, mirroring
+``test_window_minutes_end_to_end_against_real_service`` and
+``TestDetectAnomaliesCommandDryRunEndToEnd``.
+
+The five most important tests in this file are the
+``test_probe_goes_red_when_<detector>_cannot_match_its_fixture`` tests, one
+per detector in ``DETECTOR_NAMES``: each gives its detector a fixture
+pinned independently of the setting (or, for detect_challenge_farms, the
+hardcoded literal) its own query compares against, so the REAL query
+genuinely finds nothing, with ``run_all_detectors`` and all five detector
+functions executing for real. An earlier revision of this file raised only
+the setting and left the fixture's size deriving from that SAME setting,
+which self-adjusts to stay just above whatever the threshold is raised to
+and therefore cannot be defeated; every test below pins the fixture size to
+a fixed literal via each builder's explicit size parameter instead. This is
+deliberately distinct from the mapping-logic tests further down (renamed
+from an earlier revision that patched ``run_all_detectors`` itself, which
+bypasses every detector and therefore cannot distinguish a working detector
+from a broken one): a probe that cannot be shown to fail against its OWN
+real query path, for every detector it names, is worth nothing.
+"""
+
+from __future__ import annotations
+
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from django_waf.services.anomaly_detector import DETECTOR_NAMES
+from django_waf.services.detector_probe import run_detector_probe
+
+# ---------------------------------------------------------------------------
+# run_detector_probe: falsifiability against the REAL detection path
+# ---------------------------------------------------------------------------
+#
+# These tests let run_all_detectors, and every real detector function, run
+# for real. Nothing here mocks run_all_detectors itself: doing so bypasses
+# the actual queries, which is exactly the layer 2.0.0's subnet regression
+# broke at, and a test built that way cannot tell a working detector from a
+# broken one, it can only tell you your own hand-written return_value from
+# itself.
+
+
+class TestRunDetectorProbeFalsifiability:
+    def test_probe_reports_all_alive_against_the_real_service(self, db):
+        """Baseline green: every detector reports alive against real fixture traffic.
+
+        Unmocked end-to-end run: proves the fixtures this module builds
+        really do cross every detector's own configured threshold, not just
+        that the reporting/mapping logic is self-consistent. Layer under
+        test: the full real path, run_all_detectors and all five detector
+        functions execute for real against the real fixture rows.
+        """
+        result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is True
+        assert result["silent_detectors"] == []
+        for detector_name in DETECTOR_NAMES:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+    def test_probe_goes_red_when_ua_rotation_cannot_match_its_fixture(self, db, monkeypatch):
+        """detect_ua_rotation: the real query legitimately finds nothing.
+
+        Layer under test: the full real path, exactly as in the green
+        baseline above. run_all_detectors is NOT patched, and
+        detect_ua_rotation is NOT patched: the real query runs against real
+        RequestLog rows and genuinely finds nothing.
+
+        Raising conf.DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS alone cannot
+        produce this: _build_ua_rotation_fixture's default row count derives
+        from the SAME live conf value (threshold + 1), so it self-adjusts to
+        stay just above whatever the threshold is regardless of how high it
+        is raised. What actually decouples them, the way a real regression
+        does (the fixture represents real traffic and stays fixed; the
+        query's own matching logic is what breaks), is pinning the
+        fixture's size independently of the setting the query reads: this
+        test wraps _build_ua_rotation_fixture with its explicit
+        distinct_ua_count=20 (the builder's own decoupling parameter, added
+        for exactly this purpose) while raising the threshold to 9999, so
+        the fixture no longer tracks the query's own threshold. The real
+        query then runs, real RequestLog rows exist, and it genuinely finds
+        no IP clearing 9999 distinct UAs. This is the closest analogue to
+        the production failure the probe exists to catch (2.0.0's subnet
+        query silently stopped matching real rows): a real query, real
+        rows, a real empty result.
+
+        The other four detectors are untouched (their own _build_*_fixture
+        helpers still run for real, at their own conf-derived defaults) and
+        must still report alive.
+        """
+        from django_waf import conf
+        from django_waf.services import detector_probe as detector_probe_mod
+
+        monkeypatch.setattr(conf, "DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS", 9999)
+
+        real_builder = detector_probe_mod._build_ua_rotation_fixture
+        monkeypatch.setattr(
+            detector_probe_mod,
+            "_build_ua_rotation_fixture",
+            lambda *, now, conf: real_builder(now=now, conf=conf, distinct_ua_count=20),
+        )
+
+        result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_ua_rotation"]
+        assert result["detect_ua_rotation"]["alive"] is False
+        assert result["detect_ua_rotation"]["rules_reported"] == 0
+        for detector_name in DETECTOR_NAMES - {"detect_ua_rotation"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+    def test_probe_goes_red_when_a_real_detector_function_is_replaced(self, db):
+        """A second, cheaper falsifiability route: patch detect_ua_rotation
+        itself (not run_all_detectors) so run_all_detectors, and the other
+        four real detector functions, still execute for real; only the one
+        named function is swapped for a stub returning [].
+
+        Layer under test: run_all_detectors' own dispatch and aggregation
+        logic runs for real; only detect_ua_rotation's internals are
+        replaced. This is weaker evidence than the threshold test above
+        (it does not prove the real query can fail, only that a genuinely
+        empty detector result flows correctly through run_all_detectors and
+        into the probe's report), but it is cheaper to reason about and
+        pins run_all_detectors' own aggregation independently of any one
+        detector's query shape.
+        """
+        with patch("django_waf.services.anomaly_detector.detect_ua_rotation", return_value=[]):
+            result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_ua_rotation"]
+        assert result["detect_ua_rotation"]["alive"] is False
+        assert result["detect_ua_rotation"]["rules_reported"] == 0
+        for detector_name in DETECTOR_NAMES - {"detect_ua_rotation"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+    def test_probe_goes_red_when_subnet_burst_cannot_match_its_fixture(self, db, monkeypatch):
+        """detect_subnet_burst: the real query legitimately finds nothing.
+
+        Layer under test: the full real path. run_all_detectors is NOT
+        patched, and detect_subnet_burst is NOT patched.
+
+        detect_subnet_burst has two independent gates
+        (``count < min_count and count <= burst_threshold: continue``), an
+        absolute floor (DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT)
+        and a 3x-median ratio, either of which is sufficient to trigger a
+        match (issue #80). Pinning the fixture's request count to a fixed 5
+        (via the builder's total_requests parameter) while raising the
+        floor to 9999 defeats the first gate; the second gate (median
+        ratio) is also checked here rather than assumed: with the other
+        four detectors' fixtures present in the same window, the median
+        across all subnets stays low enough (the pinned subnet's own count
+        of 5 does not exceed 3x that median either), so neither gate fires
+        and the real query genuinely returns [].
+        """
+        from django_waf import conf
+        from django_waf.services import detector_probe as detector_probe_mod
+
+        monkeypatch.setattr(conf, "DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT", 9999)
+
+        real_builder = detector_probe_mod._build_subnet_burst_fixture
+        monkeypatch.setattr(
+            detector_probe_mod,
+            "_build_subnet_burst_fixture",
+            lambda *, now, conf: real_builder(now=now, conf=conf, total_requests=5),
+        )
+
+        result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_subnet_burst"]
+        assert result["detect_subnet_burst"]["alive"] is False
+        assert result["detect_subnet_burst"]["rules_reported"] == 0
+        for detector_name in DETECTOR_NAMES - {"detect_subnet_burst"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+    def test_probe_goes_red_when_unsolved_challenges_cannot_match_its_fixture(self, db, monkeypatch):
+        """detect_unsolved_challenges (per-IP path): the real query finds nothing.
+
+        Layer under test: the full real path. run_all_detectors is NOT
+        patched, and detect_unsolved_challenges is NOT patched.
+
+        Pins the fixture to a fixed 2 challenged rows (via the builder's
+        challenged_count parameter) while raising
+        DJANGO_WAF_UNSOLVED_MIN_CHALLENGED to 9999, so the per-IP
+        candidates = [row for row in challenged_by_ip if
+        row["challenged_count"] >= min_challenged] gate genuinely excludes
+        the fixture IP, and the real query returns [] for the per-IP path.
+
+        This targets the per-IP path specifically, not the subnet path
+        (which uses different settings, DJANGO_WAF_UNSOLVED_SUBNET_MIN_
+        CHALLENGED / DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS, and is already
+        unreachable by this fixture's single contributing IP regardless of
+        DJANGO_WAF_UNSOLVED_MIN_CHALLENGED, since it never reaches the
+        subnet path's distinct-IP floor of 10): raising the per-IP setting
+        cannot accidentally trip the subnet path into creating a rule that
+        would mask the per-IP path's failure.
+        """
+        from django_waf import conf
+        from django_waf.services import detector_probe as detector_probe_mod
+
+        monkeypatch.setattr(conf, "DJANGO_WAF_UNSOLVED_MIN_CHALLENGED", 9999)
+
+        real_builder = detector_probe_mod._build_unsolved_challenge_fixture
+        monkeypatch.setattr(
+            detector_probe_mod,
+            "_build_unsolved_challenge_fixture",
+            lambda *, now, conf: real_builder(now=now, conf=conf, challenged_count=2),
+        )
+
+        result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_unsolved_challenges"]
+        assert result["detect_unsolved_challenges"]["alive"] is False
+        assert result["detect_unsolved_challenges"]["rules_reported"] == 0
+        for detector_name in DETECTOR_NAMES - {"detect_unsolved_challenges"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+    def test_probe_goes_red_when_cloud_spray_cannot_match_its_fixture(self, db, monkeypatch):
+        """detect_cloud_spray: the real query legitimately finds nothing.
+
+        Layer under test: the full real path. run_all_detectors is NOT
+        patched, and detect_cloud_spray is NOT patched.
+
+        DJANGO_WAF_CLOUD_SPRAY_MIN_IPS gates the detector twice: the
+        UA-level distinct-IP aggregation (``.filter(distinct_ips__gte=
+        min_ips)``) and the subsequent per-IP recheck (``len(suspicious_ips)
+        < min_ips: continue``). Pinning the fixture to a fixed 5 distinct
+        IPs (via the builder's distinct_ip_count parameter) while raising
+        the setting to 9999 defeats both gates in one move, since both read
+        the same setting: the UA never even reaches the results returned by
+        the first query, so the real query genuinely returns [].
+        """
+        from django_waf import conf
+        from django_waf.services import detector_probe as detector_probe_mod
+
+        monkeypatch.setattr(conf, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 9999)
+
+        real_builder = detector_probe_mod._build_cloud_spray_fixture
+        monkeypatch.setattr(
+            detector_probe_mod,
+            "_build_cloud_spray_fixture",
+            lambda *, now, conf: real_builder(now=now, conf=conf, distinct_ip_count=5),
+        )
+
+        result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_cloud_spray"]
+        assert result["detect_cloud_spray"]["alive"] is False
+        assert result["detect_cloud_spray"]["rules_reported"] == 0
+        for detector_name in DETECTOR_NAMES - {"detect_cloud_spray"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+    def test_probe_goes_red_when_challenge_farms_cannot_match_its_fixture(self, db, monkeypatch):
+        """detect_challenge_farms: the real query legitimately finds nothing.
+
+        Layer under test: the full real path. run_all_detectors is NOT
+        patched, and detect_challenge_farms is NOT patched.
+
+        Unlike the other four detectors, BR-ANOM-003's thresholds
+        (``challenge_failures__gt=10, challenge_passes__lt=2``) are
+        hardcoded in the detector itself, not settings-driven, so there is
+        no conf setting to raise: the coupling trap the other four had does
+        not exist here. Instead, the fixture is built with
+        challenge_failures=10 (via the builder's own parameter), which
+        fails the detector's hardcoded ``__gt=10`` comparison (10 is not
+        greater than 10), so the real query genuinely returns [].
+        """
+        from django_waf.services import detector_probe as detector_probe_mod
+
+        real_builder = detector_probe_mod._build_challenge_farm_fixture
+        monkeypatch.setattr(
+            detector_probe_mod,
+            "_build_challenge_farm_fixture",
+            lambda *, now, conf: real_builder(now=now, conf=conf, challenge_failures=10, challenge_passes=0),
+        )
+
+        result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_challenge_farms"]
+        assert result["detect_challenge_farms"]["alive"] is False
+        assert result["detect_challenge_farms"]["rules_reported"] == 0
+        for detector_name in DETECTOR_NAMES - {"detect_challenge_farms"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+
+class TestRunDetectorProbeReportingLogic:
+    """Mapping/reporting-logic tests: a hand-written run_all_detectors result
+    dict becomes the correct alive/silent report. These do NOT exercise any
+    real detector or query; they exist to pin the reporting layer
+    (DETECTOR_NAME_TO_RESULT_KEY lookup, all_alive/silent_detectors
+    derivation) independently of detection logic, which the tests above
+    already cover. Renamed from an earlier revision that called these
+    "falsifiability" tests, which they are not: run_all_detectors never
+    runs here, so they cannot distinguish a working detector from a broken
+    one, only prove that a zero in a dict you wrote by hand is reported as
+    silent.
+    """
+
+    def test_zero_count_in_result_dict_is_reported_as_silent(self, db):
+        broken_result = {
+            "ua_rotation_rules": 0,
+            "subnet_burst_rules": 1,
+            "challenge_farm_rules": 1,
+            "unsolved_challenge_rules": 1,
+            "cloud_spray_rules": 1,
+            "total_rules_created": 4,
+        }
+
+        with patch(
+            "django_waf.services.anomaly_detector.run_all_detectors",
+            return_value=broken_result,
+        ):
+            result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_ua_rotation"]
+        assert result["detect_ua_rotation"]["alive"] is False
+        assert result["detect_ua_rotation"]["rules_reported"] == 0
+        for detector_name in DETECTOR_NAMES - {"detect_ua_rotation"}:
+            assert result[detector_name]["alive"] is True
+
+    def test_multiple_zero_counts_are_all_reported_as_silent(self, db):
+        """Two zeroed keys in a hand-written result dict are both named, not just the first."""
+        broken_result = {
+            "ua_rotation_rules": 0,
+            "subnet_burst_rules": 0,
+            "challenge_farm_rules": 1,
+            "unsolved_challenge_rules": 1,
+            "cloud_spray_rules": 1,
+            "total_rules_created": 3,
+        }
+
+        with patch(
+            "django_waf.services.anomaly_detector.run_all_detectors",
+            return_value=broken_result,
+        ):
+            result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_subnet_burst", "detect_ua_rotation"]
+
+
+# ---------------------------------------------------------------------------
+# run_detector_probe: no side effects
+# ---------------------------------------------------------------------------
+
+
+class TestRunDetectorProbeLeavesNoRowsBehind:
+    def test_probe_leaves_no_rows_behind(self, db):
+        """Direct analogue of test_dry_run_creates_zero_block_rules: after a
+        probe run, RequestLog, IPReputation, and BlockRule row counts are
+        all unchanged. This is the rollback guarantee: no synthetic row may
+        ever survive, regardless of dry_run.
+        """
+        from django_waf.models import BlockRule, IPReputation, RequestLog
+
+        before_logs = RequestLog.objects.count()
+        before_reputation = IPReputation.objects.count()
+        before_rules = BlockRule.objects.count()
+
+        run_detector_probe(dry_run=True)
+
+        assert RequestLog.objects.count() == before_logs
+        assert IPReputation.objects.count() == before_reputation
+        assert BlockRule.objects.count() == before_rules
+
+    def test_probe_leaves_no_rows_behind_with_exercise_writes(self, db):
+        """The rollback guarantee holds even with dry_run=False (exercise-writes),
+        which makes the detectors perform real writes inside the transaction:
+        the surrounding rollback must still discard everything.
+        """
+        from django_waf.models import BlockRule, IPReputation, RequestLog
+
+        before_logs = RequestLog.objects.count()
+        before_reputation = IPReputation.objects.count()
+        before_rules = BlockRule.objects.count()
+
+        run_detector_probe(dry_run=False)
+
+        assert RequestLog.objects.count() == before_logs
+        assert IPReputation.objects.count() == before_reputation
+        assert BlockRule.objects.count() == before_rules
+
+    def test_probe_leaves_no_rows_behind_when_fixture_construction_raises(self, db):
+        """The rollback is unconditional: even if something inside the
+        transaction raises, no synthetic row survives.
+        """
+        from django_waf.models import BlockRule, IPReputation, RequestLog
+
+        before_logs = RequestLog.objects.count()
+        before_reputation = IPReputation.objects.count()
+        before_rules = BlockRule.objects.count()
+
+        with (
+            patch(
+                "django_waf.services.detector_probe._build_challenge_farm_fixture",
+                side_effect=ValueError("simulated fixture-construction failure"),
+            ),
+            pytest.raises(ValueError, match="simulated fixture-construction failure"),
+        ):
+            run_detector_probe(dry_run=True)
+
+        assert RequestLog.objects.count() == before_logs
+        assert IPReputation.objects.count() == before_reputation
+        assert BlockRule.objects.count() == before_rules
+
+
+# ---------------------------------------------------------------------------
+# run_detector_probe: dry_run forwarding and DETECTOR_NAMES mapping
+# ---------------------------------------------------------------------------
+
+
+class TestRunDetectorProbeDryRunForwarding:
+    def test_dry_run_true_is_forwarded_to_run_all_detectors(self, db):
+        from django_waf.services.anomaly_detector import DETECTOR_NAME_TO_RESULT_KEY
+
+        with patch(
+            "django_waf.services.anomaly_detector.run_all_detectors",
+            return_value=dict.fromkeys(DETECTOR_NAME_TO_RESULT_KEY.values(), 1),
+        ) as mock_run:
+            run_detector_probe(dry_run=True)
+
+        mock_run.assert_called_once_with(dry_run=True)
+
+    def test_dry_run_false_exercise_writes_is_forwarded(self, db):
+        from django_waf.services.anomaly_detector import DETECTOR_NAME_TO_RESULT_KEY
+
+        with patch(
+            "django_waf.services.anomaly_detector.run_all_detectors",
+            return_value=dict.fromkeys(DETECTOR_NAME_TO_RESULT_KEY.values(), 1),
+        ) as mock_run:
+            run_detector_probe(dry_run=False)
+
+        mock_run.assert_called_once_with(dry_run=False)
+
+    def test_result_dry_run_key_echoes_argument(self, db):
+        result_true = run_detector_probe(dry_run=True)
+        assert result_true["dry_run"] is True
+
+    def test_report_is_keyed_on_detector_names_not_result_dict_keys(self, db):
+        """The report dict's keys are DETECTOR_NAMES entries (function names),
+        never run_all_detectors' own result-dict keys (e.g. "ua_rotation_rules"),
+        which is the whole point of the DETECTOR_NAME_TO_RESULT_KEY mapping.
+        """
+        result = run_detector_probe(dry_run=True)
+
+        for detector_name in DETECTOR_NAMES:
+            assert detector_name in result
+        assert "ua_rotation_rules" not in result
+        assert "total_rules_created" not in result
+
+
+# ---------------------------------------------------------------------------
+# probe_detectors task
+# ---------------------------------------------------------------------------
+
+
+class TestProbeDetectorsTask:
+    def test_calls_run_detector_probe_and_returns_result(self, db):
+        from django_waf.tasks import probe_detectors
+
+        expected = {
+            "all_alive": True,
+            "silent_detectors": [],
+            "dry_run": True,
+            **{name: {"alive": True, "rules_reported": 1} for name in DETECTOR_NAMES},
+        }
+
+        with patch(
+            "django_waf.services.detector_probe.run_detector_probe",
+            return_value=expected,
+        ) as mock_probe:
+            result = probe_detectors()
+
+        mock_probe.assert_called_once_with(dry_run=True)
+        assert result == expected
+
+    def test_task_never_raises_and_reports_failure_as_a_result(self, db):
+        """The task's whole point is unattended liveness reporting: an
+        exception from the service layer must be caught, logged, and turned
+        into a failure-shaped result, never propagated.
+        """
+        from django_waf.tasks import probe_detectors
+
+        with patch(
+            "django_waf.services.detector_probe.run_detector_probe",
+            side_effect=RuntimeError("simulated probe crash"),
+        ):
+            result = probe_detectors()
+
+        assert result["all_alive"] is False
+        assert set(result["silent_detectors"]) == set(DETECTOR_NAMES)
+        assert "error" in result
+
+    def test_task_default_dry_run_is_true(self, db):
+        """The scheduled task always runs in dry-run mode: it never exposes
+        exercise-writes, since a signal wired to paging firing on a schedule
+        from synthetic data would be a self-inflicted incident.
+        """
+        from django_waf.tasks import probe_detectors
+
+        with patch(
+            "django_waf.services.detector_probe.run_detector_probe",
+            return_value={"all_alive": True, "silent_detectors": [], "dry_run": True},
+        ) as mock_probe:
+            probe_detectors()
+
+        mock_probe.assert_called_once_with(dry_run=True)
+
+
+# ---------------------------------------------------------------------------
+# django_waf_probe_detectors command
+# ---------------------------------------------------------------------------
+
+
+class TestProbeDetectorsCommand:
+    @pytest.mark.django_db
+    def test_all_alive_reports_success(self):
+        """Real (unmocked) end-to-end run: the command completes cleanly
+        and reports every detector alive, mirroring
+        TestDetectAnomaliesCommandDryRunEndToEnd's real-service pattern.
+        """
+        out = StringIO()
+        call_command("django_waf_probe_detectors", stdout=out)
+
+        output = out.getvalue()
+        assert "All detectors alive." in output
+        for detector_name in DETECTOR_NAMES:
+            assert f"{detector_name}: alive" in output
+
+    @pytest.mark.django_db
+    def test_silent_detector_raises_command_error_with_exit_status(self):
+        """A silent detector must raise CommandError so a cron wrapper or
+        k8s probe can key off exit status 1, per this command's deliberate
+        departure from most django-waf commands.
+        """
+        broken_result = {
+            "ua_rotation_rules": 0,
+            "subnet_burst_rules": 1,
+            "challenge_farm_rules": 1,
+            "unsolved_challenge_rules": 1,
+            "cloud_spray_rules": 1,
+            "total_rules_created": 4,
+        }
+
+        with patch(
+            "django_waf.services.anomaly_detector.run_all_detectors",
+            return_value=broken_result,
+        ):
+            out = StringIO()
+            with pytest.raises(CommandError, match="detect_ua_rotation"):
+                call_command("django_waf_probe_detectors", stdout=out)
+
+    @pytest.mark.django_db
+    def test_exercise_writes_flag_forwarded_as_dry_run_false(self):
+        with patch("django_waf.services.detector_probe.run_detector_probe") as mock_probe:
+            mock_probe.return_value = {
+                "all_alive": True,
+                "silent_detectors": [],
+                "dry_run": False,
+                **{name: {"alive": True, "rules_reported": 1} for name in DETECTOR_NAMES},
+            }
+            out = StringIO()
+            call_command("django_waf_probe_detectors", "--exercise-writes", stdout=out)
+
+        mock_probe.assert_called_once_with(dry_run=False)
+        assert "exercise-writes" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_default_invocation_uses_dry_run(self):
+        with patch("django_waf.services.detector_probe.run_detector_probe") as mock_probe:
+            mock_probe.return_value = {
+                "all_alive": True,
+                "silent_detectors": [],
+                "dry_run": True,
+                **{name: {"alive": True, "rules_reported": 1} for name in DETECTOR_NAMES},
+            }
+            out = StringIO()
+            call_command("django_waf_probe_detectors", stdout=out)
+
+        mock_probe.assert_called_once_with(dry_run=True)
+
+    @pytest.mark.django_db
+    def test_service_exception_raises_command_error(self):
+        with patch(
+            "django_waf.services.detector_probe.run_detector_probe",
+            side_effect=RuntimeError("boom"),
+        ):
+            out = StringIO()
+            with pytest.raises(CommandError, match="Detector probe failed to run"):
+                call_command("django_waf_probe_detectors", stdout=out)

--- a/tests/test_detector_probe.py
+++ b/tests/test_detector_probe.py
@@ -112,8 +112,6 @@ class TestRunDetectorProbeFalsifiability:
         from django_waf import conf
         from django_waf.services import detector_probe as detector_probe_mod
 
-        monkeypatch.setattr(conf, "DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS", 9999)
-
         real_builder = detector_probe_mod._build_ua_rotation_fixture
         monkeypatch.setattr(
             detector_probe_mod,
@@ -121,7 +119,8 @@ class TestRunDetectorProbeFalsifiability:
             lambda *, now, conf: real_builder(now=now, conf=conf, distinct_ua_count=25),
         )
 
-        result = run_detector_probe(dry_run=True)
+        with patch.object(conf, "DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS", 9999):
+            result = run_detector_probe(dry_run=True)
 
         assert result["all_alive"] is False
         assert result["silent_detectors"] == ["detect_ua_rotation"]
@@ -191,8 +190,6 @@ class TestRunDetectorProbeFalsifiability:
         from django_waf import conf
         from django_waf.services import detector_probe as detector_probe_mod
 
-        monkeypatch.setattr(conf, "DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT", 9999)
-
         real_builder = detector_probe_mod._build_subnet_burst_fixture
         monkeypatch.setattr(
             detector_probe_mod,
@@ -200,7 +197,8 @@ class TestRunDetectorProbeFalsifiability:
             lambda *, now, conf: real_builder(now=now, conf=conf, total_requests=31),
         )
 
-        result = run_detector_probe(dry_run=True)
+        with patch.object(conf, "DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT", 9999):
+            result = run_detector_probe(dry_run=True)
 
         assert result["all_alive"] is False
         assert result["silent_detectors"] == ["detect_subnet_burst"]
@@ -247,8 +245,6 @@ class TestRunDetectorProbeFalsifiability:
         from django_waf import conf
         from django_waf.services import detector_probe as detector_probe_mod
 
-        monkeypatch.setattr(conf, "DJANGO_WAF_UNSOLVED_MIN_CHALLENGED", 9999)
-
         real_builder = detector_probe_mod._build_unsolved_challenge_fixture
         monkeypatch.setattr(
             detector_probe_mod,
@@ -256,7 +252,8 @@ class TestRunDetectorProbeFalsifiability:
             lambda *, now, conf: real_builder(now=now, conf=conf, challenged_count=5),
         )
 
-        result = run_detector_probe(dry_run=True)
+        with patch.object(conf, "DJANGO_WAF_UNSOLVED_MIN_CHALLENGED", 9999):
+            result = run_detector_probe(dry_run=True)
 
         assert result["all_alive"] is False
         assert result["silent_detectors"] == ["detect_unsolved_challenges"]
@@ -298,8 +295,6 @@ class TestRunDetectorProbeFalsifiability:
         from django_waf import conf
         from django_waf.services import detector_probe as detector_probe_mod
 
-        monkeypatch.setattr(conf, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 9999)
-
         real_builder = detector_probe_mod._build_cloud_spray_fixture
         monkeypatch.setattr(
             detector_probe_mod,
@@ -307,7 +302,8 @@ class TestRunDetectorProbeFalsifiability:
             lambda *, now, conf: real_builder(now=now, conf=conf, distinct_ip_count=21),
         )
 
-        result = run_detector_probe(dry_run=True)
+        with patch.object(conf, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 9999):
+            result = run_detector_probe(dry_run=True)
 
         assert result["all_alive"] is False
         assert result["silent_detectors"] == ["detect_cloud_spray"]

--- a/tests/test_detector_probe.py
+++ b/tests/test_detector_probe.py
@@ -85,7 +85,7 @@ class TestRunDetectorProbeFalsifiability:
         query's own matching logic is what breaks), is pinning the
         fixture's size independently of the setting the query reads: this
         test wraps _build_ua_rotation_fixture with its explicit
-        distinct_ua_count=20 (the builder's own decoupling parameter, added
+        distinct_ua_count=25 (the builder's own decoupling parameter, added
         for exactly this purpose) while raising the threshold to 9999, so
         the fixture no longer tracks the query's own threshold. The real
         query then runs, real RequestLog rows exist, and it genuinely finds
@@ -93,6 +93,17 @@ class TestRunDetectorProbeFalsifiability:
         the production failure the probe exists to catch (2.0.0's subnet
         query silently stopped matching real rows): a real query, real
         rows, a real empty result.
+
+        25 is deliberately above the query's REAL, un-raised default
+        threshold of 20 (``distinct_ua_count__gt=20``), not merely "some
+        number below 9999": pinning at exactly 20 would fail the query's
+        strict ``__gt`` comparison even with the raise removed (20 is not
+        greater than 20), which would make this test pass whether or not
+        conf.DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS was ever monkeypatched,
+        the same class of vacuity this test exists to rule out. 25 clears
+        the real default (25 > 20, so with the raise removed the query
+        WOULD match and the test would correctly fail), so the raise to
+        9999 is the only thing that makes the query miss.
 
         The other four detectors are untouched (their own _build_*_fixture
         helpers still run for real, at their own conf-derived defaults) and
@@ -107,7 +118,7 @@ class TestRunDetectorProbeFalsifiability:
         monkeypatch.setattr(
             detector_probe_mod,
             "_build_ua_rotation_fixture",
-            lambda *, now, conf: real_builder(now=now, conf=conf, distinct_ua_count=20),
+            lambda *, now, conf: real_builder(now=now, conf=conf, distinct_ua_count=25),
         )
 
         result = run_detector_probe(dry_run=True)
@@ -156,14 +167,26 @@ class TestRunDetectorProbeFalsifiability:
         (``count < min_count and count <= burst_threshold: continue``), an
         absolute floor (DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT)
         and a 3x-median ratio, either of which is sufficient to trigger a
-        match (issue #80). Pinning the fixture's request count to a fixed 5
+        match (issue #80). Pinning the fixture's request count to a fixed 31
         (via the builder's total_requests parameter) while raising the
         floor to 9999 defeats the first gate; the second gate (median
         ratio) is also checked here rather than assumed: with the other
         four detectors' fixtures present in the same window, the median
         across all subnets stays low enough (the pinned subnet's own count
-        of 5 does not exceed 3x that median either), so neither gate fires
+        of 31 does not exceed 3x that median either), so neither gate fires
         and the real query genuinely returns [].
+
+        31, not a smaller number such as 5, is deliberately chosen to be one
+        ABOVE the real, un-raised default floor of 30
+        (DJANGO_WAF_ANOMALY_THRESHOLD_SUBNET_BURST_MIN_COUNT's default):
+        with the floor at its real default, this fixture's count of 31
+        clears ``count < min_count`` (31 is not less than 30) and so WOULD
+        create a rule, and the test would correctly fail, if the raise to
+        9999 were ever removed or not actually reaching the query. A
+        fixture pinned below the real default (e.g. 5) fails the floor gate
+        whether or not the setting is raised at all, which would make this
+        assertion pass regardless of whether the monkeypatched conf value
+        is real, live conf read by the query.
         """
         from django_waf import conf
         from django_waf.services import detector_probe as detector_probe_mod
@@ -174,7 +197,7 @@ class TestRunDetectorProbeFalsifiability:
         monkeypatch.setattr(
             detector_probe_mod,
             "_build_subnet_burst_fixture",
-            lambda *, now, conf: real_builder(now=now, conf=conf, total_requests=5),
+            lambda *, now, conf: real_builder(now=now, conf=conf, total_requests=31),
         )
 
         result = run_detector_probe(dry_run=True)
@@ -193,12 +216,24 @@ class TestRunDetectorProbeFalsifiability:
         Layer under test: the full real path. run_all_detectors is NOT
         patched, and detect_unsolved_challenges is NOT patched.
 
-        Pins the fixture to a fixed 2 challenged rows (via the builder's
+        Pins the fixture to a fixed 5 challenged rows (via the builder's
         challenged_count parameter) while raising
         DJANGO_WAF_UNSOLVED_MIN_CHALLENGED to 9999, so the per-IP
         candidates = [row for row in challenged_by_ip if
         row["challenged_count"] >= min_challenged] gate genuinely excludes
         the fixture IP, and the real query returns [] for the per-IP path.
+
+        5, not a smaller number such as 2, is deliberately chosen to be
+        ABOVE the real, un-raised default of 3
+        (DJANGO_WAF_UNSOLVED_MIN_CHALLENGED's default): with the setting at
+        its real default, this fixture's count of 5 clears
+        ``challenged_count >= min_challenged`` (5 >= 3) and so WOULD create
+        a rule, and the test would correctly fail, if the raise to 9999
+        were ever removed or not actually reaching the query. A fixture
+        pinned below the real default (e.g. 2, which fails 2 >= 3 on its
+        own) fails the gate whether or not the setting is raised at all,
+        which would make this assertion pass regardless of whether the
+        monkeypatched conf value is real, live conf read by the query.
 
         This targets the per-IP path specifically, not the subnet path
         (which uses different settings, DJANGO_WAF_UNSOLVED_SUBNET_MIN_
@@ -218,7 +253,7 @@ class TestRunDetectorProbeFalsifiability:
         monkeypatch.setattr(
             detector_probe_mod,
             "_build_unsolved_challenge_fixture",
-            lambda *, now, conf: real_builder(now=now, conf=conf, challenged_count=2),
+            lambda *, now, conf: real_builder(now=now, conf=conf, challenged_count=5),
         )
 
         result = run_detector_probe(dry_run=True)
@@ -240,11 +275,25 @@ class TestRunDetectorProbeFalsifiability:
         DJANGO_WAF_CLOUD_SPRAY_MIN_IPS gates the detector twice: the
         UA-level distinct-IP aggregation (``.filter(distinct_ips__gte=
         min_ips)``) and the subsequent per-IP recheck (``len(suspicious_ips)
-        < min_ips: continue``). Pinning the fixture to a fixed 5 distinct
+        < min_ips: continue``). Pinning the fixture to a fixed 21 distinct
         IPs (via the builder's distinct_ip_count parameter) while raising
         the setting to 9999 defeats both gates in one move, since both read
         the same setting: the UA never even reaches the results returned by
         the first query, so the real query genuinely returns [].
+
+        21, not a smaller number such as 5, is deliberately chosen to be
+        ABOVE the real, un-raised default of 20
+        (DJANGO_WAF_CLOUD_SPRAY_MIN_IPS's default): with the setting at its
+        real default, this fixture's 21 distinct IPs clears
+        ``distinct_ips__gte=min_ips`` (21 >= 20) and so WOULD create a rule,
+        and the test would correctly fail, if the raise to 9999 were ever
+        removed or not actually reaching the query. A fixture pinned below
+        the real default (e.g. 5, which fails 5 >= 20 on its own) fails the
+        gate whether or not the setting is raised at all, which would make
+        this assertion pass regardless of whether the monkeypatched conf
+        value is real, live conf read by the query. All 21 IPs still share
+        one /24 (the fixture's own contiguous range), so the subsequent
+        per-subnet ``count < 2: continue`` gate remains trivially cleared.
         """
         from django_waf import conf
         from django_waf.services import detector_probe as detector_probe_mod
@@ -255,7 +304,7 @@ class TestRunDetectorProbeFalsifiability:
         monkeypatch.setattr(
             detector_probe_mod,
             "_build_cloud_spray_fixture",
-            lambda *, now, conf: real_builder(now=now, conf=conf, distinct_ip_count=5),
+            lambda *, now, conf: real_builder(now=now, conf=conf, distinct_ip_count=21),
         )
 
         result = run_detector_probe(dry_run=True)

--- a/tests/test_feed_validation.py
+++ b/tests/test_feed_validation.py
@@ -389,14 +389,11 @@ class TestAllowRuleQuarantineAndRdnsConstraint:
 
     def test_quarantine_disabled_activates_allow_rule_on_create(self, db, settings):
         """With quarantine disabled via setting, a valid allow entry is active on create."""
-        import importlib
 
-        import django_waf.conf as conf_mod
         from django_waf.models import AllowRule
         from django_waf.services.threat_feed import sync_feed
 
         settings.DJANGO_WAF_FEED_QUARANTINE_ALLOW_RULES = False
-        importlib.reload(conf_mod)
 
         feed_payload = [
             {

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -61,42 +61,72 @@ def _mock_redis():
 
 
 class TestWafEnabledKillSwitch:
-    """DJANGO_WAF_ENABLED=False passes every request through without evaluation."""
+    """DJANGO_WAF_ENABLED=False passes every request through without evaluation.
+
+    Both tests provide a working Redis client (matching the pattern used
+    throughout this file) so the request cannot reach get_response via the
+    unrelated BR-EVAL-007 Redis-unavailable fail-open path (redis_client is
+    None under this suite's LocMemCache settings). Without that, a request
+    passes through and looks identical whether the kill switch is doing its
+    job or is silently broken: the fail-open path converges on exactly the
+    same observable outcome (200, get_response called once) regardless of
+    DJANGO_WAF_ENABLED's real value, so an assertion on outcome alone cannot
+    tell the two apart. The discriminator these tests assert on is whether
+    evaluate_request was reached at all: with the kill switch OFF it must
+    never be called; with it ON (proven by the enabled counterpart test) it
+    must be called exactly once. That is what actually differs between the
+    two states.
+    """
 
     @override_settings(DJANGO_WAF_ENABLED=False)
-    def test_disabled_waf_passes_request_through(self):
-        # Reload conf so the override is picked up
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
+    def test_disabled_waf_passes_through_without_reaching_evaluation(self):
         factory = RequestFactory()
         request = factory.get("/some/path/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
         get_response = MagicMock(return_value=HttpResponse("passed"))
         middleware = _make_middleware(get_response)
 
-        response = middleware(request)
+        with (
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        ):
+            mock_redis_fn.return_value = _mock_redis()
 
+            response = middleware(request)
+
+        mock_eval.assert_not_called()
         get_response.assert_called_once_with(request)
         assert response.status_code == 200
 
-    @override_settings(DJANGO_WAF_ENABLED=False)
-    def test_disabled_waf_does_not_call_evaluate_request(self):
-        import importlib
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_enabled_waf_reaches_evaluation_with_the_same_request_shape(self):
+        """The falsifiability counterpart to the test above.
 
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
+        Same request shape, same working Redis client, only DJANGO_WAF_ENABLED
+        flipped. This is what proves the disabled test's assert_not_called()
+        is actually pinned to the kill switch and not merely a permanent
+        feature of this request shape: if evaluate_request were never called
+        regardless of DJANGO_WAF_ENABLED, both tests would pass for the same
+        wrong reason the original pair did.
+        """
         factory = RequestFactory()
-        request = factory.get("/")
+        request = factory.get("/some/path/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("passed"))
+        middleware = _make_middleware(get_response)
 
-        with patch("django_waf.services.rule_engine.evaluate_request") as mock_eval:
-            middleware = _make_middleware()
+        with (
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_eval.return_value = _make_result("allowed")
+
             middleware(request)
-            mock_eval.assert_not_called()
+
+        mock_eval.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -109,12 +139,6 @@ class TestExemptPaths:
 
     @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_EXEMPT_PATHS=["/static/", "/health/"])
     def test_static_path_is_exempt(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/static/app.css")
         get_response = MagicMock(return_value=HttpResponse("static"))
@@ -126,12 +150,6 @@ class TestExemptPaths:
 
     @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_EXEMPT_PATHS=["/static/", "/health/"])
     def test_health_path_is_exempt(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/health/")
         get_response = MagicMock(return_value=HttpResponse("ok"))
@@ -143,12 +161,6 @@ class TestExemptPaths:
 
     @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_EXEMPT_PATHS=["/static/"])
     def test_non_exempt_path_continues_to_evaluation(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/api/data/")
         # Evaluation raises to confirm we reached it
@@ -175,12 +187,6 @@ class TestExemptHosts:
         ALLOWED_HOSTS=["admin.example.com", "app.example.com"],
     )
     def test_exact_host_is_exempt(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/api/data/", HTTP_HOST="admin.example.com")
         get_response = MagicMock(return_value=HttpResponse("ok"))
@@ -196,12 +202,6 @@ class TestExemptHosts:
         ALLOWED_HOSTS=["admin.example.com:8000"],
     )
     def test_port_is_stripped_before_matching(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/api/data/", HTTP_HOST="admin.example.com:8000")
         get_response = MagicMock(return_value=HttpResponse("ok"))
@@ -217,12 +217,6 @@ class TestExemptHosts:
         ALLOWED_HOSTS=[".example.com"],
     )
     def test_leading_dot_matches_subdomains(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         get_response = MagicMock(return_value=HttpResponse("ok"))
         middleware = _make_middleware(get_response)
@@ -239,12 +233,6 @@ class TestExemptHosts:
         ALLOWED_HOSTS=["public.example.com", "admin.example.com"],
     )
     def test_non_exempt_host_continues_to_evaluation(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/api/data/", HTTP_HOST="public.example.com")
         with patch("django_waf.middleware._get_redis_client") as mock_redis_fn:
@@ -260,12 +248,6 @@ class TestExemptHosts:
         ALLOWED_HOSTS=["app.example.com"],
     )
     def test_empty_exempt_hosts_continues_to_evaluation(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/api/data/", HTTP_HOST="app.example.com")
         with patch("django_waf.middleware._get_redis_client") as mock_redis_fn:
@@ -286,12 +268,6 @@ class TestStaffBypass:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_staff_user_bypasses_waf(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/page/")
         request.user = MagicMock(is_authenticated=True, is_staff=True, is_superuser=False)
@@ -306,12 +282,6 @@ class TestStaffBypass:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_superuser_bypasses_waf(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/admin/")
         request.user = MagicMock(is_authenticated=True, is_staff=False, is_superuser=True)
@@ -326,12 +296,6 @@ class TestStaffBypass:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_anonymous_user_does_not_bypass_waf(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/page/")
         request.user = MagicMock(is_authenticated=False)
@@ -355,12 +319,6 @@ class TestWafPassCookie:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_valid_waf_pass_cookie_bypasses_evaluation(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/page/")
         request.user = MagicMock(is_authenticated=False)
@@ -382,12 +340,6 @@ class TestWafPassCookie:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_invalid_waf_pass_cookie_proceeds_to_evaluation(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/page/")
         request.user = MagicMock(is_authenticated=False)
@@ -418,11 +370,6 @@ class TestVerdictDispatch:
 
     def _run_with_verdict(self, verdict: str, **result_kwargs):
         """Helper: run middleware with a mocked evaluate_request returning the given verdict."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/page/")
@@ -448,48 +395,24 @@ class TestVerdictDispatch:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_blocked_verdict_returns_403(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         response = self._run_with_verdict("blocked")
 
         assert response.status_code == 403
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_throttled_verdict_returns_429(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         response = self._run_with_verdict("throttled")
 
         assert response.status_code == 429
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_throttled_verdict_includes_retry_after_header(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         response = self._run_with_verdict("throttled")
 
         assert "Retry-After" in response
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_challenged_verdict_redirects_to_challenge_page(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         response = self._run_with_verdict("challenged")
 
         assert response.status_code == 302
@@ -503,12 +426,7 @@ class TestVerdictDispatch:
         here has the same effect as a failure on the read side, escalation
         goes blind for this IP. Fail-open must still redirect to the
         challenge page (BR-EVAL-007), but the failure must be logged."""
-        import importlib
         import logging
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/page/")
@@ -541,11 +459,6 @@ class TestVerdictDispatch:
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_challenged_verdict_on_challenge_path_passes_through(self):
         """Challenge verdict on /waf/challenge/ must not redirect to itself (loop prevention)."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         for path in ["/waf/challenge/", "/waf/verify/"]:
@@ -575,11 +488,6 @@ class TestVerdictDispatch:
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_blocked_verdict_on_challenge_path_still_blocks(self):
         """Blocked IPs must NOT be able to access /waf/challenge/ or /waf/verify/."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         for path in ["/waf/challenge/", "/waf/verify/"]:
@@ -607,12 +515,6 @@ class TestVerdictDispatch:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_allowed_verdict_passes_to_get_response(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         response = self._run_with_verdict("allowed")
 
         assert response.status_code == 200
@@ -620,12 +522,6 @@ class TestVerdictDispatch:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_passed_verdict_passes_to_get_response(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         response = self._run_with_verdict("passed")
 
         assert response.status_code == 200
@@ -642,11 +538,6 @@ class TestFailOpen:
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_redis_unavailable_passes_request_through(self):
         """When _get_redis_client() returns None the request must pass through."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/page/")
@@ -664,11 +555,6 @@ class TestFailOpen:
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_evaluation_error_passes_request_through(self):
         """An exception in evaluate_request must not surface — request passes through."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/page/")
@@ -702,12 +588,7 @@ class TestIpExtraction:
 
     @override_settings(DJANGO_WAF_TRUST_X_FORWARDED_FOR=True)
     def test_uses_first_xff_ip_when_trusted(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
         from django_waf.middleware import _extract_ip
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/")
@@ -719,12 +600,7 @@ class TestIpExtraction:
 
     @override_settings(DJANGO_WAF_TRUST_X_FORWARDED_FOR=False)
     def test_uses_remote_addr_when_xff_not_trusted(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
         from django_waf.middleware import _extract_ip
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/")
@@ -737,12 +613,7 @@ class TestIpExtraction:
 
     @override_settings(DJANGO_WAF_TRUST_X_FORWARDED_FOR=True)
     def test_falls_back_to_remote_addr_when_xff_absent(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
         from django_waf.middleware import _extract_ip
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/")
@@ -755,12 +626,7 @@ class TestIpExtraction:
 
     @override_settings(DJANGO_WAF_TRUST_X_FORWARDED_FOR=False)
     def test_uses_remote_addr_directly(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
         from django_waf.middleware import _extract_ip
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/")
@@ -783,11 +649,6 @@ class TestRequestLogging:
     @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_LOG_SAMPLE_RATE=1.0)
     def test_blocked_verdict_is_always_logged(self):
         """Security verdicts (blocked) are logged regardless of sample rate."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         from django_waf.models import RequestLog
 
@@ -816,11 +677,6 @@ class TestRequestLogging:
     @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_LOG_SAMPLE_RATE=0.0)
     def test_allowed_verdict_not_logged_when_sample_rate_zero(self):
         """Allowed requests are skipped when the sample rate is 0.0."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         from django_waf.models import RequestLog
 
@@ -858,12 +714,6 @@ class TestCountryBlocking:
     @pytest.mark.django_db
     @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCKED_COUNTRIES=["CN", "RU"])
     def test_request_from_blocked_country_returns_403(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/page/")
         request.user = MagicMock(is_authenticated=False)
@@ -879,12 +729,6 @@ class TestCountryBlocking:
     @pytest.mark.django_db
     @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCKED_COUNTRIES=["CN", "RU"])
     def test_request_from_unlisted_country_passes_through_to_normal_evaluation(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         factory = RequestFactory()
         request = factory.get("/page/")
         request.user = MagicMock(is_authenticated=False)
@@ -911,11 +755,6 @@ class TestCountryBlocking:
     @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCKED_COUNTRIES=["CN", "RU"])
     def test_empty_geoip_result_fails_open(self):
         """No GeoIP database / lookup failure returns '' — the request is not blocked."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         factory = RequestFactory()
         request = factory.get("/page/")

--- a/tests/test_nginx_export.py
+++ b/tests/test_nginx_export.py
@@ -14,25 +14,18 @@ _validate_nginx_config or subprocess.run directly.
 
 from __future__ import annotations
 
-import importlib
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from django_waf import conf as conf_mod
 from django_waf.testing.factories import BlockRuleFactory
 
 
 def _disable_nginx_validation(settings) -> None:
-    """Turn off nginx -t validation for content-only generator tests.
-
-    conf caches DJANGO_WAF_* at import, so the setting is mutated and the
-    module reloaded, matching the established pattern in test_api.py.
-    """
+    """Turn off nginx -t validation for content-only generator tests."""
     settings.DJANGO_WAF_NGINX_VALIDATE = False
-    importlib.reload(conf_mod)
 
 
 class TestBlockThrottleSeparation:
@@ -259,15 +252,12 @@ class TestNginxValidationAndRollback:
 
     def test_validation_disabled_activates_unconditionally_old_behaviour(self, db, tmp_path, settings):
         """DJANGO_WAF_NGINX_VALIDATE=False reproduces the pre-#31 unconditional-activate behaviour."""
-        import importlib
 
-        import django_waf.conf as conf_mod
         from django_waf.services.blocklist_generator import generate_nginx_blocklist
 
         output_file = tmp_path / "blocklist.conf"
         output_file.write_text("# previous good config\n")
         settings.DJANGO_WAF_NGINX_VALIDATE = False
-        importlib.reload(conf_mod)
 
         BlockRuleFactory(is_active=True, rule_type="ip", match_type="exact", pattern="7.7.7.7", action="block")
 
@@ -281,15 +271,12 @@ class TestNginxValidationAndRollback:
 
     def test_custom_test_command_setting_is_used(self, db, tmp_path, settings):
         """DJANGO_WAF_NGINX_TEST_COMMAND overrides the default ['nginx', '-t']."""
-        import importlib
 
-        import django_waf.conf as conf_mod
         from django_waf.services.blocklist_generator import generate_nginx_blocklist
 
         output_file = tmp_path / "blocklist.conf"
         settings.DJANGO_WAF_NGINX_VALIDATE = True
         settings.DJANGO_WAF_NGINX_TEST_COMMAND = ["/usr/local/bin/nginx-test", "-c", "custom.conf"]
-        importlib.reload(conf_mod)
 
         with patch("django_waf.services.blocklist_generator.subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(returncode=0, stderr="")

--- a/tests/test_pass_cookie.py
+++ b/tests/test_pass_cookie.py
@@ -322,12 +322,6 @@ class TestMiddlewareIPv6PassCookie:
 
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_solved_ipv6_client_cookie_bypasses_evaluation(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         ip = "2001:db8::1"
         cookie_value = _issued_cookie_value("ipv6-client-token", ip, secure=False)
 
@@ -355,11 +349,6 @@ class TestMiddlewareIPv6PassCookie:
     @override_settings(DJANGO_WAF_ENABLED=True)
     def test_solved_ipv6_client_cookie_rejected_for_different_ip(self):
         """A pass cookie issued to one IPv6 client does not bypass evaluation for another."""
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
 
         issued_ip = "2001:db8::1"
         requesting_ip = "2001:db8::2"

--- a/tests/test_redis_fallback.py
+++ b/tests/test_redis_fallback.py
@@ -230,12 +230,6 @@ class TestRedisBackendSystemCheck:
         }
     )
     def test_silent_on_a_configured_redis_backend(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         messages = check_redis_backend(None)
 
         assert messages == []
@@ -254,16 +248,9 @@ class TestRedisBackendSystemCheck:
         DJANGO_WAF_REDIS_ALIAS="waf",
     )
     def test_respects_a_non_default_redis_alias(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-
         messages = check_redis_backend(None)
 
         assert messages == []
-        importlib.reload(conf_mod)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3885,6 +3885,342 @@ class TestDetectUnsolvedChallenges:
         assert len(second_subnet_rules) == 1
         assert second_subnet_rules[0].action == RuleAction.BLOCK
         assert second_subnet_rules[0].pattern == "203.0.114.0/24"
+        assert "detect_unsolved_challenges" in second_subnet_rules[0].detectors.split(",")
+
+    @pytest.mark.django_db
+    def test_subnet_burst_challenge_rule_does_not_promote_first_own_crossing(self):
+        """A CHALLENGE rule created by detect_subnet_burst for the same
+        subnet must not count as detect_unsolved_challenges's own prior
+        crossing (issue #97, own-provenance-only). The first
+        detect_unsolved_challenges crossing for this subnet must still
+        create CHALLENGE, not BLOCK, even though an active AUTO/CIDR/
+        CHALLENGE rule for the identical pattern already exists.
+
+        This must fail against the pre-#97 code: matching on rule shape
+        alone (rule_type, pattern, source=AUTO, action=CHALLENGE,
+        is_active=True) with no detector scoping treats any detector's
+        rule as this detector's own, so the first real crossing here would
+        wrongly promote straight to BLOCK.
+
+        A pre-existing CHALLENGE row for this exact lookup key means
+        _get_or_create_auto_rule refreshes it (created=False) rather than
+        creating a new one, so this test reads the BlockRule row directly
+        rather than the function's created_rules return value, which only
+        ever includes newly-created rows.
+        """
+        from django_waf.models import BlockRule
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+        BlockRuleFactory(
+            rule_type=RuleType.CIDR,
+            match_type="cidr",
+            pattern="203.0.116.0/24",
+            action=RuleAction.CHALLENGE,
+            source=RuleSource.AUTO,
+            is_active=True,
+            detectors="detect_subnet_burst",
+        )
+
+        for i in range(15):
+            for _ in range(2):
+                RequestLogFactory(
+                    ip_address=f"203.0.116.{i}",
+                    verdict=Verdict.CHALLENGED,
+                    path="/page",
+                    referer="",
+                    timestamp=now,
+                )
+
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            detect_unsolved_challenges(window_minutes=60, min_challenged=3)
+
+        rule = BlockRule.objects.get(rule_type=RuleType.CIDR, pattern="203.0.116.0/24")
+        assert rule.action == RuleAction.CHALLENGE
+        assert "detect_unsolved_challenges" in rule.detectors.split(",")
+
+    @pytest.mark.django_db
+    def test_cloud_spray_challenge_rule_does_not_promote_first_own_crossing(self):
+        """Same as above for a detect_cloud_spray-provenance CHALLENGE rule:
+        another detector's rule of the identical shape still must not
+        promote detect_unsolved_challenges's own first crossing.
+
+        As above, a pre-existing row for this lookup key means
+        _get_or_create_auto_rule reports created=False, so this test reads
+        the BlockRule row directly rather than the created_rules return
+        value.
+        """
+        from django_waf.models import BlockRule
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+        BlockRuleFactory(
+            rule_type=RuleType.CIDR,
+            match_type="cidr",
+            pattern="203.0.117.0/24",
+            action=RuleAction.CHALLENGE,
+            source=RuleSource.AUTO,
+            is_active=True,
+            detectors="detect_cloud_spray",
+        )
+
+        for i in range(15):
+            for _ in range(2):
+                RequestLogFactory(
+                    ip_address=f"203.0.117.{i}",
+                    verdict=Verdict.CHALLENGED,
+                    path="/page",
+                    referer="",
+                    timestamp=now,
+                )
+
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            detect_unsolved_challenges(window_minutes=60, min_challenged=3)
+
+        rule = BlockRule.objects.get(rule_type=RuleType.CIDR, pattern="203.0.117.0/24")
+        assert rule.action == RuleAction.CHALLENGE
+        assert "detect_unsolved_challenges" in rule.detectors.split(",")
+
+    @pytest.mark.django_db
+    def test_own_provenance_repeat_crossing_still_promotes_to_block(self):
+        """Own-provenance-only (#97) must not regress the existing
+        own-detector repeat-crossing promotion: an active CHALLENGE rule
+        this detector itself created still promotes on the next crossing.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.services.anomaly_detector import detect_unsolved_challenges
+
+        now = timezone.now()
+        BlockRuleFactory(
+            rule_type=RuleType.CIDR,
+            match_type="cidr",
+            pattern="203.0.118.0/24",
+            action=RuleAction.CHALLENGE,
+            source=RuleSource.AUTO,
+            is_active=True,
+            detectors="detect_unsolved_challenges",
+        )
+
+        for i in range(15):
+            for _ in range(2):
+                RequestLogFactory(
+                    ip_address=f"203.0.118.{i}",
+                    verdict=Verdict.CHALLENGED,
+                    path="/page",
+                    referer="",
+                    timestamp=now,
+                )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            rules = detect_unsolved_challenges(window_minutes=60, min_challenged=3)
+
+        subnet_rules = [r for r in rules if r.rule_type == RuleType.CIDR and r.pattern == "203.0.118.0/24"]
+        assert len(subnet_rules) == 1
+        assert subnet_rules[0].action == RuleAction.BLOCK
+        assert "detect_unsolved_challenges" in subnet_rules[0].detectors.split(",")
+
+    @pytest.mark.django_db
+    def test_detector_field_populated_by_every_detector_passing_it(self):
+        """Every detector that passes detector_name to _get_or_create_auto_rule
+        must have its name added to the created BlockRule's detectors set
+        (#97). Covers all five DETECTOR_NAMES entries plus rule_engine's
+        escalation caller, which passes a detector_name outside that set.
+        """
+        from django_waf.services.anomaly_detector import _get_or_create_auto_rule
+
+        cases = [
+            ("detect_ua_rotation", RuleType.UA, "some-bot/1.0"),
+            ("detect_subnet_burst", RuleType.CIDR, "203.0.119.0/24"),
+            ("detect_challenge_farms", RuleType.IP, "203.0.119.50"),
+            ("detect_unsolved_challenges", RuleType.CIDR, "203.0.120.0/24"),
+            ("detect_cloud_spray", RuleType.CIDR, "203.0.121.0/24"),
+            ("challenge_escalation", RuleType.IP, "203.0.119.51"),
+        ]
+        for detector_name, rule_type, pattern in cases:
+            rule, created = _get_or_create_auto_rule(
+                name=f"Auto: {detector_name} test",
+                rule_type=rule_type,
+                match_type="exact" if rule_type != RuleType.CIDR else "cidr",
+                pattern=pattern,
+                action=RuleAction.CHALLENGE,
+                expiry=timezone.now() + timezone.timedelta(hours=24),
+                detector_name=detector_name,
+            )
+            assert created is True
+            assert rule.detectors == detector_name
+
+    @pytest.mark.django_db
+    def test_detectors_field_is_additive_not_overwritten_by_a_later_detector(self):
+        """The regression this session's coordinator review caught: three
+        detectors (detect_subnet_burst, detect_unsolved_challenges's subnet
+        path, detect_cloud_spray) can all target the identical (CIDR,
+        subnet, AUTO, CHALLENGE) key for a shared subnet, and
+        run_all_detectors runs them in exactly that order on every pass.
+        A last-writer-wins detectors value would let detect_cloud_spray,
+        which always runs after detect_unsolved_challenges, clobber that
+        detector's own stamp at the end of every pass, so on the NEXT pass
+        detect_unsolved_challenges would no longer recognise its own prior
+        rule and could never promote to BLOCK.
+
+        This must fail against a last-writer-wins implementation: after
+        detect_cloud_spray writes to the row, detect_unsolved_challenges's
+        own name must still be present in detectors, and a subsequent
+        crossing must still promote to BLOCK.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.models import BlockRule
+        from django_waf.services.anomaly_detector import (
+            detect_cloud_spray,
+            detect_unsolved_challenges,
+        )
+
+        now = timezone.now()
+        subnet_ips = [f"203.0.122.{i}" for i in range(15)]
+
+        def make_challenge_traffic():
+            for ip in subnet_ips:
+                for _ in range(2):
+                    RequestLogFactory(
+                        ip_address=ip,
+                        verdict=Verdict.CHALLENGED,
+                        path="/page",
+                        referer="",
+                        timestamp=now,
+                    )
+
+        # First pass: detect_unsolved_challenges creates the stage-one
+        # CHALLENGE rule and stamps its own name.
+        make_challenge_traffic()
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            first_pass = detect_unsolved_challenges(window_minutes=60, min_challenged=3)
+        first_subnet_rules = [r for r in first_pass if r.rule_type == RuleType.CIDR]
+        assert len(first_subnet_rules) == 1
+        assert first_subnet_rules[0].action == RuleAction.CHALLENGE
+
+        rule = BlockRule.objects.get(rule_type=RuleType.CIDR, pattern="203.0.122.0/24", action=RuleAction.CHALLENGE)
+        assert "detect_unsolved_challenges" in rule.detectors.split(",")
+
+        # A different detector, sharing the same subnet pattern via
+        # _get_subnet_prefix, now writes to the SAME row: enough distinct
+        # IPs with no referer, each making a small number of requests, to
+        # clear detect_cloud_spray's own thresholds.
+        for ip in subnet_ips:
+            for _ in range(2):
+                RequestLogFactory(
+                    ip_address=ip,
+                    verdict=Verdict.CHALLENGED,
+                    path="/page",
+                    referer="",
+                    timestamp=now,
+                )
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 10),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 5),
+        ):
+            detect_cloud_spray(window_minutes=60)
+        # detect_cloud_spray finds the same (CIDR, subnet, AUTO, CHALLENGE)
+        # row detect_unsolved_challenges already created, so its own
+        # update_or_create reports created=False (a refresh, not a new
+        # row) and this subnet is absent from its returned created_rules
+        # list. That is expected dedup behaviour and not what this test is
+        # about: the row itself, not the return value, carries the
+        # evidence of whether the write was additive.
+
+        # The shared row must now carry BOTH names, not just the most
+        # recent writer's.
+        rule.refresh_from_db()
+        detectors_after_spray = set(rule.detectors.split(","))
+        assert "detect_unsolved_challenges" in detectors_after_spray
+        assert "detect_cloud_spray" in detectors_after_spray
+
+        # Second pass: detect_unsolved_challenges must still recognise its
+        # own prior rule and promote to BLOCK, despite detect_cloud_spray
+        # having written to the row in between. Promotion creates a
+        # separate BLOCK row (action is part of the update_or_create
+        # lookup key, unrelated to this fix and unchanged by it); what
+        # matters here is that this second crossing reaches BLOCK at all,
+        # rather than re-issuing CHALLENGE because the own-provenance
+        # check no longer finds this detector's name in a row
+        # detect_cloud_spray has since touched.
+        make_challenge_traffic()
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+        ):
+            second_pass = detect_unsolved_challenges(window_minutes=60, min_challenged=3)
+        second_subnet_rules = [r for r in second_pass if r.rule_type == RuleType.CIDR]
+        assert len(second_subnet_rules) == 1
+        assert second_subnet_rules[0].action == RuleAction.BLOCK
+
+    @pytest.mark.django_db
+    def test_run_all_detectors_two_passes_still_promotes_shared_subnet(self):
+        """The realistic production path (coordinator review): run
+        run_all_detectors itself, twice, for a subnet that trips both
+        detect_unsolved_challenges and detect_cloud_spray on every pass.
+        Promotion to BLOCK must still occur on the repeat crossing, exactly
+        as it would if detect_unsolved_challenges were the only detector
+        ever touching this subnet.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.models import BlockRule
+        from django_waf.services.anomaly_detector import run_all_detectors
+
+        now = timezone.now()
+        subnet_ips = [f"203.0.123.{i}" for i in range(15)]
+
+        def make_traffic():
+            for ip in subnet_ips:
+                for _ in range(2):
+                    RequestLogFactory(
+                        ip_address=ip,
+                        verdict=Verdict.CHALLENGED,
+                        path="/page",
+                        referer="",
+                        timestamp=now,
+                    )
+
+        patches = (
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_CHALLENGED", 30),
+            patch.object(conf_mod, "DJANGO_WAF_UNSOLVED_SUBNET_MIN_IPS", 10),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", 10),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 5),
+        )
+
+        make_traffic()
+        with patches[0], patches[1], patches[2], patches[3]:
+            run_all_detectors(window_minutes=60)
+
+        rule = BlockRule.objects.get(rule_type=RuleType.CIDR, pattern="203.0.123.0/24", action=RuleAction.CHALLENGE)
+        assert "detect_unsolved_challenges" in rule.detectors.split(",")
+        assert "detect_cloud_spray" in rule.detectors.split(",")
+
+        make_traffic()
+        with patches[0], patches[1], patches[2], patches[3]:
+            run_all_detectors(window_minutes=60)
+
+        # Promotion creates a separate BLOCK row (action is part of the
+        # update_or_create lookup key, unrelated to and unchanged by this
+        # fix); what this asserts is that the second pass reaches BLOCK at
+        # all, which is exactly what the last-writer-wins defect prevented.
+        assert BlockRule.objects.filter(
+            rule_type=RuleType.CIDR, pattern="203.0.123.0/24", action=RuleAction.BLOCK
+        ).exists()
 
     @pytest.mark.django_db
     def test_ip_solved_outside_recency_window_is_still_eligible(self):

--- a/tests/test_site_password.py
+++ b/tests/test_site_password.py
@@ -630,13 +630,6 @@ class TestGateRunsWithinMiddlewareEnabledCheck:
     """Per PRD 2.1 / BR-SP-008: the gate check sits after the WAF's own
     enabled/exempt-path/exempt-host short-circuits. When the whole WAF
     middleware is disabled, the site-password gate does not run either.
-
-    DJANGO_WAF_SITE_PASSWORD_ENABLED is set directly via override_settings
-    (not patch.multiple) here because DJANGO_WAF_ENABLED must go through a
-    real importlib.reload(conf_mod) for the master kill switch to take
-    effect -- reload() re-executes the module body and would silently wipe
-    any patch.multiple-patched attributes in the same block (they are
-    class/module attribute patches, not settings-backed).
     """
 
     @override_settings(
@@ -645,17 +638,9 @@ class TestGateRunsWithinMiddlewareEnabledCheck:
         DJANGO_WAF_SITE_PASSWORD="letmein",
     )
     def test_gate_does_not_run_when_waf_disabled(self):
-        import importlib
-
-        import django_waf.conf as conf_mod
-
-        importlib.reload(conf_mod)
-        try:
-            client = Client()
-            response = client.get("/")
-            assert response.status_code == 200
-        finally:
-            importlib.reload(conf_mod)
+        client = Client()
+        response = client.get("/")
+        assert response.status_code == 200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Five items, merged as four branches with merge commits so each change keeps its own history. **Merge this with "Create a merge commit", not squash**, or that history is flattened.

## What is in it

| Item | Issue |
|---|---|
| `conf.py` resolves settings at call time, not import time | #75 |
| Seven system checks respect `DJANGO_WAF_ENABLED` | #95 |
| Subnet promotion scoped to the detector's own prior rule | #97 |
| `django_waf.E006`: WafMiddleware absent from `MIDDLEWARE` | #101 |
| Detector liveness probe | new capability |

### #75 is the consumer-visible one

Every `DJANGO_WAF_*` setting was frozen at first import of `conf.py`, despite the module docstring promising call-time resolution. Two consequences, both observed live: `override_settings` and the pytest `settings` fixture silently did nothing, and any consuming project whose settings module touched `django_waf.conf` during settings execution froze every value at the package default for the process. One deployment ran with the WAF enabled against the wrong Redis alias while its own settings said `DJANGO_WAF_ENABLED = False`.

**A consumer test suite that relied on the WAF ignoring `override_settings` will now see it take effect.** If a suite worked around this with `importlib.reload(django_waf.conf)`, that reload is now a harmless no-op and can be removed. The public `disable_waf` fixture's signature changed from `disable_waf(monkeypatch)` to `disable_waf(settings)`.

### #97 ships a migration

`0006_blockrule_detectors` adds `BlockRule.detectors`, an additive set of the detectors that created or refreshed a rule. Existing rows backfill blank, so a subnet whose CHALLENGE rule predates the upgrade gets one extra CHALLENGE stage before promoting. Intentional: it fails safe toward the less disruptive action.

### The probe

Synthetic fixture traffic in a rolled-back transaction, sized from each detector's own configured thresholds, asserting every detector still produces rules. Real traffic cannot serve this purpose: zero rules is the normal healthy result on a quiet site and is indistinguishable from a dead detector, which is how a 13-hour outage of the 2.0.0 subnet feature went unnoticed. Hourly Celery task plus `django_waf_probe_detectors`, which exits non-zero on a silent detector.

A dead beat entry produces no log line at all, so consumers must alert on the log line's absence, not only its content. The package stays stateless and persists no last-run timestamp.

## Verification

Verified on the merged state, not per branch. 1237 passed, 5 skipped, 93.36% coverage on Django 5.2.17 and 6.0.8; identical across forward and reversed file order; real Redis 6.0 integration leg green; ruff 0.15.22 check and format clean; mypy delta zero against `main`; `makemigrations --check` clean.

Every fault-injection test was teeth-checked individually: the injection was removed, the test confirmed to fail, then restored. That check caught four separate defects that a passing run could not distinguish from working code, including the probe's own falsifiability tests twice.

## Found and fixed during the work

- A cross-file settings leak: an E2E test restored `DJANGO_WAF_SITE_PASSWORD_ENABLED` with `setattr` where `delattr` was correct, leaking an explicit `False` onto live settings for the process. Invisible until #75 made `conf` read live settings.
- `monkeypatch.setattr(conf, ...)` restores by `setattr`, never `delattr`, permanently shadowing `__getattr__` for that name. Four probe tests used it; all moved to `patch.object`.

## Filed, not fixed here

#98 (CI's Django 6.1 legs are inert: `django-celery-beat` caps `Django<6.1` and pip silently downgrades), #99 (`django_waf_detect_anomalies` double-counts its summary), #100 (the Redis flush path needs its own probe), #102 (no check for `django_waf.urls` unrouted while challenges are live).

Closes #75
Closes #95
Closes #97
Closes #101
