### PR TITLE
test(ci): run the suite against real PostgreSQL, not only sqlite (#72)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,62 @@ jobs:
         env:
           DJANGO_WAF_TEST_REDIS_URL: redis://localhost:6379/0
 
+  # Dedicated leg, not part of the matrix above. The matrix runs entirely on
+  # sqlite in-memory, which is materially more permissive than the PostgreSQL
+  # consumers actually deploy on: it does not validate GenericIPAddressField
+  # values on write, and it differs on constraint and transaction behaviour.
+  # That gap is not theoretical. Two tests in test_services.py passed on
+  # sqlite for their whole life by inserting '999.999.999.999' into
+  # RequestLog.ip_address to exercise a ValueError guard; PostgreSQL's inet
+  # type rejects that at insert, so the precondition, and the guard it was
+  # proving, are unreachable there via that column. Any bulk_create or
+  # field-validation claim was unverifiable against a real deployment before
+  # this leg existed (issue #72).
+  #
+  # One leg, not a matrix dimension: backend divergence is a property of the
+  # backend, not of the Python/Django pair, so multiplying it across the
+  # matrix would multiply CI time for no extra defect-catching power. Same
+  # reasoning as the Redis leg above.
+  test-postgres:
+    name: Test (real PostgreSQL 16)
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: django_waf_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          pip install -e ".[dev,celery]" "psycopg[binary]>=3.1"
+
+      - name: Test against real PostgreSQL
+        run: pytest tests/ -q --color=yes
+        env:
+          DJANGO_WAF_TEST_DB: postgres
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: django_waf_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The test suite now runs against real PostgreSQL in CI** (#72). Every
+  one of the 1245 tests ran on sqlite in-memory, which is materially more
+  permissive than the PostgreSQL consumers deploy on: it does not
+  validate `GenericIPAddressField` values on write, and it differs on
+  constraint and transaction behaviour. Any `bulk_create` or
+  field-validation claim was therefore unverifiable against a real
+  deployment, and a regression test for that class of defect would pass
+  whether or not the defect was fixed.
+
+  A dedicated `test-postgres` CI leg now runs the full suite against
+  PostgreSQL 16. `tests/settings.py` selects the backend from
+  `DJANGO_WAF_TEST_DB`, defaulting to sqlite so a local run needs no
+  database server and nothing changes for existing contributors.
+
+  This immediately surfaced two tests that had passed on sqlite for their
+  whole life by inserting `999.999.999.999` into `RequestLog.ip_address`
+  to exercise a `ValueError` guard. PostgreSQL's `inet` type rejects that
+  at insert, so both the precondition and the guard it was proving are
+  unreachable there via that column. The guards are kept, since a sqlite
+  deployment can still reach them, and both tests are now skipped on any
+  backend that cannot construct their precondition rather than passing
+  against a state production cannot produce.
+
+
 - **Cloud-spray detection catches diffuse residential-proxy botnets**
   (#68, #69, BR-ANOM-002b). `detect_cloud_spray` grouped on two keys the
   attacker controls, which left the detector purpose-built for

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,7 @@
 """Django settings for django-waf tests."""
 
+import os
+
 SECRET_KEY = "django-waf-test-secret-key"  # noqa: S105
 DEBUG = True
 ALLOWED_HOSTS = ["*"]
@@ -47,13 +49,39 @@ TEMPLATES = [
     },
 ]
 
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": ":memory:",
+# The suite runs on sqlite by default, which keeps a local run dependency-free,
+# but sqlite is materially more permissive than the PostgreSQL that consumers
+# actually deploy on. It does not validate GenericIPAddressField values on
+# bulk_create, and it differs on constraint and transaction behaviour, so a
+# regression test for a defect of that class can pass on sqlite whether or not
+# the defect is fixed (issue #72). Setting DJANGO_WAF_TEST_DB=postgres runs the
+# same suite against a real PostgreSQL server; CI does this on a dedicated leg.
+if os.environ.get("DJANGO_WAF_TEST_DB") == "postgres":
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": os.environ.get("POSTGRES_DB", "django_waf_test"),
+            "USER": os.environ.get("POSTGRES_USER", "postgres"),
+            "PASSWORD": os.environ.get("POSTGRES_PASSWORD", "postgres"),
+            "HOST": os.environ.get("POSTGRES_HOST", "localhost"),
+            "PORT": os.environ.get("POSTGRES_PORT", "5432"),
+        }
     }
-}
+else:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    }
 
+# Schema is built directly from the models rather than by running migrations,
+# which is faster but means the suite cannot see a model-vs-migration
+# divergence: that is exactly how issue #105 shipped a BlockRule.detectors
+# default that disagreed with migration 0006 and broke makemigrations --check
+# for every consumer. tests/test_migrations.py covers that gap explicitly by
+# running the autodetector, and it handles this setting deliberately; read it
+# before changing anything here.
 MIGRATION_MODULES = {
     "django_waf": None,
     "contenttypes": None,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -12,6 +12,7 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
+from django.db import connection
 from django.utils import timezone
 
 from django_waf.enums import (
@@ -1846,6 +1847,17 @@ class TestDetectSubnetBurstBranches:
 
         assert created == []
 
+    @pytest.mark.skipif(
+        connection.vendor != "sqlite",
+        reason=(
+            "Needs a malformed value in RequestLog.ip_address, which only a permissive "
+            "backend allows. GenericIPAddressField is backed by PostgreSQL's inet type, "
+            "which rejects '999.999.999.999' at insert, so this precondition is "
+            "unreachable there and the _get_subnet_prefix ValueError guard it exercises "
+            "is correspondingly unreachable via this column. The guard is kept because "
+            "sqlite deployments can reach it; this test can only run where it is real."
+        ),
+    )
     def test_invalid_ip_in_logs_is_skipped(self, db):
         """RequestLog entries with invalid IP addresses are silently skipped."""
         import django_waf.conf as conf_mod
@@ -2676,6 +2688,14 @@ class TestBuildTelemetryPayload:
         subnet_cidrs = [s["cidr"] for s in payload["subnets"]]
         assert "192.0.2.0/24" in subnet_cidrs
 
+    @pytest.mark.skipif(
+        connection.vendor != "sqlite",
+        reason=(
+            "Needs a malformed value in RequestLog.ip_address; PostgreSQL's inet type "
+            "rejects it at insert. See the matching skip on "
+            "TestDetectSubnetBurstBranches.test_invalid_ip_in_logs_is_skipped."
+        ),
+    )
     def test_invalid_ip_in_logs_is_skipped(self, db):
         """RequestLog entries with invalid IPs are skipped during subnet aggregation."""
         from django_waf.services.threat_feed import build_telemetry_payload


### PR DESCRIPTION
Unblocks #72.

## The gap

All 1245 tests ran on sqlite in-memory (`tests/settings.py:52`). No CI leg touched PostgreSQL; the only `services:` block in `ci.yml` was Redis.

sqlite is materially more permissive than the database consumers deploy on. It does not validate `GenericIPAddressField` on write, and it differs on constraint and transaction behaviour. So any `bulk_create` or field-validation claim was unverifiable against a real deployment, and **a regression test for that defect class passes whether or not the defect is fixed**. That is precisely why #72 could not be worked.

## The change

`tests/settings.py` selects the backend from `DJANGO_WAF_TEST_DB`, defaulting to sqlite. A local run stays dependency-free and nothing changes for existing contributors.

A dedicated `test-postgres` leg runs the full suite against PostgreSQL 16. One leg, not a matrix dimension: backend divergence is a property of the backend, not of the Python/Django pair, so multiplying it across the matrix costs CI time for no extra defect-catching power. Same reasoning as the existing Redis leg.

## Teeth, proven by fault injection

Not asserted by inspection. `bulk_create` of a malformed IP, the exact #72 shape:

| Backend | Result | Can catch #72? |
|---|---|---|
| sqlite | ACCEPTED silently | no |
| postgresql | REJECTED (`ValueError`) | **yes** |

## What it found immediately

Two tests had passed on sqlite for their entire life by constructing a state production cannot reach.

`TestDetectSubnetBurstBranches` and `TestBuildTelemetryPayload` each have a `test_invalid_ip_in_logs_is_skipped` that inserts `999.999.999.999` into `RequestLog.ip_address` to exercise a `_get_subnet_prefix` `ValueError` guard. PostgreSQL's `inet` type rejects that at insert, so on that backend both the precondition **and the guard it was proving** are unreachable via that column.

The guards are kept, all three (`anomaly_detector.py:196`, `:657`, `:913`): a sqlite deployment can still reach them and they cost nothing. The tests are now skipped on any backend that cannot construct their precondition, with the reason stated in the skip rather than left for the next reader to rediscover.

This is the honest outcome. The alternative, deleting the guards because one backend cannot reach them, would remove real defence for sqlite consumers; and leaving the tests as they were means two tests asserting something untrue of production.

## Verification

| Backend | Result |
|---|---|
| sqlite | **1245 passed, 5 skipped** (unchanged; both tests still run) |
| postgresql | **1243 passed, 7 skipped** (the 2 above correctly skipped) |

`ruff check` and `ruff format --check` pass. Verified locally against `postgres:16-alpine` before committing.

## Follow-on

#72 itself is now testable and is **not** fixed here; this PR only makes it possible to write a test that can fail. Worth noting separately that the Redis leg installs `Django~=6.1.0` then `.[dev,celery]`, so it silently runs 6.0 for the reason fixed in #109 for the matrix; that leg was left alone here rather than widening this diff.