### PR TITLE
chore(release): prepare v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2.2.0
+## [2.2.0] - 2026-08-29
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.1.0"
+version = "2.2.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Version bump and CHANGELOG date for 2.2.0. No code changes; the release content merged in #103.

- `pyproject.toml` 2.1.0 to 2.2.0 (`__version__` reads from package metadata, so nothing to change there)
- `## [Unreleased] - 2.2.0` becomes `## [2.2.0] - 2026-08-29`; nothing left under Unreleased

## Release gate, verified before tagging

1. Version matches in `pyproject.toml` and the package metadata; CHANGELOG entry dated; nothing left under Unreleased.
2. Suite green on the tagged content: nine CI legs passed on #103 (Python 3.11-3.13, Django 5.2/6.0/6.1, plus the real Redis 6.0 integration leg and lint).
3. **Publish gate simulated.** `publish.yml` installs a different set from `ci.yml` (Python 3.12, `Django~=5.2.0`, `.[dev,celery]`). Replicated in a clean venv: 1237 passed, 5 skipped, 93.36% coverage.
4. **Artefact verified, not just the run.** `python -m build` then `twine check`: both pass. The wheel carries `services/detector_probe.py`, `management/commands/django_waf_probe_detectors.py`, `migrations/0006_blockrule_detectors.py` and the updated `checks.py`. Installed into a clean venv from the built wheel and imported: reports 2.2.0.
5. Tagging `main` after this merges, so the tagged commit carries this repo current `publish.yml`.
6. Consumer-visible changes named in the CHANGELOG in consumer terms: `override_settings` and the pytest `settings` fixture now affect WAF behaviour; the `disable_waf` fixture signature changed; migration `0006` backfills blank and costs one extra CHALLENGE stage per pre-existing subnet rule.

Note: `py.typed` is absent from the wheel. Checked against 2.1.0, it has never been shipped, so this is unchanged rather than a regression. Worth a separate issue.