### PR TITLE
chore(release): 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-09-01
+
+### Fixed
+
+- **`BlockRule.detectors` field default restored to match its own migration**
+  (#105, #107, closes #115). The `v2.2.0` tag was cut roughly 76 minutes
+  before #107 merged to `main`, so the published 2.2.0 wheel still carried
+  the pre-fix `models.py`: the `detectors` field had no `default=""` while
+  migration `0006_blockrule_detectors.py` already recorded one. Every
+  consumer who installed `django-waf==2.2.0` and ran
+  `manage.py makemigrations --check --dry-run`, a standard merge-blocking CI
+  gate, got a spurious `AlterField` diff for a field inside an installed
+  package, with no local remedy: the migration that would settle it has to
+  live in the package. Fixed on the model side rather than with a new
+  `AlterField` migration, since the migration graph already records
+  `default=""` and only `deconstruct()`, never DDL, differed between the two.
+
+  **Upgrading from 2.2.0**: the `makemigrations --check` drift disappears on
+  upgrade to this release; no new migration runs and no data is affected.
+  If you added a local workaround (an `AlterField` migration of your own, or
+  an exclusion for `django_waf` in your CI's drift check), it can be
+  removed.
+
 ### Added
 
 - **The test suite now runs against real PostgreSQL in CI** (#72). Every
@@ -68,6 +91,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   how many spray user agents a single run inspects. The previous
   hardcoded limit silently discarded the long tail of exactly the
   rotated-UA pool the detector is meant to catch.
+
+  **Upgrading from 2.2.0**: no change to detection behaviour unless you set
+  `DJANGO_WAF_CLOUD_SPRAY_UA_RULE = True`, since it defaults off. If you do
+  enable it, `detect_cloud_spray` gains a second, independent rule path
+  that can create CHALLENGE (never BLOCK) rules keyed on a shared user
+  agent alone; the existing subnet-based path and its behaviour are
+  unchanged. `DJANGO_WAF_CLOUD_SPRAY_TOP_N` (default 5) now governs how
+  many spray user agents a run inspects, replacing a previous hardcoded
+  cap of the same value, so a default deployment sees no change there
+  either.
 
 ## [2.2.0] - 2026-08-29
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.2.0"
+version = "2.3.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Closes #115.

## Why this release exists

The `v2.2.0` tag was cut at 2026-08-29 20:55, and PR #107 merged roughly 76 minutes later. #107 restored `default=""` on `BlockRule.detectors` to match what migration `0006`, shipped inside that same tag, already declared.

Verified at source on both refs:

| ref | `default=""` on `BlockRule.detectors` |
|---|---|
| `v2.2.0` (models.py:230) | absent |
| `main` (models.py:233) | present |
| `0006` inside the v2.2.0 wheel | declares it |

So the published 2.2.0 artefact contains a model that disagrees with its own migration. Every consumer of 2.2.0 gets `Alter field detectors on blockrule` from `makemigrations --check`, which exits 1: a hard CI gate, and a deploy abort where the check runs as a deploy step. Found by icvlocal.com.

`main` has been 6 commits ahead of the tag with no newer release since.

## 2.3.0, not 2.2.1

Issue #115 and this branch's original name both assumed a patch. That is wrong. `e53753e` adds two new settings, `DJANGO_WAF_CLOUD_SPRAY_TOP_N` (default 5) and `DJANGO_WAF_CLOUD_SPRAY_UA_RULE` (default `False`), confirmed present in `conf.py:570-581`. New settings are new public API, and RELEASING.md's own rule is "if in doubt between patch and minor, choose minor". This is not even a doubtful case.

## Consumer impact

- **The drift disappears.** No migration runs; `0006` is unchanged and already applied by anyone on 2.2.0.
- **Detection behaviour is unchanged unless opted in.** `DJANGO_WAF_CLOUD_SPRAY_UA_RULE` defaults to `False`, so the new user-agent-keyed cloud-spray rule path is inert until enabled.
- Consumers still on 2.2.0 or earlier who have never run beat are unaffected by the 2.0.0 auto-block escalation, since no detector creates rules without it.

## Verification

- Wheel built and `twine check`ed, both artefacts PASSED.
- **Artefact inspected, not the source tree**: `models.py` inside the built wheel carries `default=""` on `detectors`, and `0006_blockrule_detectors.py` is present.
- Installed into a clean venv, imports, reports `2.3.0`.
- **Proven against the real consumer**: installing this wheel into icvlocal.com removes `django_waf` from `makemigrations --check` output.

## Note on the release

This is a public package, so pushing the tag publishes to PyPI via OIDC and is irreversible. Tagging only after this PR's CI is green on the merged commit.