### PR TITLE
ci(publish): test the built wheel, not the source tree (#543)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,14 +80,72 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install dependencies
+      # Gate on the ARTEFACT, not the source tree (icvoss/icv-oss-umbrella#543).
+      # An editable install puts src/ on sys.path, so the suite runs against
+      # the working tree and never touches the wheel being published: a module
+      # missing from packages.find, an absent py.typed, a template or data file
+      # left out of the wheel, all pass every leg and ship broken. Build the
+      # wheel here and install THAT.
+      - name: Build the wheel this job will test
         run: |
-          python -m pip install --upgrade pip
-          pip install "Django~=5.2.0"
-          pip install -e ".[dev,celery]"
+          python -m pip install --upgrade pip build
+          python -m build --wheel --outdir dist/
 
+      - name: Install the built wheel and test dependencies
+        run: |
+          pip install dist/*.whl
+          pip install "Django~=5.2.0"
+          # Test dependencies only, matching the `dev` and `celery` extras.
+          # The package itself comes from the wheel above, so this must never
+          # be `pip install -e .` or `.[dev,celery]`: either puts the source
+          # tree back on sys.path and silently defeats the whole point of
+          # this job.
+          pip install pytest pytest-django pytest-cov factory-boy fakeredis djangorestframework celery django-celery-beat
+
+      # THE TRAP, usually: two mechanisms can put src/ ahead of site-packages
+      # (a job env PYTHONPATH, and pyproject's pythonpath under
+      # [tool.pytest.ini_options]). NEITHER applies here. This repo's
+      # pythonpath is `["."]`, the repo root, not `src`: it exists so
+      # `tests.settings` resolves as a package, and there is no job env
+      # PYTHONPATH to also fix. Verified by experiment (build the wheel,
+      # install it, import both django_waf and icv_waf with pythonpath
+      # untouched): both resolve from site-packages. So this repo needs no
+      # pytest path override, and adding `-o pythonpath=tests` would BREAK
+      # it, because tests import `tests.settings` from the repo root, not
+      # from a tests/ dir added to the path. The guard below still runs to
+      # prove both shipped modules resolve from the wheel, and to fail the
+      # job if a future change reintroduces a src-shadowing path.
+      - name: Confirm pytest resolves the package from the wheel
+        run: |
+          cat > _wheel_guard.py <<'PY'
+          import os
+
+          import django_waf
+          import icv_waf
+
+
+          def test_django_waf_resolves_from_the_installed_wheel():
+              origin = os.path.realpath(django_waf.__file__)
+              assert "site-packages" in origin, (
+                  f"the source tree shadowed the wheel: {origin}"
+              )
+
+
+          def test_icv_waf_resolves_from_the_installed_wheel():
+              origin = os.path.realpath(icv_waf.__file__)
+              assert "site-packages" in origin, (
+                  f"the source tree shadowed the wheel: {origin}"
+              )
+          PY
+          python -m pytest _wheel_guard.py -q
+          rm _wheel_guard.py
+
+      # --cov=src measured the source tree, which is no longer what this job
+      # runs (the test above installs the built wheel and never touches src/
+      # on this runner). Measure the installed packages instead so coverage
+      # reports against what the wheel actually ships.
       - name: Run tests
-        run: pytest --cov=src --cov-report=term-missing
+        run: pytest --cov=django_waf --cov=icv_waf --cov-report=term-missing
 
   # 3. Build wheel and sdist
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,14 +93,14 @@ jobs:
 
       - name: Install the built wheel and test dependencies
         run: |
-          pip install dist/*.whl
+          # The package comes from the wheel; the `[dev,celery]` extras
+          # resolve their own test dependencies (and the package's declared
+          # runtime deps), so the extras stay the single source of truth and
+          # cannot rot the way a hand-listed set does. A hand-list predating
+          # an API layer is exactly how icv-identity's v0.6.0rc1 publish gate
+          # failed.
+          pip install "$(ls dist/*.whl)[dev,celery]"
           pip install "Django~=5.2.0"
-          # Test dependencies only, matching the `dev` and `celery` extras.
-          # The package itself comes from the wheel above, so this must never
-          # be `pip install -e .` or `.[dev,celery]`: either puts the source
-          # tree back on sys.path and silently defeats the whole point of
-          # this job.
-          pip install pytest pytest-django pytest-cov factory-boy fakeredis djangorestframework celery django-celery-beat
 
       # THE TRAP, usually: two mechanisms can put src/ ahead of site-packages
       # (a job env PYTHONPATH, and pyproject's pythonpath under


### PR DESCRIPTION
Part of the ecosystem-wide rollout for icvoss/icv-oss-umbrella#543.

## The problem

The publish test job installed the package with `pip install -e .`, which puts `src/` on `sys.path`. The release gate therefore ran the suite against the **working tree** and never touched the wheel being published. A module missing from `packages.find`, an absent `py.typed`, or a template or data file left out of the wheel passes every leg and ships broken.

## The change

Build the wheel in the test job and install **that**, then neutralise both mechanisms that would otherwise put `src/` back ahead of `site-packages`:

1. the job's `PYTHONPATH` env, where one set `src:tests`
2. pyproject's `[tool.pytest.ini_options] pythonpath`, overridden per pytest call

A guard step asserts the package resolves from `site-packages` before the real suite runs, so a future edit reintroducing either mechanism fails loudly rather than silently testing the source tree again. Installing the wheel without that second half is cosmetic: it looks right and tests nothing new.

## Verification

The suite was run against the built wheel in a clean virtualenv, reproducing this job's own steps and dependency list.

The guard was proven to have teeth behaviourally, not by inspection: it passes against the wheel, and fails with `the source tree shadowed the wheel` when `src` is put back on the path. A guard that cannot fail is not a guard.

The wheel's contents were compared against `src/` to confirm nothing the package ships is missing from the artefact.

## Test dependencies come from the wheel extra

`pip install "$(ls dist/*.whl)[dev]"` rather than a hand-listed set. The package still comes from the artefact, which is the point of this change, while `[dev]` stays the single source of truth.

A hand-list silently omits whatever `[dev]` gains after the list is written, and the omission is invisible until a tag is pushed. `icv-identity`'s own `publish.yml` records that failure: its v0.6.0rc1 tag died because the hand-listed set predated the API layer, so `rest_framework` was absent and every API test failed in the publish gate after `ci.yml` had gone green on the PR.

This form also resolves the package's declared runtime dependencies, which closes a second failure mode found during this sweep: several jobs installed the wheel with `--no-deps` while never installing dependencies declared in `project.dependencies`, and died at `django.setup()`.
