### PR TITLE
fix: restore default="" on BlockRule.detectors to match migration 0006 (#105)

### DIFF
--- a/src/django_waf/models.py
+++ b/src/django_waf/models.py
@@ -230,6 +230,7 @@ class BlockRule(BaseModel):
     detectors = models.CharField(
         max_length=255,
         blank=True,
+        default="",
         db_index=True,
         verbose_name=_("detectors"),
         help_text=_(

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,56 @@
+"""Tests that the django_waf app has no un-migrated model changes (#105).
+
+BlockRule.detectors was declared without a ``default=`` kwarg while the
+migration that added it recorded ``default=""``, so model state and
+migration-graph state disagreed. A consumer running
+``manage.py makemigrations --check --dry-run`` (a standard merge-blocking CI
+gate) got a spurious AlterField diff for a field they do not own, with no
+local fix available.
+
+No test in this suite ran the migration autodetector at all, so nothing
+caught it. tests/settings.py sets ``MIGRATION_MODULES`` to disable migrations
+for the rest of the suite (fast, migration-free test databases), which means
+this check must explicitly re-enable them for django_waf rather than relying
+on the ambient setting, or it would either raise ("migrations have been
+disabled") or silently compare against nothing.
+"""
+
+from __future__ import annotations
+
+import django
+from django.db import connections
+from django.db.migrations.autodetector import MigrationAutodetector
+from django.db.migrations.loader import MigrationLoader
+from django.db.migrations.state import ProjectState
+from django.test import override_settings
+
+
+class TestNoPendingMigrations:
+    def test_django_waf_has_no_pending_model_changes(self, db):
+        """The django_waf app's models match its committed migrations.
+
+        Builds a real MigrationLoader (with MIGRATION_MODULES temporarily
+        cleared so django_waf's actual migration files are read, not the
+        None sentinel tests/settings.py normally installs) and asks the
+        MigrationAutodetector whether current model state diverges from
+        what the migration graph records. A single un-migrated field
+        default is enough to trip this: it is exactly the class of drift
+        that a `makemigrations --check --dry-run` CI gate would catch for
+        this app, and exactly what shipped un-caught in 2.2.0 (#105).
+        """
+        with override_settings(MIGRATION_MODULES={}):
+            connection = connections["default"]
+            loader = MigrationLoader(connection, ignore_no_migrations=True)
+            autodetector = MigrationAutodetector(
+                loader.project_state(),
+                ProjectState.from_apps(django.apps.apps),
+            )
+            changes = autodetector.changes(graph=loader.graph)
+
+        pending = changes.get("django_waf", [])
+        descriptions = [f"{migration.name}: {[op.describe() for op in migration.operations]}" for migration in pending]
+        assert not pending, (
+            "django_waf has model changes with no matching migration. "
+            "Run `makemigrations django_waf` and commit the result. "
+            f"Detected operations: {descriptions}"
+        )


### PR DESCRIPTION
Closes #105.

## The defect

`BlockRule.detectors` was declared without a `default=` kwarg while `0006_blockrule_detectors.py` recorded the field with `default=""`. Model state and migration-graph state have disagreed since 2.2.0 shipped.

Any consumer running `manage.py makemigrations --check --dry-run`, a standard merge-blocking CI gate, gets exit code 1 and a spurious `AlterField` diff for a field inside an installed package, with no local remedy: the migration that would settle it has to live in the package.

Reproduced against a clean consumer settings module on 2.2.0:

```
Migrations for 'django_waf':
  0007_alter_blockrule_detectors.py
    ~ Alter field detectors on blockrule
```

## Why the model side, not an AlterField

The graph already records `default=""`, so adding the kwarg reconciles the two with **no new migration**: consumers need only the version bump.

The two directions are behaviourally identical in any case. `get_default()` already returned `""` either way (`empty_strings_allowed=True`, `null=False`), and a Django field default is app-level only, never emitted as DDL, so the difference lived purely in `deconstruct()` and therefore only in migration state. `default=""` is also what `matched_rule_type` and `source_event_id` already do on blank CharFields in this module.

## The test asserts the class, not the instance

The regression test asserts the **whole app** has no pending migration operations, rather than that this one field carries a default. The defect was an absent gate, not an absent kwarg: no test in the suite ran the autodetector at all, which is how a released package came to advertise a migration state its own models contradicted. A field-specific assertion would not have caught this and would not catch the next one.

`tests/settings.py` disables migrations via `MIGRATION_MODULES`, so the test clears that setting explicitly rather than inheriting it, which would otherwise raise "migrations have been disabled" or silently compare against nothing.

## Verification

Fault injection, confirmed by hand rather than assumed:

- Remove `default=""` -> test **fails**: `Detected operations: ["0007_alter_blockrule_detectors: ['Alter field detectors on blockrule']"]`
- Restore it -> test **passes**

Gates: 1238 passed, 5 skipped; `ruff check` and `ruff format --check` clean. The `test-redis-integration` leg was not run locally (needs a live Redis service container); it does not touch models or migrations. mypy reports 3 errors on this file, all pre-existing on `main` and unchanged by this diff (no CI job runs mypy); filed separately rather than mixed into a bug fix.