### PR TITLE
fix(ci): the Django 6.1 legs actually run 6.1 (#98)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,39 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # django-celery-beat caps at Django<6.1 (2.9.0 declares
+      # "Django<6.1,>=2.2"). Installing the celery extra alongside Django 6.1
+      # silently DOWNGRADES Django to 6.0.x and exits 0, so both nominal 6.1
+      # legs executed 6.0 for their entire life while pyproject.toml
+      # advertised Framework :: Django :: 6.1 on PyPI (issue #98).
+      #
+      # Only django-celery-beat carries that cap: celery itself is
+      # Django-agnostic and installs cleanly on 6.1. So the 6.1 leg keeps
+      # full celery coverage (src/django_waf/tasks.py imports `shared_task`
+      # from celery at module scope, and 81 tests import that module) and
+      # drops ONLY the beat scheduler. Do not "simplify" this to
+      # ".[dev]" on 6.1: that removes celery, tasks.py then raises
+      # ModuleNotFoundError at import, and 81 tests fail for a reason that
+      # has nothing to do with Django 6.1.
       - name: Install dependencies
         run: |
           pip install "Django~=${{ matrix.django-version }}.0"
-          pip install -e ".[dev,celery]"
+          if [ "${{ matrix.django-version }}" = "6.1" ]; then
+            pip install -e ".[dev]" "celery>=5.3"
+          else
+            pip install -e ".[dev,celery]"
+          fi
+
+      - name: Assert the installed Django is the version this leg claims
+        run: |
+          want="${{ matrix.django-version }}"
+          got="$(python -c 'import django; print(".".join(map(str, django.VERSION[:2])))')"
+          echo "requested Django ${want}, resolved ${got}"
+          if [ "${got}" != "${want}" ]; then
+            echo "::error::Django ${want} was requested but ${got} is installed."
+            echo "::error::A dependency has silently downgraded Django (see issue #98)."
+            exit 1
+          fi
 
       - name: Lint
         run: ruff check src/ tests/


### PR DESCRIPTION
Closes #98.

## The defect

Both nominal Django 6.1 legs have never executed Django 6.1.

`ci.yml` installed `Django~=6.1.0` on one line and `-e ".[dev,celery]"` on the next. The celery extra pins `django-celery-beat`, which declares `Django<6.1,>=2.2` (verified against installed 2.9.0 metadata), so pip silently downgraded Django to 6.0.x and exited 0. Nothing asserted between the two steps.

Consequences:

- Both 6.1 legs were green while testing a version they did not claim to test, including on both 2.2.0 PRs.
- `pyproject.toml:18` advertises `Framework :: Django :: 6.1` to PyPI on the strength of those legs.

## The fix

**1. Assert the resolved version after install.** This is the load-bearing half: it stops the class of defect, not just this instance. Any future dependency that moves Django now fails the leg loudly instead of passing green.

**2. Choose the extras per leg.** Only `django-celery-beat` carries the 6.1 cap; celery itself is Django-agnostic and installs cleanly on 6.1. The 6.1 leg therefore keeps full celery coverage and drops only the beat scheduler.

This last point is why the obvious fix is wrong. Installing plain `.[dev]` on the 6.1 leg removes celery entirely, and `src/django_waf/tasks.py:29` imports `shared_task` from celery at module scope, so 81 tests fail with `ModuleNotFoundError` for a reason that has nothing to do with Django 6.1. There is a comment in the workflow warning against that simplification.

## Verification

Measured, not inspected.

Teeth of the assertion, both directions:

| Environment | Resolves | Assertion |
|---|---|---|
| `[dev,celery]` (the broken state both legs were in) | Django 6.0 | fires, exit 1 |
| `[dev]` + `celery>=5.3` (this PR) | Django 6.1 | passes |

Suite on genuine Django 6.1, celery present, beat absent: **1238 passed, 5 skipped**, identical to the 6.0 baseline. That is the first evidence this package actually works on Django 6.1.

## Not addressed here

Whether `django-celery-beat` should be unpinned or replaced so beat itself can run on 6.1. That is an upstream constraint, not a CI one, and it does not block making the leg honest.