### PR TITLE
fix(anomaly): cloud spray detection catches diffuse residential spray (#68, #69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Cloud-spray detection catches diffuse residential-proxy botnets**
+  (#68, #69, BR-ANOM-002b). `detect_cloud_spray` grouped on two keys the
+  attacker controls, which left the detector purpose-built for
+  distributed spray largely inert against it. It groups by exact
+  user-agent string, so rotating a pool of UAs divides each bucket's
+  distinct-IP count; and its subnet aggregation required at least 2
+  suspicious IPs per /24, which assumes cloud-contiguous allocation.
+  Measured live: one UA shared by 217 distinct IPs occupied 216 distinct
+  subnets, so 215 of 216 were discarded and the detector created zero
+  rules against the flood it exists to catch. Raising the log sample rate
+  was investigated and ruled out as the cause; the signal is present in
+  the retained rows and the grouping discards it.
+
+  A second, opt-in rule path now keys on the user agent itself once it
+  alone clears `DJANGO_WAF_CLOUD_SPRAY_MIN_IPS` distinct suspicious IPs,
+  independent of how those IPs distribute across subnets. The subnet path
+  and its 2-IP floor are unchanged.
+
+- `DJANGO_WAF_CLOUD_SPRAY_UA_RULE` (default `False`). Enables the UA path
+  above. Off by default: a user agent shared by many IPs has legitimate
+  causes (a corporate NAT, a carrier CGNAT range, a popular app's
+  embedded webview), so no existing consumer's enforcement behaviour
+  changes on upgrade. Rules from this path are created with
+  `action=challenge` and never `block`, because a shared UA is a coarse
+  signal: a production measurement over 1,544,473 requests put the
+  false-positive floor for acting on it at no less than 35.6% real users,
+  including genuine Bingbot and Applebot. CHALLENGE rules are excluded
+  from `for_nginx()`, so these rules are enforced by `WafMiddleware`
+  only and the matched user-agent string never reaches a rendered nginx
+  configuration.
+
+- `DJANGO_WAF_CLOUD_SPRAY_TOP_N` (default 5). Replaces a hardcoded cap on
+  how many spray user agents a single run inspects. The previous
+  hardcoded limit silently discarded the long tail of exactly the
+  rotated-UA pool the detector is meant to catch.
+
 ## [2.2.0] - 2026-08-29
 
 ### Added

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -565,6 +565,22 @@ def _DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP() -> int:
     return _get_setting("DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3)
 
 
+# Top-N spray UAs (ranked by distinct suspicious IPs) considered per
+# detect_cloud_spray run, replacing the previous hardcoded [:5] cap.
+def _DJANGO_WAF_CLOUD_SPRAY_TOP_N() -> int:
+    return _get_setting("DJANGO_WAF_CLOUD_SPRAY_TOP_N", 5)
+
+
+# Enable detect_cloud_spray's diffuse-spray UA path: when a UA alone clears
+# DJANGO_WAF_CLOUD_SPRAY_MIN_IPS distinct suspicious IPs, create a single
+# CHALLENGE rule for that exact UA, independent of subnet clustering.
+# Default False: a shared UA can be a corporate NAT, a CGNAT range, or an
+# embedded webview, so this is opt-in and does not change behaviour for an
+# existing consumer on upgrade.
+def _DJANGO_WAF_CLOUD_SPRAY_UA_RULE() -> bool:
+    return _get_setting("DJANGO_WAF_CLOUD_SPRAY_UA_RULE", False)
+
+
 # Per-path rate limits: {path_prefix: (max_requests, window_seconds)}.
 # Longest-prefix match wins; checked before the global IP windows.
 def _DJANGO_WAF_RATE_LIMIT_PATHS() -> dict:

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -769,7 +769,8 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
 
     Identifies UAs shared by many distinct IPs (>= DJANGO_WAF_CLOUD_SPRAY_MIN_IPS)
     where each IP makes only 1-3 requests with no referer. This pattern is
-    characteristic of cloud-hosted bot farms that evade per-IP rate limits.
+    characteristic of cloud-hosted bot farms and diffuse residential-proxy
+    botnets that evade per-IP rate limits.
 
     A referer that is a bare origin with no path (``BARE_ORIGIN_REFERER_RE``,
     e.g. "https://example.com") is treated the same as a missing referer:
@@ -777,10 +778,27 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
     after the host, so a spoofed static bare-origin referer is otherwise
     invisible to this detector (issue #24).
 
-    Flags subnets rather than individual IPs — cloud providers allocate
-    contiguous blocks, so a single CIDR catches the cluster efficiently.
-    Aggregation uses ``_get_subnet_prefix`` (the /24 network for IPv4, the
-    /48 network for IPv6), shared with ``detect_subnet_burst``.
+    Two independent rule-creation paths run per spray UA, because no single
+    grouping key catches both threat shapes (issue #68):
+
+    Subnet path (always on): flags subnets rather than individual IPs, since
+    cloud providers allocate contiguous blocks and a single CIDR catches
+    that cluster efficiently. Aggregation uses ``_get_subnet_prefix`` (the
+    /24 network for IPv4, the /48 network for IPv6), shared with
+    ``detect_subnet_burst``, and requires at least 2 suspicious IPs sharing
+    a subnet before flagging it. This path structurally cannot catch a
+    residential-proxy botnet that puts one IP per /24: issue #69's live
+    reproduction had 217 IPs spread over 216 distinct subnets, so 215 of
+    216 subnets never cleared this floor and zero rules were created.
+
+    UA path (opt-in via DJANGO_WAF_CLOUD_SPRAY_UA_RULE, default False):
+    flags the exact UA string itself once it alone clears
+    DJANGO_WAF_CLOUD_SPRAY_MIN_IPS distinct suspicious IPs, independent of
+    how those IPs are distributed across subnets. This is what catches the
+    diffuse-spray shape the subnet path misses. It is opt-in and staged at
+    CHALLENGE because a shared UA is a coarse signal: issue #82's
+    production measurement (1,544,473 rows) puts the false-positive floor
+    at >= 35.6% real users, including genuine Bingbot and Applebot.
 
     Args:
         window_minutes: Time window to analyse (default 30).
@@ -800,6 +818,8 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
     cutoff = timezone.now() - timedelta(minutes=window_minutes)
     min_ips = conf.DJANGO_WAF_CLOUD_SPRAY_MIN_IPS
     max_per_ip = conf.DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP
+    top_n = conf.DJANGO_WAF_CLOUD_SPRAY_TOP_N
+    ua_rule_enabled = conf.DJANGO_WAF_CLOUD_SPRAY_UA_RULE
 
     # Step 1: Find UAs used by many distinct IPs with no referer (or a
     # spoofed bare-origin referer, which is indistinguishable from missing).
@@ -812,7 +832,7 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
         .values("user_agent")
         .annotate(distinct_ips=Count("ip_address", distinct=True))
         .filter(distinct_ips__gte=min_ips)
-        .order_by("-distinct_ips")[:5]
+        .order_by("-distinct_ips")[:top_n]
     )
 
     created_rules = []
@@ -838,7 +858,54 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
         if len(suspicious_ips) < min_ips:
             continue
 
-        # Step 3: Aggregate into subnets (/24 IPv4, /48 IPv6) and create rules
+        # Step 3a (diffuse-spray UA path, issue #68): the UA alone already
+        # cleared min_ips distinct suspicious IPs, independent of how those
+        # IPs are distributed across subnets. This catches the shape the
+        # subnet path structurally cannot: one IP per /24 residential-proxy
+        # spray, where every subnet count is 1 and never clears the
+        # count < 2 floor below. Opt-in (default False) and staged at
+        # CHALLENGE, see the docstring for why.
+        if ua_rule_enabled:
+            ua_confidence = _scaled_confidence(observed=len(suspicious_ips), threshold=min_ips, span=min_ips * 2)
+            ua_details = {
+                "distinct_ips": len(suspicious_ips),
+                "user_agent": ua[:200],
+                "window_minutes": window_minutes,
+            }
+            # No length guard on `pattern`: RequestLog.user_agent is
+            # max_length=1024 (models.py) and BlockRule.pattern is
+            # max_length=2048, so `ua` (read from RequestLog) can never
+            # overflow pattern. Truncating it here would create a rule
+            # whose exact-match pattern never matches the real UA again,
+            # a silent dead rule, so the full string is always written.
+            ua_rule, ua_created = _get_or_create_auto_rule(
+                name=f"Auto: cloud spray UA ({len(suspicious_ips)} IPs, UA: {ua[:40]})",
+                rule_type=RuleType.UA,
+                match_type="exact",
+                pattern=ua,
+                action=RuleAction.CHALLENGE,
+                expiry=expiry,
+                dry_run=dry_run,
+                detector_name="detect_cloud_spray",
+                confidence=ua_confidence,
+                evidence=ua_details,
+            )
+            if ua_created:
+                created_rules.append(ua_rule)
+                if not dry_run:
+                    _emit_anomaly_signal(
+                        rule=ua_rule,
+                        anomaly_type=AnomalyType.CLOUD_SPRAY,
+                        details=ua_details,
+                    )
+                    logger.info(
+                        "django-waf: auto-created cloud spray UA rule for %s (%d IPs)",
+                        ua[:40],
+                        len(suspicious_ips),
+                    )
+
+        # Step 3b (subnet path): aggregate into subnets (/24 IPv4, /48
+        # IPv6) and create rules for cloud-contiguous clusters.
         subnet_counts: dict[str, int] = {}
         for ip in suspicious_ips:
             try:

--- a/tests/test_cloud_spray_referer.py
+++ b/tests/test_cloud_spray_referer.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import pytest
 from django.utils import timezone
 
+from django_waf.enums import RuleAction, RuleType
 from django_waf.services.anomaly_detector import detect_cloud_spray
 from django_waf.testing.factories import RequestLogFactory
 
@@ -181,3 +182,206 @@ class TestDetectCloudSprayBareOriginReferer:
 
         assert len(created) == 1
         assert created[0].pattern == "203.0.113.0/24"
+
+
+class TestDetectCloudSprayDiffuseUA:
+    """Regression tests for issues #68/#69: diffuse residential-proxy spray.
+
+    A botnet that puts one IP per /24 (issue #69's live reproduction: 217
+    IPs across 216 distinct subnets) is invisible to the subnet path, whose
+    ``count < 2`` membership floor drops any subnet with only one
+    suspicious IP in it. The UA path (opt-in, DJANGO_WAF_CLOUD_SPRAY_UA_RULE)
+    flags the shared UA itself once it alone clears MIN_IPS distinct
+    suspicious IPs, independent of subnet distribution.
+    """
+
+    # 25 distinct /24s, one suspicious IP each: the shape issue #69 measured.
+    # Deliberately > MIN_IPS (20) via an explicit literal, not derived from
+    # the patched setting, so the fixture provably crosses the threshold.
+    RESIDENTIAL_SPRAY_IP_COUNT = 25
+
+    def _create_residential_spray_fixture(self, shared_ua: str) -> None:
+        now = timezone.now()
+        for i in range(self.RESIDENTIAL_SPRAY_IP_COUNT):
+            RequestLogFactory(
+                ip_address=f"203.0.{i}.7",
+                user_agent=shared_ua,
+                referer="",
+                timestamp=now,
+            )
+
+    def test_residential_spray_creates_ua_rule_when_toggle_on(self):
+        """One IP per /24 over MIN_IPS subnets creates a UA rule when opted in.
+
+        This is the core regression test for #68/#69: it MUST fail against
+        the unmodified detector, since the old code has no UA-creation path
+        at all and the subnet path's count < 2 floor drops every one of
+        these single-IP subnets.
+        """
+        import django_waf.conf as conf_mod
+
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+        assert min_ips < self.RESIDENTIAL_SPRAY_IP_COUNT
+
+        self._create_residential_spray_fixture(shared_ua)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_UA_RULE", True),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        ua_rules = [rule for rule in created if rule.rule_type == RuleType.UA]
+        assert len(ua_rules) == 1
+        assert ua_rules[0].pattern == shared_ua
+
+    def test_residential_spray_creates_no_ua_rule_when_toggle_off(self):
+        """Same fixture, default toggle (off): no UA rule, no behaviour change on upgrade."""
+        import django_waf.conf as conf_mod
+
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        self._create_residential_spray_fixture(shared_ua)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        assert created == []
+
+    def test_ua_rule_action_is_challenge_not_block(self):
+        import django_waf.conf as conf_mod
+
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        self._create_residential_spray_fixture(shared_ua)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_UA_RULE", True),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        ua_rules = [rule for rule in created if rule.rule_type == RuleType.UA]
+        assert len(ua_rules) == 1
+        assert ua_rules[0].action == RuleAction.CHALLENGE
+
+    def test_ua_rule_carries_detector_provenance(self):
+        import django_waf.conf as conf_mod
+
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        self._create_residential_spray_fixture(shared_ua)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_UA_RULE", True),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        ua_rules = [rule for rule in created if rule.rule_type == RuleType.UA]
+        assert len(ua_rules) == 1
+        assert ua_rules[0].detectors == "detect_cloud_spray"
+
+    def test_ua_rule_absent_from_for_nginx_export(self):
+        """A CHALLENGE UA rule is middleware-only, never exported to nginx (BR-BL-005)."""
+        import django_waf.conf as conf_mod
+        from django_waf.models import BlockRule
+
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        self._create_residential_spray_fixture(shared_ua)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_UA_RULE", True),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        ua_rules = [rule for rule in created if rule.rule_type == RuleType.UA]
+        assert len(ua_rules) == 1
+        assert not BlockRule.objects.for_nginx().filter(pk=ua_rules[0].pk).exists()
+
+    def test_top_n_cap_is_configurable_not_hardcoded(self):
+        """DJANGO_WAF_CLOUD_SPRAY_TOP_N replaces the old hardcoded [:5] cap.
+
+        Six distinct spray UAs each individually clear MIN_IPS, each with a
+        different distinct-IP count so Step 1's ``order_by("-distinct_ips")``
+        ranking is unambiguous. With TOP_N patched to 2, only the top 2 UAs
+        are considered at all, so with the UA path enabled at most 2 UA
+        rules can be created even though six UAs qualify.
+        """
+        import django_waf.conf as conf_mod
+
+        now = timezone.now()
+        min_ips = 5
+        num_uas = 6
+
+        for ua_index in range(num_uas):
+            # Distinct, strictly descending IP counts: ua 0 has the most
+            # distinct IPs, ua 5 the fewest, so the top-N ranking is exact.
+            ip_count_for_this_ua = min_ips + (num_uas - ua_index)
+            for ip_index in range(ip_count_for_this_ua):
+                RequestLogFactory(
+                    ip_address=f"203.{ua_index}.{ip_index}.7",
+                    user_agent=f"spray-agent-{ua_index}",
+                    referer="",
+                    timestamp=now,
+                )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 1),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_TOP_N", 2),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_UA_RULE", True),
+        ):
+            created = detect_cloud_spray(window_minutes=30)
+
+        ua_rules = [rule for rule in created if rule.rule_type == RuleType.UA]
+        flagged_uas = {rule.pattern for rule in ua_rules}
+        assert flagged_uas == {"spray-agent-0", "spray-agent-1"}
+
+    def test_dry_run_creates_no_rows(self):
+        """dry_run=True (BR-ANOM-006) writes nothing; check _state.adding, not pk.
+
+        BlockRule.id is a UUIDField with default=uuid.uuid4, so pk is
+        always populated even on an unsaved instance; _state.adding is the
+        only reliable signal that a row was never written.
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.models import BlockRule
+
+        shared_ua = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0"
+        min_ips = 20
+
+        self._create_residential_spray_fixture(shared_ua)
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MIN_IPS", min_ips),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_MAX_REQUESTS_PER_IP", 3),
+            patch.object(conf_mod, "DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch.object(conf_mod, "DJANGO_WAF_CLOUD_SPRAY_UA_RULE", True),
+        ):
+            created = detect_cloud_spray(window_minutes=30, dry_run=True)
+
+        ua_rules = [rule for rule in created if rule.rule_type == RuleType.UA]
+        assert len(ua_rules) == 1
+        assert ua_rules[0]._state.adding is True
+        assert not BlockRule.objects.filter(rule_type=RuleType.UA, pattern=shared_ua).exists()


### PR DESCRIPTION
Closes #68. Closes #69.

These ship as one fix, per triage on both issues: they are two halves of the same defect, `detect_cloud_spray` grouping on keys the attacker controls. #68 is the diagnosis, #69 the fix.

## The defect

| Grouping key | Location | How it fails |
|---|---|---|
| Exact `user_agent` | `anomaly_detector.py:813` | Rotating N plausible UAs divides each bucket's distinct-IP count by N, pushing every bucket under `MIN_IPS` |
| Subnet membership floor | `anomaly_detector.py:850` | `if count < 2: continue` assumes cloud-contiguous allocation |
| Hardcoded top-N | `anomaly_detector.py:815` | `[:5]` silently discards a rotated pool's long tail |

Measured live on the consumer deployment (#69): a single UA shared by **217 distinct IPs across 216 distinct /24 subnets**, 1.00 IP per subnet. 215 of 216 subnets never reached the 2-IP floor, so `detect_cloud_spray(dry_run=True)` created **zero rules** against the exact flood it was built for.

The log sample rate was investigated as the cause and ruled out (#68): the signal is already present in the retained rows, and the grouping discards it.

## The fix

A second, independent rule path keyed on the user agent itself, taken once that UA alone clears `DJANGO_WAF_CLOUD_SPRAY_MIN_IPS` distinct suspicious IPs, regardless of subnet distribution.

The subnet path and its 2-IP floor are **unchanged**. A single suspicious IP is not evidence about its neighbours, and that path is still correct for the cloud-contiguous shape it was written for. The two paths cover different threat shapes; neither subsumes the other.

### Three constraints on the new path

**Staged at CHALLENGE, never BLOCK.** A shared UA is a coarse signal. #82's production measurement (1,544,473 rows over 833,956 distinct IPs) puts the false-positive floor for acting on such a signal at **no less than 35.6% real users**, and identifies genuine Bingbot and Applebot in the caught traffic. Since `for_nginx()` filters `action__in=[BLOCK, THROTTLE]`, these rules are middleware-only, which also means an attacker-supplied UA string from this path can never reach a rendered nginx configuration.

**Opt-in, default off** (`DJANGO_WAF_CLOUD_SPRAY_UA_RULE`). A UA shared by many IPs has legitimate causes: a corporate NAT, a carrier CGNAT range, a popular app's embedded webview. Default-off means no consumer's enforcement behaviour changes on upgrade.

**Reuses the provenance machinery.** Both paths pass `detector_name="detect_cloud_spray"` into `_get_or_create_auto_rule`, so 2.2.0's additive merge (BR-ANOM-011, #97) covers every rule either path writes. Rebuilding or omitting it would silently regress the own-provenance guarantee on the shared CIDR/CHALLENGE key space that 2.2.0 exists to fix.

### One detail worth calling out

The UA written as `pattern` is never truncated. `RequestLog.user_agent` is `max_length=1024` against `BlockRule.pattern`'s 2048, so overflow is structurally impossible; truncating would instead produce an exact-match rule that can never match the UA it was created from, which is silently dead rather than merely wrong.

## Verification

**The regression tests were confirmed to fail against the pre-fix detector**, not merely to pass after the fix. The first attempt at that proof was weak and is worth recording: with the whole change reverted, the tests failed with `AttributeError` on the missing setting, which proves nothing about detector behaviour. Restoring only the settings and leaving the detector at its old implementation produced the real proof:

```
assert 0 == 1
 +  where 0 = len([])
```

The old detector returns an empty list for the residential-spray fixture, reproducing #69's live result exactly.

| Gate | Result |
|---|---|
| `pytest` | **1245 passed, 5 skipped** (baseline 1238 + 7 new) |
| Coverage | 93.40% (required 90.0%) |
| `ruff check` | pass |
| `ruff format --check` | pass |
| `mypy src/` | 35 errors, **zero new**: diffed set-wise against unmodified `35c6c34` in the same venv |

The existing `test_bare_origin_referer_with_rotated_uas_still_detected` passes untouched: it does not patch the new toggle, so it runs with the UA path off.

## Spec

Ships with the code, on the umbrella: BR-ANOM-002b, AC-ANOM-025 through AC-ANOM-030, CHK-SPRAY-001..006, plus the settings table and services entries.

## Noted, not fixed here

`mypy` is a declared dev dependency with full config at `pyproject.toml:96`, and **no workflow runs it**. Pre-existing gap, out of scope for this PR; filed separately.