### PR TITLE
fix(ci): the Redis integration leg actually runs Django 6.1 too (#98)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,10 +106,27 @@ jobs:
         with:
           python-version: "3.13"
 
+      # Same trap as the matrix legs (#98): django-celery-beat caps at
+      # Django<6.1, so installing the celery extra after Django 6.1 silently
+      # downgrades it to 6.0.x at exit 0. Verified on a green main run of
+      # this very job, which logged "Successfully installed Django-6.1"
+      # followed by "Successfully installed Django-6.0.8". Only beat carries
+      # the cap; celery itself installs cleanly on 6.1, and tasks.py imports
+      # shared_task at module scope, so celery must stay.
       - name: Install dependencies
         run: |
           pip install "Django~=6.1.0"
-          pip install -e ".[dev,celery]"
+          pip install -e ".[dev]" "celery>=5.3"
+
+      - name: Assert the installed Django is the version this leg claims
+        run: |
+          got="$(python -c 'import django; print(".".join(map(str, django.VERSION[:2])))')"
+          echo "requested Django 6.1, resolved ${got}"
+          if [ "${got}" != "6.1" ]; then
+            echo "::error::Django 6.1 was requested but ${got} is installed."
+            echo "::error::A dependency has silently downgraded Django (see issue #98)."
+            exit 1
+          fi
 
       - name: Test against real Redis 6.0
         run: pytest tests/ -v --tb=short --color=yes --ds=tests.settings_redis -m redis_integration


### PR DESCRIPTION
Follow-on to #109, which fixed this on the matrix legs and left the dedicated Redis leg carrying the identical defect.

## Evidence

Not inferred from the pattern. The most recent **green** run of this job on `main` logs, in order:

```
Successfully installed Django-6.1
Successfully installed Django-6.0.8 ... django-celery-beat-2.9.0
```

So `test-redis-integration` has been running Django 6.0 under a 6.1 label, exactly as the matrix legs were before #109.

## Fix

Identical to #109 and for the same reason: only `django-celery-beat` carries the `Django<6.1` cap. `celery` itself installs cleanly on 6.1, and `src/django_waf/tasks.py` imports `shared_task` at module scope, so celery stays and only beat is dropped.

The version assertion is the part that matters: it stops the class of defect rather than this instance of it.

## Verification

Against `redis:6.0-alpine` locally:

| Check | Result |
|---|---|
| Install resolves | Django **6.1**, celery 5.6.3, beat absent |
| `redis_integration` tests | **5 passed** |
| Assertion teeth | installing `django-celery-beat` drops Django to 6.0 → assertion **fires** |

That last row is the anti-vacuity check: the assertion was confirmed to fail against the environment this PR removes, not merely to pass against the one it introduces.

## Scope

CI only. No package code changes, so no CHANGELOG entry: the user-visible statement about 6.1 support was already made by #109, and this closes the remaining leg that contradicted it.