### PR TITLE
feat(anomaly): flag scrapers by 404 ratio (BR-ANOM-014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,166 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A sixth anomaly detector, `detect_scraper_404_ratio`, catches a
+  residential-proxy scraping botnet that defeated every existing detector
+  at once** (BR-ANOM-014). Traced against a live deployment (VendablyCSS,
+  shopping.vendably.com, django-waf 2.1.0, three-day window): 10,874
+  distinct IPs spread across roughly 9,700 distinct /24 subnets (about 1.1
+  IPs per /24, mean 1.42 requests per IP) evaded `detect_subnet_burst`'s
+  absolute floor (needs >= 30 requests per subnet) and
+  `detect_unsolved_challenges`'s subnet path (needs >= 10 IPs per subnet).
+  15,426 distinct User-Agent strings, one per request, meant no shared UA
+  existed for `detect_cloud_spray` to group on, and its subnet path also
+  needed at least 2 suspicious IPs sharing a subnet, which this shape
+  almost never produced. All 15,378 of the botnet's requests scored
+  exactly 3.50 (fingerprint-derived only; zero matched a suspicious path
+  pattern), landing strictly between `DJANGO_WAF_SCORE_THRESHOLD_LOG`
+  (2.5) and `DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE` (5.0), so every request
+  was `verdict=logged`, passed straight through to the application.
+
+  The one signal that does separate the botnet from real traffic is the
+  404 ratio. Filtering the same window to IPs with >= 20 requests and
+  >= 85% of them 404 yielded 14 IPs, all confirmed scrapers, for example
+  31.58.20.59 at 100% over 32 requests, 88.167.25.244 at 97% over 75, and
+  103.59.160.242 at 92% over 115. A real browser does not sustain a
+  ~100% 404 rate over dozens of requests: a human who hits a dead link
+  navigates somewhere real, or gives up, long before reaching that
+  volume. The requested paths were stale internal URLs (old
+  category/merchant paths, with and without a trailing slash), i.e. a
+  scrape working from an outdated link graph, not a vulnerability scan
+  (which `DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS` already covers).
+
+  Every IP the detector would flag against the production trace at its
+  final defaults (window 1440 minutes, 20 requests, 0.85 ratio, verdicts
+  `allowed`/`logged`) was individually verified by UA and requested paths:
+  precision was 100%, with no legitimate user among them, across four
+  shapes the other five detectors structurally miss:
+
+  1. Webshell/backdoor hunters sending an EMPTY User-Agent string, for
+     example 4.205.62.107 (446 requests, 100% 404, requesting `/agg.php`,
+     `/cp2.php`, `/ebahvhhh.php`) and 158.23.18.78 (138 requests, 100%
+     404, requesting `/inx.php`, `/file1221.php`, `/adminner.php`). These
+     filenames are random per host, so no static path-pattern list
+     (`DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS`) can ever enumerate them; the
+     404 ratio catches them precisely because the filenames are guesses
+     that, by definition, do not exist.
+  2. A self-identifying exploit scanner, 103.59.160.242 (123 requests,
+     96% 404), whose User-Agent is literally `xploit_probe`, requesting
+     `/wp-admin/*` paths.
+  3. Distributed scrapers hitting dead product URLs with a shared mobile
+     UA, 114.119.148.27 (83 requests, 94% 404) and 114.119.137.80 (56
+     requests, 100% 404), both classified `fingerprint_verdict=suspicious`
+     on every row.
+  4. A spoofed Googlebot, 45.45.237.69 (27 requests, 89% 404), sending the
+     genuine Googlebot User-Agent string
+     (`Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)`)
+     and classified `fingerprint_verdict=browser` on every row. This IP is
+     outside Google's published ranges, so it fails the forward-confirmed
+     reverse-DNS (FCrDNS) check the seeded Googlebot `AllowRule` requires
+     (`verify_rdns=True`, `rule_engine._check_allow_rules` /
+     `_verify_rdns`); it therefore never matches the AllowRule and never
+     gets `verdict=passed`, unlike the genuine Googlebot IPs (66.249.x)
+     in the same trace. This is the sharpest argument for excluding
+     `passed` on AllowRule grounds rather than on UA or IP shape: a UA
+     match cannot distinguish this impostor from the real crawler (the
+     UA string is identical), an IP/CIDR rule cannot either (the
+     impostor's address is not stable across a botnet), and the
+     fingerprint scorer does not catch it (it presents as a browser on
+     every row). Only "did this client actually earn an AllowRule match"
+     separates them, which is exactly what excluding non-`passed`
+     traffic tests. The empty-UA cases in point 1 show the same property
+     from the other direction: this detector still catches a scraper
+     when every UA-derived signal (`detect_cloud_spray`'s UA path,
+     `detect_ua_rotation`) is entirely absent, because it never looks at
+     the UA at all.
+
+  Verdict scoping is the correctness-critical part of this detector, and
+  it was proven, not assumed: a request the WAF itself blocked,
+  challenged, or throttled never reaches a view (`middleware.py`'s
+  `_handle_verdict` returns a `HttpResponseForbidden`/429/redirect for
+  those verdicts without ever calling `_get_response`), so its
+  `response_code` reflects what the WAF returned, not a genuine 404 the
+  application produced; production data confirms this, blocked,
+  challenged, and throttled rows show exactly 0.0% 404 in the trace,
+  because none of them ever reached a view. Only rows whose verdict shows
+  the request reached the application (`allowed`, `logged`) are counted,
+  in both the numerator and the denominator; a WAF-produced verdict can
+  never dilute or inflate an IP's ratio.
+
+  `passed` (an AllowRule match) is excluded, and this was measured, not
+  assumed: over an identical 180-minute window at the default
+  20-request/85%-ratio gate, excluding `passed` traffic flagged zero IPs;
+  including it flagged 10, every one a verified Bingbot IP, for example
+  40.77.167.132 (34 requests, 100% 404) and 207.46.13.156 (25 requests,
+  100% 404), re-crawling roughly 14,897 dead URLs still present in its own
+  historical index (one URL was hit 478 times in three days), a
+  stale-sitemap/HTTP 410 gap on the site's side, not malicious behaviour.
+  Including `passed` would have made this detector auto-challenge (or,
+  with `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK=True`, auto-block) Bingbot,
+  risking delisting. The exclusion is applied on exactly the same
+  "AllowRules win" precedence the rule engine already applies at its step
+  4, ahead of every BlockRule: this detector only ever creates a new
+  `(rule_type=ip, source=auto)` BlockRule and can neither touch nor take
+  precedence over an existing AllowRule, so excluding `passed` traffic
+  from the count is what keeps a verified crawler out of this detector's
+  results entirely, rather than relying on a rule that would never fire
+  anyway. Point 4 above (the spoofed Googlebot) is the same property from
+  the other direction: excluding `passed` protects the real crawler
+  without also protecting an impostor presenting the identical UA string
+  but never earning the AllowRule match.
+
+  A qualifying IP is created at `RuleAction.CHALLENGE` by default,
+  promoted to `RuleAction.BLOCK` only when
+  `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK` is `True`. A 404 ratio is
+  behavioural, not proof of malice on its own (a broken external link
+  farm or a stale sitemap could in principle produce a similar shape),
+  so this follows the same staging precedent as `detect_cloud_spray`'s
+  UA path (issue #82): a coarse aggregate signal stages at CHALLENGE by
+  default.
+
+- `DJANGO_WAF_SCRAPER_404_MIN_REQUESTS` (default `20`). Minimum request
+  count an IP must reach within the window before its 404 ratio is
+  considered at all.
+
+- `DJANGO_WAF_SCRAPER_404_RATIO` (default `0.85`). Fraction of an IP's
+  application-reaching requests that must be 404 before it is flagged.
+
+- `DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES` (default `1440`, 24 hours).
+  Deliberately wide, on the same precedent as
+  `DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES` (360, #93): a detector whose
+  attacker spreads volume thinly over time needs its own wider window, or
+  the count/ratio thresholds are never reachable regardless of tuning.
+  Simulated live against the traced deployment, sweeping window x
+  `DJANGO_WAF_SCRAPER_404_MIN_REQUESTS` at the default 0.85 ratio,
+  counting flagged IPs:
+
+  ```
+  window   180m: minreq 10 ->  0, 15 ->  0, 20 ->  0, 30 ->  0
+  window   360m: minreq 10 ->  3, 15 ->  2, 20 ->  1, 30 ->  1
+  window   720m: minreq 10 ->  4, 15 ->  3, 20 ->  3, 30 ->  2
+  window  1440m: minreq 10 -> 13, 15 -> 10, 20 ->  8, 30 ->  7
+  ```
+
+  At 180 minutes the detector caught nothing at all: this cohort's mean of
+  1.42 requests per IP over the full three-day trace means no individual
+  IP accumulates enough volume inside 3 hours to clear even the lowest
+  swept `min_requests`. 1440 minutes is the smallest swept window at
+  which the default `DJANGO_WAF_SCRAPER_404_MIN_REQUESTS=20` catches a
+  materially non-trivial, confirmed-scraper population (8 IPs), so it is
+  the default rather than a threshold change: the window, not the
+  count/ratio thresholds, was the wrong knob, exactly as it was for #93.
+
+- `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK` (default `False`). When `True`,
+  a qualifying IP is created at `RuleAction.BLOCK` instead of
+  `RuleAction.CHALLENGE`.
+
+  **Upgrading**: no change to existing detection behaviour. This is a new,
+  additive detector; `run_all_detectors` and the `detect_anomalies` Celery
+  task now also run it, and their result dict gains a `scraper_404_rules`
+  key alongside the five existing ones.
+
 ## [2.3.0] - 2026-09-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ path) before relying on this package as a site's only defence layer.
   generates the variables; you wire the enforcement, see
   [nginx Integration](#nginx-integration)
 - **Anomaly detection**: auto-creates expiring rules for UA rotation, subnet
-  bursts, and challenge farms
+  bursts, challenge farms, unsolved challenges, cloud spray, and scraper
+  404-ratio patterns
 - **Collective threat feed**: opt-in sync of anonymised threat intelligence
   across deployments
 - **Staff dashboard**: HTMX-powered real-time analytics with anomaly management
@@ -226,6 +227,10 @@ without any feed.
 | `DJANGO_WAF_SUSPICIOUS_PATH_SCORE` | `3.0` | Score added per suspicious path match |
 | `DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES` | `False` | When `True`, a newly-created auto-generated rule is created inactive and `pending` review rather than enforcing immediately (BR-ANOM-007). Default `False` deliberately, not a mirror of the threat-feed equivalent: flipping it would silently stop enforcement on every existing deployment on upgrade |
 | `DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS` | `[]` | Detector function names (e.g. `["detect_cloud_spray"]`) that always create quarantined rules regardless of the setting above, for building trust in one detector without quarantining all of them (BR-ANOM-008). An unrecognised name is flagged by `django_waf.W008` at boot |
+| `DJANGO_WAF_SCRAPER_404_MIN_REQUESTS` | `20` | Minimum request count an IP must reach in the window before its 404 ratio is considered (BR-ANOM-014) |
+| `DJANGO_WAF_SCRAPER_404_RATIO` | `0.85` | Fraction of an IP's application-reaching requests that must be 404 before it is flagged |
+| `DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES` | `1440` | Detection window in minutes for `detect_scraper_404_ratio` |
+| `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK` | `False` | When `True`, a qualifying IP is auto-created at `action=block` instead of the default `action=challenge` |
 
 Auto-generated rules that are created quarantined, or that a detector in
 `DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS` creates, appear in the

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -1080,6 +1080,90 @@ def _DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS() -> int:
 
 
 # ---------------------------------------------------------------------------
+# detect_scraper_404_ratio: residential-proxy scraper detection by 404 rate
+# ---------------------------------------------------------------------------
+# Traced against a live deployment (VendablyCSS, shopping.vendably.com,
+# django-waf 2.1.0, three-day window): a residential-proxy scraping botnet
+# defeated every existing detector at once. 10,874 distinct IPs spread across
+# roughly 9,700 distinct /24 subnets (about 1.1 IPs per /24, mean 1.42
+# requests per IP) evaded detect_subnet_burst's >= 30 req/subnet floor and
+# detect_unsolved_challenges's subnet path (>= 10 IPs/subnet). 15,426 distinct
+# User-Agent strings, one per request, meant no shared-UA grouping key
+# existed for detect_cloud_spray's UA path, and its subnet path needs >= 2
+# suspicious IPs sharing a subnet, which this shape almost never produces.
+# Every one of the botnet's 15,378 requests scored exactly 3.50
+# (fingerprint-derived only, zero matched a suspicious path pattern), landing
+# strictly between DJANGO_WAF_SCORE_THRESHOLD_LOG (2.5) and
+# DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE (5.0), so every one was verdict=logged
+# and passed straight through to the application.
+#
+# The signal that does separate them is the 404 ratio. Filtering the same
+# window to IPs with >= 20 requests and >= 85% 404 responses yielded 14 IPs,
+# all confirmed scrapers (e.g. 31.58.20.59 at 100% over 32 requests,
+# 88.167.25.244 at 97% over 75, 103.59.160.242 at 92% over 115). A real
+# browser does not sustain a ~100% 404 rate over dozens of requests: a human
+# who hits a dead link navigates somewhere real, or gives up, long before
+# reaching that volume. The requested paths were stale internal URLs (old
+# category/merchant paths, with and without a trailing slash), i.e. a scrape
+# working from an outdated link graph, not a vulnerability scan probing for
+# known-bad paths (which DJANGO_WAF_SUSPICIOUS_PATH_PATTERNS already covers).
+
+
+# Minimum request count an IP must reach within the window before its 404
+# ratio is considered at all. 20 is comfortably below the smallest confirmed
+# scraper in the traced attack (32 requests) while high enough that a
+# handful of genuinely broken links from a real visitor's session cannot
+# alone qualify.
+def _DJANGO_WAF_SCRAPER_404_MIN_REQUESTS() -> int:
+    return _get_setting("DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20)
+
+
+# Fraction of an IP's (non-WAF-rejected) requests that must be 404 before it
+# is flagged. 0.85 sits below every confirmed scraper measured (92-100%)
+# with margin, while comfortably above what a real visitor following a few
+# stale bookmarks or an old external link would ever sustain.
+def _DJANGO_WAF_SCRAPER_404_RATIO() -> float:
+    return _get_setting("DJANGO_WAF_SCRAPER_404_RATIO", 0.85)
+
+
+# Time window, in minutes, the detector aggregates over. 1440 (24 hours) is
+# deliberately wide, on the same precedent as
+# DJANGO_WAF_UNSOLVED_SUBNET_WINDOW_MINUTES (360, #93): a detector whose
+# attacker spreads volume thinly over time needs its own wider window, or
+# the fixed count/ratio thresholds it compares against are never reachable
+# regardless of how they are tuned. Simulated live against the traced
+# deployment, sweeping window x DJANGO_WAF_SCRAPER_404_MIN_REQUESTS at the
+# default 0.85 ratio, counting flagged IPs:
+#
+#   window   180m: minreq 10 ->  0, 15 ->  0, 20 ->  0, 30 ->  0
+#   window   360m: minreq 10 ->  3, 15 ->  2, 20 ->  1, 30 ->  1
+#   window   720m: minreq 10 ->  4, 15 ->  3, 20 ->  3, 30 ->  2
+#   window  1440m: minreq 10 -> 13, 15 -> 10, 20 ->  8, 30 ->  7
+#
+# At 180 minutes the detector catches nothing at all: this cohort's mean of
+# 1.42 requests per IP over the full 3-day trace means no individual IP
+# accumulates enough volume inside 3 hours to clear even the lowest
+# min_requests swept. 1440 (24 hours) is the smallest swept window at which
+# the default DJANGO_WAF_SCRAPER_404_MIN_REQUESTS=20 catches a materially
+# non-trivial, confirmed-scraper population (8 IPs), so it is the default
+# rather than a threshold change: the window, not the count/ratio
+# thresholds, was the wrong knob, exactly as it was for #93.
+def _DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES() -> int:
+    return _get_setting("DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES", 1440)
+
+
+# Whether a qualifying IP is auto-created at RuleAction.BLOCK rather than
+# RuleAction.CHALLENGE. Default False: a 404 ratio is a behavioural signal,
+# not proof of malice on its own (a broken external link farm or a stale
+# sitemap could theoretically produce the same shape), so this detector
+# follows the same staging precedent as detect_cloud_spray's UA path
+# (issue #82): a coarse aggregate signal is staged at CHALLENGE by default,
+# and an operator who has built confidence in the signal opts into BLOCK.
+def _DJANGO_WAF_SCRAPER_404_ACTION_BLOCK() -> bool:
+    return _get_setting("DJANGO_WAF_SCRAPER_404_ACTION_BLOCK", False)
+
+
+# ---------------------------------------------------------------------------
 # PEP 562 module-level __getattr__ / __dir__: call-time resolution (#75)
 # ---------------------------------------------------------------------------
 # Every DJANGO_WAF_* name above is a private ``_NAME()`` resolver function,

--- a/src/django_waf/enums.py
+++ b/src/django_waf/enums.py
@@ -94,6 +94,7 @@ class AnomalyType(models.TextChoices):
     CHALLENGE_FARM = "challenge_farm", _("Challenge farm")
     UNSOLVED_CHALLENGE = "unsolved_challenge", _("Unsolved challenge")
     CLOUD_SPRAY = "cloud_spray", _("Cloud spray")
+    SCRAPER_404 = "scraper_404", _("Scraper 404 ratio")
 
 
 class RequestLogSource(models.TextChoices):

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -24,7 +24,7 @@ logger = logging.getLogger("django_waf.anomaly_detector")
 # check must therefore be treated the same as a missing referer (issue #24).
 BARE_ORIGIN_REFERER_RE = r"^https?://[^/]+$"
 
-# Single source of truth for the five detector function names, so
+# Single source of truth for the six detector function names, so
 # DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS (BR-ANOM-008) and the boot-time
 # check that validates it (checks.check_observe_only_detector_names,
 # django_waf.W008) cannot desync if a detector is ever renamed. Each
@@ -37,6 +37,7 @@ DETECTOR_NAMES = frozenset(
         "detect_challenge_farms",
         "detect_unsolved_challenges",
         "detect_cloud_spray",
+        "detect_scraper_404_ratio",
     }
 )
 
@@ -54,6 +55,7 @@ DETECTOR_NAME_TO_RESULT_KEY = {
     "detect_challenge_farms": "challenge_farm_rules",
     "detect_unsolved_challenges": "unsolved_challenge_rules",
     "detect_cloud_spray": "cloud_spray_rules",
+    "detect_scraper_404_ratio": "scraper_404_rules",
 }
 
 
@@ -956,6 +958,218 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
     return created_rules
 
 
+def detect_scraper_404_ratio(window_minutes: int | None = None, dry_run: bool = False) -> list:
+    """Detect IPs whose requests are overwhelmingly 404s (BR-ANOM-014).
+
+    Traced against a live deployment (VendablyCSS, shopping.vendably.com,
+    django-waf 2.1.0, three-day window): a residential-proxy scraping
+    botnet defeated every other detector at once. 10,874 distinct IPs
+    spread across roughly 9,700 distinct /24 subnets (about 1.1 IPs per
+    /24) evaded ``detect_subnet_burst``'s absolute floor and
+    ``detect_unsolved_challenges``'s subnet path (both need many IPs
+    concentrated in the same /24). 15,426 distinct User-Agent strings, one
+    per request, meant no shared UA existed for ``detect_cloud_spray`` to
+    key on. Every one of the botnet's requests scored exactly 3.50
+    (fingerprint-derived only, no suspicious path match), landing between
+    ``DJANGO_WAF_SCORE_THRESHOLD_LOG`` and ``DJANGO_WAF_SCORE_THRESHOLD_
+    CHALLENGE``, so every request was logged and passed through.
+
+    The signal that does separate them is the 404 ratio: filtering the same
+    window to IPs with >= ``DJANGO_WAF_SCRAPER_404_MIN_REQUESTS`` requests
+    and >= ``DJANGO_WAF_SCRAPER_404_RATIO`` of them 404 yielded 14 IPs, all
+    confirmed scrapers requesting stale internal URLs (old category/merchant
+    paths, with and without a trailing slash) from an outdated link graph,
+    not a vulnerability scan. A real browser does not sustain a ~100% 404
+    rate over dozens of requests.
+
+    Verdict scoping is the correctness-critical part of this detector, and
+    it was proven, not assumed: ``middleware.py``'s ``_handle_verdict``
+    returns a rejection response (``HttpResponseForbidden``/429/a redirect)
+    for ``Verdict.BLOCKED``, ``Verdict.CHALLENGED``, and
+    ``Verdict.THROTTLED`` *without ever calling* ``_get_response``, so a
+    row with one of those verdicts never reached a view and its
+    ``response_code`` reflects what the WAF itself returned, not a genuine
+    404 the *application* produced; production data confirms this
+    directly, blocked/challenged/throttled rows show exactly 0.0% 404 in
+    the traced deployment. This detector counts only rows whose verdict
+    shows the request reached the application AND was not already vetted
+    by an AllowRule: ``Verdict.ALLOWED`` and ``Verdict.LOGGED``.
+    ``Verdict.BLOCKED``, ``Verdict.CHALLENGED``, and ``Verdict.THROTTLED``
+    are excluded from both the numerator and the denominator, never only
+    one side: excluding them from the denominator alone while still
+    counting a stray 404 among them (there should not be any, since those
+    verdicts short-circuit before a view runs, but the exclusion is
+    unconditional rather than relying on that invariant holding forever).
+
+    ``Verdict.PASSED`` (an AllowRule match) is deliberately EXCLUDED, and
+    this is not a minor refinement: measured against the same production
+    trace over an identical window, excluding ``passed`` flagged zero IPs,
+    while including it flagged 10, every one a verified Bingbot IP (e.g.
+    40.77.167.132, 34 requests, 100% 404; 207.46.13.156, 25 requests, 100%
+    404), re-crawling roughly 14,897 dead URLs still present in its own
+    historical index, a stale-sitemap/HTTP 410 problem on the site's side,
+    not malicious behaviour. Including ``passed`` would have made this
+    detector auto-challenge (or, with ``DJANGO_WAF_SCRAPER_404_ACTION_
+    BLOCK=True``, auto-block) Bingbot on every deployment shaped like the
+    traced one, risking delisting. This is the same "AllowRules win"
+    precedence ``rule_engine.evaluate_request`` already applies at its
+    step 4, ahead of every BlockRule and every scoring path, applied here
+    at the counting stage rather than left to downstream staging alone.
+
+    Excluding ``passed`` does more than protect a legitimate crawler from
+    this detector's own count: it is what lets the detector *distinguish*
+    a real verified crawler from an impostor presenting the identical UA
+    string. In the same trace, 45.45.237.69 sent the genuine Googlebot
+    User-Agent (``Mozilla/5.0 (compatible; Googlebot/2.1;
+    +http://www.google.com/bot.html)``) and scored
+    ``fingerprint_verdict=browser`` on every row (27 requests, 89% 404),
+    yet its address is outside Google's published ranges, so it fails the
+    forward-confirmed reverse-DNS check the seeded Googlebot ``AllowRule``
+    requires (``verify_rdns=True``; see ``rule_engine._check_allow_rules``
+    / ``_verify_rdns``). It therefore never matches the AllowRule and never
+    gets ``verdict=passed``, unlike the genuine Googlebot IPs (66.249.x,
+    which produced 17,980 *distinct* 404 paths in the same trace, all
+    correctly excluded) in the same window, and this detector catches it.
+    Neither a UA-keyed rule (the UA string is byte-identical to the real
+    crawler's) nor an IP/CIDR-keyed rule (an impostor's address is not
+    stable) could separate the two; only "did this client actually earn an
+    AllowRule match, and is it 404ing" can. The same production trace also
+    showed this detector catching scrapers with no User-Agent at all
+    (e.g. 4.205.62.107, 446 requests, 100% 404, requesting
+    ``/agg.php``/``/cp2.php``/random-named PHP paths), a shape
+    ``detect_ua_rotation`` and ``detect_cloud_spray``'s UA path are
+    structurally blind to, since neither has any UA-derived signal to key
+    on when the header is empty.
+
+    Action staging: a qualifying IP is auto-created at
+    ``RuleAction.CHALLENGE``, promoted to ``RuleAction.BLOCK`` only when
+    ``DJANGO_WAF_SCRAPER_404_ACTION_BLOCK`` is ``True`` (default ``False``).
+    A 404 ratio is behavioural, not proof of malice by itself: a broken
+    external link farm, a stale sitemap, or a migrated URL scheme could in
+    principle produce the same shape for a legitimate-but-confused client.
+    This mirrors the package's own precedent for a coarse aggregate signal,
+    ``detect_cloud_spray``'s UA path (issue #82), which stages at CHALLENGE
+    by default for the same reason.
+
+    Args:
+        window_minutes: Time window to analyse. Defaults to
+                        DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES.
+        dry_run: When True (#38), collects what would be created without
+                 writing any BlockRule or emitting the anomaly_detected signal.
+
+    Returns:
+        List of BlockRule instances that were created (or, in dry-run, would
+        have been created).
+    """
+    from django.db.models import Count, Q
+
+    from django_waf import conf
+    from django_waf.enums import AnomalyType, RuleAction, RuleType, Verdict
+    from django_waf.models import RequestLog
+
+    effective_window_minutes = (
+        window_minutes if window_minutes is not None else conf.DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES
+    )
+    min_requests = conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS
+    ratio_floor = conf.DJANGO_WAF_SCRAPER_404_RATIO
+    action = RuleAction.BLOCK if conf.DJANGO_WAF_SCRAPER_404_ACTION_BLOCK else RuleAction.CHALLENGE
+
+    cutoff = timezone.now() - timedelta(minutes=effective_window_minutes)
+
+    # Only verdicts that show the request reached the application AND were
+    # not already vetted by an AllowRule (see docstring). This is applied
+    # once, as the base filter for the whole aggregation, so a WAF-produced
+    # verdict cannot enter the denominator OR the numerator for any IP.
+    # Verdict.PASSED (an AllowRule match, e.g. a verified crawler) is
+    # deliberately excluded, not merely tolerated: it is what stops a
+    # legitimate high-404-volume crawler (Bingbot re-crawling its own stale
+    # index, measured at up to 100% 404 over dozens of requests in
+    # production) from ever being counted at all, rather than relying on
+    # downstream staging to save it.
+    reached_app = Q(verdict__in=(Verdict.ALLOWED, Verdict.LOGGED))
+
+    # The floor (total >= min_requests) is applied in the database: it is a
+    # simple integer comparison with no precision concerns. The ratio
+    # comparison (count_404 / total >= ratio_floor) is applied in Python
+    # below, after fetching the two integer counts, rather than as a third
+    # database filter: comparing a computed float ratio in the database
+    # would require either a float division expression (backend-dependent
+    # rounding behaviour) or a cross-multiplied integer comparison
+    # (total * ratio_floor, which reintroduces the same float on the
+    # right-hand side since ratio_floor is itself a float setting). Doing
+    # the division once in Python, on already-fetched small integers, is
+    # exact, backend-independent, and the same ratio value is needed again
+    # immediately afterwards for the evidence dict and the confidence
+    # calculation, so a third query would not avoid the computation, only
+    # move it.
+    candidates = (
+        RequestLog.objects.filter(reached_app, timestamp__gte=cutoff)
+        .values("ip_address")
+        .annotate(
+            total=Count("id"),
+            count_404=Count("id", filter=Q(response_code=404)),
+        )
+        .filter(total__gte=min_requests)
+    )
+
+    created_rules = []
+    expiry = timezone.now() + timedelta(hours=conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS)
+
+    for row in candidates:
+        total = row["total"]
+        count_404 = row["count_404"]
+        ratio = count_404 / total
+        if ratio < ratio_floor:
+            continue
+
+        ip = row["ip_address"]
+        details = {
+            "total_requests": total,
+            "count_404": count_404,
+            "ratio": round(ratio, 2),
+            "window_minutes": effective_window_minutes,
+        }
+        # Span is the ratio's own remaining headroom above the floor, up to
+        # the ratio's hard ceiling of 1.0: a bounded [0, 1] value has no
+        # natural "threshold * N" span the way a request-count detector
+        # does, so the span is the distance from the floor to the maximum
+        # possible ratio instead. A detection right at the floor scores 0.5
+        # (the shared coin-flip floor every detector uses); a detection at
+        # ratio=1.0 (the observed shape: several of the traced IPs were
+        # exactly 100%) approaches, but per _scaled_confidence's own cap,
+        # never reaches, the ceiling.
+        confidence = _scaled_confidence(observed=ratio, threshold=ratio_floor, span=1 - ratio_floor)
+
+        rule, created = _get_or_create_auto_rule(
+            name=f"Auto: scraper 404 ratio from {ip}",
+            rule_type=RuleType.IP,
+            match_type="exact",
+            pattern=ip,
+            action=action,
+            expiry=expiry,
+            dry_run=dry_run,
+            detector_name="detect_scraper_404_ratio",
+            confidence=confidence,
+            evidence=details,
+        )
+        if created:
+            created_rules.append(rule)
+            if not dry_run:
+                _emit_anomaly_signal(
+                    rule=rule,
+                    anomaly_type=AnomalyType.SCRAPER_404,
+                    details=details,
+                )
+                logger.info(
+                    "django-waf: auto-created scraper 404 ratio rule for %s (ratio=%.0f%%, total=%d)",
+                    ip,
+                    ratio * 100,
+                    total,
+                )
+
+    return created_rules
+
+
 def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) -> dict:
     """Run all anomaly detectors and return a summary of findings.
 
@@ -979,8 +1193,8 @@ def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) 
     Returns:
         Dict with keys: ua_rotation_rules, subnet_burst_rules,
         challenge_farm_rules, unsolved_challenge_rules, cloud_spray_rules,
-        total_rules_created. In dry-run these counts describe what WOULD be
-        created, not what was created.
+        scraper_404_rules, total_rules_created. In dry-run these counts
+        describe what WOULD be created, not what was created.
     """
     if window_minutes is None:
         ua_rules = detect_ua_rotation(dry_run=dry_run)
@@ -988,6 +1202,7 @@ def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) 
         farm_rules = detect_challenge_farms(dry_run=dry_run)
         unsolved_rules = detect_unsolved_challenges(dry_run=dry_run)
         spray_rules = detect_cloud_spray(dry_run=dry_run)
+        scraper_404_rules = detect_scraper_404_ratio(dry_run=dry_run)
     else:
         window_hours = max(1, -(-window_minutes // 60))  # ceiling division
         ua_rules = detect_ua_rotation(window_minutes=window_minutes, dry_run=dry_run)
@@ -995,17 +1210,26 @@ def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) 
         farm_rules = detect_challenge_farms(window_hours=window_hours, dry_run=dry_run)
         unsolved_rules = detect_unsolved_challenges(window_minutes=window_minutes, dry_run=dry_run)
         spray_rules = detect_cloud_spray(window_minutes=window_minutes, dry_run=dry_run)
+        scraper_404_rules = detect_scraper_404_ratio(window_minutes=window_minutes, dry_run=dry_run)
 
-    total = len(ua_rules) + len(subnet_rules) + len(farm_rules) + len(unsolved_rules) + len(spray_rules)
+    total = (
+        len(ua_rules)
+        + len(subnet_rules)
+        + len(farm_rules)
+        + len(unsolved_rules)
+        + len(spray_rules)
+        + len(scraper_404_rules)
+    )
     logger.info(
         "django-waf anomaly detection%s: ua_rotation=%d subnet_burst=%d "
-        "challenge_farm=%d unsolved_challenge=%d cloud_spray=%d total=%d",
+        "challenge_farm=%d unsolved_challenge=%d cloud_spray=%d scraper_404=%d total=%d",
         " (dry-run)" if dry_run else "",
         len(ua_rules),
         len(subnet_rules),
         len(farm_rules),
         len(unsolved_rules),
         len(spray_rules),
+        len(scraper_404_rules),
         total,
     )
 
@@ -1015,6 +1239,7 @@ def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) 
         "challenge_farm_rules": len(farm_rules),
         "unsolved_challenge_rules": len(unsolved_rules),
         "cloud_spray_rules": len(spray_rules),
+        "scraper_404_rules": len(scraper_404_rules),
         "total_rules_created": total,
     }
 

--- a/src/django_waf/services/detector_probe.py
+++ b/src/django_waf/services/detector_probe.py
@@ -60,6 +60,7 @@ _UNSOLVED_CHALLENGE_IP = "192.0.2.50"
 _SUBNET_BURST_SUBNET_BASE = "198.51.100."  # .10-.15 used below
 _CHALLENGE_FARM_IP = "203.0.113.10"
 _CLOUD_SPRAY_SUBNET_BASE = "203.0.113."  # .20-.40 used below (21 IPs)
+_SCRAPER_404_IP = "192.0.2.90"
 
 _PROBE_UA = "django-waf-detector-probe/1.0"
 
@@ -203,6 +204,7 @@ def _build_fixture_traffic() -> None:
     _build_challenge_farm_fixture(now=now, conf=conf)
     _build_unsolved_challenge_fixture(now=now, conf=conf)
     _build_cloud_spray_fixture(now=now, conf=conf)
+    _build_scraper_404_fixture(now=now, conf=conf)
 
 
 def _build_ua_rotation_fixture(*, now, conf, distinct_ua_count: int | None = None) -> None:
@@ -394,5 +396,43 @@ def _build_cloud_spray_fixture(*, now, conf, distinct_ip_count: int | None = Non
                 referer="",
             )
             for i in range(distinct_ip_count)
+        ]
+    )
+
+
+def _build_scraper_404_fixture(*, now, conf, total_requests: int | None = None) -> None:
+    """BR-ANOM-014: a single IP with at least
+    DJANGO_WAF_SCRAPER_404_MIN_REQUESTS (default 20) requests within the
+    window, at least DJANGO_WAF_SCRAPER_404_RATIO (default 0.85) of them
+    404, all carrying a verdict that reached the application (allowed,
+    passed, or logged, never a WAF-produced verdict). Every row is built
+    with response_code=404 so the fixture's ratio is 100%, comfortably
+    clear of the default 85% floor.
+
+    ``total_requests`` defaults to ``conf.DJANGO_WAF_SCRAPER_404_MIN_
+    REQUESTS + 1``, for the same reason as the other config-derived
+    fixtures in this module: raising the threshold alone cannot falsify a
+    fixture that grows to match it. A falsifiability test that needs to
+    raise the threshold past a FIXED fixture size must pass an explicit
+    literal here.
+    """
+    from django_waf.enums import Verdict
+    from django_waf.models import RequestLog
+
+    if total_requests is None:
+        total_requests = conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS + 1
+
+    RequestLog.objects.bulk_create(
+        [
+            RequestLog(
+                timestamp=now,
+                ip_address=_SCRAPER_404_IP,
+                user_agent=_PROBE_UA,
+                path=f"/scraper-404-fixture-path-{i}/",
+                method="GET",
+                verdict=Verdict.ALLOWED,
+                response_code=404,
+            )
+            for i in range(total_requests)
         ]
     )

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -66,7 +66,8 @@ def detect_anomalies() -> dict:
 
     Returns:
         Dict with keys: ua_rotation_rules, subnet_burst_rules,
-        challenge_farm_rules, total_rules_created.
+        challenge_farm_rules, unsolved_challenge_rules, cloud_spray_rules,
+        scraper_404_rules, total_rules_created.
 
     Scheduled: every 15 minutes (BR-ANOM-005).
     """

--- a/tests/test_detector_probe.py
+++ b/tests/test_detector_probe.py
@@ -347,6 +347,51 @@ class TestRunDetectorProbeFalsifiability:
             assert result[detector_name]["alive"] is True
             assert result[detector_name]["rules_reported"] > 0
 
+    def test_probe_goes_red_when_scraper_404_ratio_cannot_match_its_fixture(self, db, monkeypatch):
+        """detect_scraper_404_ratio: the real query legitimately finds nothing.
+
+        Layer under test: the full real path. run_all_detectors is NOT
+        patched, and detect_scraper_404_ratio is NOT patched.
+
+        Pins the fixture to a fixed 25 requests (via the builder's own
+        total_requests parameter) while raising
+        DJANGO_WAF_SCRAPER_404_MIN_REQUESTS to 9999, so the real query's
+        ``total__gte=min_requests`` gate genuinely excludes the fixture IP
+        and the query returns [].
+
+        25, not a smaller number such as 5, is deliberately chosen to be
+        ABOVE the real, un-raised default of 20
+        (DJANGO_WAF_SCRAPER_404_MIN_REQUESTS's default): with the setting
+        at its real default, this fixture's 25 requests (100% 404) clears
+        both ``total__gte=20`` and the 85% ratio floor and so WOULD create a
+        rule, and the test would correctly fail, if the raise to 9999 were
+        ever removed or not actually reaching the query. A fixture pinned
+        below the real default (e.g. 5) fails the gate whether or not the
+        setting is raised at all, which would make this assertion pass
+        regardless of whether the monkeypatched conf value is real, live
+        conf read by the query.
+        """
+        from django_waf import conf
+        from django_waf.services import detector_probe as detector_probe_mod
+
+        real_builder = detector_probe_mod._build_scraper_404_fixture
+        monkeypatch.setattr(
+            detector_probe_mod,
+            "_build_scraper_404_fixture",
+            lambda *, now, conf: real_builder(now=now, conf=conf, total_requests=25),
+        )
+
+        with patch.object(conf, "DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 9999):
+            result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_scraper_404_ratio"]
+        assert result["detect_scraper_404_ratio"]["alive"] is False
+        assert result["detect_scraper_404_ratio"]["rules_reported"] == 0
+        for detector_name in DETECTOR_NAMES - {"detect_scraper_404_ratio"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
 
 class TestRunDetectorProbeReportingLogic:
     """Mapping/reporting-logic tests: a hand-written run_all_detectors result
@@ -368,7 +413,8 @@ class TestRunDetectorProbeReportingLogic:
             "challenge_farm_rules": 1,
             "unsolved_challenge_rules": 1,
             "cloud_spray_rules": 1,
-            "total_rules_created": 4,
+            "scraper_404_rules": 1,
+            "total_rules_created": 5,
         }
 
         with patch(
@@ -392,7 +438,8 @@ class TestRunDetectorProbeReportingLogic:
             "challenge_farm_rules": 1,
             "unsolved_challenge_rules": 1,
             "cloud_spray_rules": 1,
-            "total_rules_created": 3,
+            "scraper_404_rules": 1,
+            "total_rules_created": 4,
         }
 
         with patch(
@@ -605,7 +652,8 @@ class TestProbeDetectorsCommand:
             "challenge_farm_rules": 1,
             "unsolved_challenge_rules": 1,
             "cloud_spray_rules": 1,
-            "total_rules_created": 4,
+            "scraper_404_rules": 1,
+            "total_rules_created": 5,
         }
 
         with patch(

--- a/tests/test_scraper_404_ratio.py
+++ b/tests/test_scraper_404_ratio.py
@@ -1,0 +1,409 @@
+"""Tests for detect_scraper_404_ratio (BR-ANOM-014).
+
+Production case: VendablyCSS, shopping.vendably.com, django-waf 2.1.0,
+three-day window. A residential-proxy scraping botnet (10,874 distinct IPs
+across roughly 9,700 distinct /24 subnets, 15,426 distinct User-Agent
+strings) defeated every other detector: it never concentrated enough
+volume in any one subnet, never shared a UA, and every request scored
+exactly 3.50 (below DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE), so verdict was
+"logged" throughout. The 404 ratio is the one signal that separates a
+scraper working from a stale link graph from real traffic.
+
+House discipline: every threshold test is sized from a fixed literal, never
+derived from the setting under test, so raising the threshold alone can
+falsify the fixture rather than the fixture silently tracking the raise.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from django_waf.enums import RuleAction, RuleSource, RuleType, Verdict
+from django_waf.services.anomaly_detector import detect_scraper_404_ratio
+from django_waf.testing.factories import RequestLogFactory
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_requests(
+    ip: str,
+    *,
+    total: int,
+    count_404: int,
+    verdict: str = Verdict.ALLOWED,
+    response_code_non_404: int = 200,
+    timestamp=None,
+) -> None:
+    """Create ``total`` RequestLog rows for ``ip``, ``count_404`` of them 404."""
+    now = timestamp or timezone.now()
+    for i in range(total):
+        RequestLogFactory(
+            ip_address=ip,
+            path=f"/stale-path-{i}/",
+            verdict=verdict,
+            response_code=404 if i < count_404 else response_code_non_404,
+            timestamp=now,
+        )
+
+
+class TestDetectScraper404RatioCreatesRule:
+    def test_ip_at_100_percent_404_over_min_requests_creates_rule(self):
+        """An IP at 100% 404 over >= MIN_REQUESTS creates a rule."""
+        ip = "31.58.20.59"
+        _make_requests(ip, total=32, count_404=32)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert len(created) == 1
+        rule = created[0]
+        assert rule.pattern == ip
+        assert rule.rule_type == RuleType.IP
+        assert rule.source == RuleSource.AUTO
+        assert rule.action == RuleAction.CHALLENGE
+
+    def test_evidence_dict_carries_counts_and_ratio(self):
+        """notes/evidence records total_requests, count_404, ratio, window_minutes."""
+        ip = "88.167.25.244"
+        _make_requests(ip, total=75, count_404=73)  # 97.3%, matches the production trace
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert len(created) == 1
+        notes = created[0].notes
+        assert "total_requests: 75" in notes
+        assert "count_404: 73" in notes
+        assert "window_minutes: 180" in notes
+        assert "ratio:" in notes
+
+
+class TestDetectScraper404RatioThresholdTeeth:
+    def test_below_min_requests_creates_no_rule_even_at_100_percent(self):
+        """An IP below MIN_REQUESTS does NOT create a rule even at 100% 404.
+
+        Fixed at 19 requests (one below the pinned floor of 20): if the
+        min-requests gate were ever dropped this would still create a rule
+        at 100% ratio, so this is a genuine test of the floor, not a
+        vacuous one.
+        """
+        ip = "10.10.10.10"
+        _make_requests(ip, total=19, count_404=19)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []
+
+    def test_above_min_requests_but_below_ratio_creates_no_rule(self):
+        """An IP above MIN_REQUESTS but below RATIO does NOT create a rule.
+
+        30 requests (above the 20-request floor), 20 of them 404
+        (66.7%, below the pinned 85% floor).
+        """
+        ip = "10.10.10.20"
+        _make_requests(ip, total=30, count_404=20)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []
+
+    def test_min_requests_threshold_has_teeth_against_reversion(self):
+        """Raising MIN_REQUESTS past a fixed fixture size defeats the query for real.
+
+        The fixture is pinned to 25 requests (a literal, not derived from
+        the setting under test); raising the setting to 9999 must make the
+        real query return nothing, proving the floor is read live rather
+        than baked into a fixture that would pass regardless.
+        """
+        ip = "10.10.10.30"
+        _make_requests(ip, total=25, count_404=25)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 9999),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []
+
+
+class TestDetectScraper404RatioVerdictScoping:
+    def test_verified_crawler_passed_verdict_with_huge_404_count_creates_no_rule(self):
+        """A verified-crawler IP (verdict=PASSED) with a huge 404 count creates NO rule.
+
+        Regression test for the most dangerous failure mode this detector
+        could introduce: auto-challenging (or, with
+        DJANGO_WAF_SCRAPER_404_ACTION_BLOCK=True, auto-blocking) a verified
+        search crawler. Production evidence (measured over an identical
+        180-minute window at the default 20-request/85%-ratio gate):
+        excluding verdict=passed traffic flagged zero IPs; including it
+        flagged 10, every single one a verified Bingbot IP, e.g.
+        40.77.167.132 (34 requests, 100% 404) and 207.46.13.156 (25
+        requests, 100% 404), re-crawling roughly 14,897 dead URLs still
+        present in its own historical index (a stale-sitemap/HTTP 410 gap
+        on the site's side, not malicious behaviour).
+
+        This fixture is pinned at 100% 404 (the actual worst-case shape
+        measured live for Bingbot, not a softened one), well clear of the
+        ratio floor, specifically so this is a genuine falsifiability
+        check: a detector that forgot to exclude Verdict.PASSED would
+        create a rule here, not merely one that happened to fall on the
+        safe side of some other gate.
+        """
+        ip = "40.77.167.132"
+        _make_requests(ip, total=34, count_404=34, verdict=Verdict.PASSED)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []
+
+    def test_spoofed_crawler_ua_that_fails_allowrule_is_still_caught(self):
+        """An impostor sending a genuine crawler UA, but that never matches
+        the AllowRule (fails FCrDNS, so verdict is never PASSED), is not
+        given the same protection as the real crawler.
+
+        Production trace: 45.45.237.69 sent the exact Googlebot User-Agent
+        string but sits outside Google's published ranges, so it fails the
+        seeded AllowRule's forward-confirmed reverse-DNS check and never
+        gets verdict=passed; it was flagged (27 requests, 89% 404). Real
+        Googlebot IPs (66.249.x) in the same trace matched the AllowRule,
+        got verdict=passed, and were excluded (see the previous test's
+        sibling case). This is the property that makes verdict-scoping
+        (rather than a UA or IP/CIDR rule) able to distinguish an impostor
+        presenting an identical UA string from the real crawler: this test
+        represents the impostor's outcome (verdict=allowed, since it did
+        not match the AllowRule) and asserts it IS flagged.
+        """
+        ip = "45.45.237.69"
+        _make_requests(
+            ip,
+            total=27,
+            count_404=24,  # ~89%, matching the production trace
+            verdict=Verdict.ALLOWED,
+        )
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert len(created) == 1
+        assert created[0].pattern == ip
+
+    def test_empty_user_agent_scraper_is_caught(self):
+        """A scraper sending no User-Agent at all is still caught.
+
+        Production trace: 4.205.62.107 sent an empty User-Agent header and
+        was flagged (446 requests, 100% 404, requesting randomly-named PHP
+        paths such as /agg.php, /cp2.php). This detector has no UA-derived
+        signal at all, unlike detect_ua_rotation and detect_cloud_spray's
+        UA path, both of which are structurally blind to an empty or
+        absent User-Agent.
+        """
+        ip = "4.205.62.107"
+        for i in range(30):
+            RequestLogFactory(
+                ip_address=ip,
+                user_agent="",
+                path=f"/random-{i}.php",
+                verdict=Verdict.ALLOWED,
+                response_code=404,
+                timestamp=timezone.now(),
+            )
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert len(created) == 1
+        assert created[0].pattern == ip
+
+    def test_blocked_challenged_throttled_rows_do_not_dilute_denominator(self):
+        """WAF-produced verdicts (blocked/challenged/throttled) never enter the ratio.
+
+        An IP with 15 real, application-reaching 404s (below MIN_REQUESTS
+        of 20 alone) plus 10 BLOCKED-verdict rows that, if wrongly counted,
+        would push it over the 20-request floor. If the detector counted
+        those rows, this IP would qualify (25 total >= 20); because it must
+        exclude them, only 15 real requests remain, below the floor, so no
+        rule is created. This is the genuine falsifiability check for the
+        verdict-scoping filter: a detector that forgot the filter would
+        create a rule here.
+        """
+        ip = "10.10.10.40"
+        _make_requests(ip, total=15, count_404=15)
+        # WAF-produced verdicts: never reached the view, response_code is
+        # what the WAF itself returned (403 for blocked), not a genuine
+        # application 404.
+        for i in range(10):
+            RequestLogFactory(
+                ip_address=ip,
+                path=f"/blocked-path-{i}/",
+                verdict=Verdict.BLOCKED,
+                response_code=403,
+                timestamp=timezone.now(),
+            )
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []
+
+    def test_challenged_and_throttled_rows_also_excluded(self):
+        """CHALLENGED and THROTTLED rows are excluded from the denominator too.
+
+        Mirrors the BLOCKED case: 15 real 404s plus 10 CHALLENGED and 10
+        THROTTLED rows. If any of those entered the count, this IP (35
+        total) would clear the 20-request floor; correctly excluded, only
+        15 real requests remain and no rule is created.
+        """
+        ip = "10.10.10.50"
+        _make_requests(ip, total=15, count_404=15)
+        for i in range(10):
+            RequestLogFactory(
+                ip_address=ip,
+                path=f"/challenged-path-{i}/",
+                verdict=Verdict.CHALLENGED,
+                response_code=302,
+                timestamp=timezone.now(),
+            )
+        for i in range(10):
+            RequestLogFactory(
+                ip_address=ip,
+                path=f"/throttled-path-{i}/",
+                verdict=Verdict.THROTTLED,
+                response_code=429,
+                timestamp=timezone.now(),
+            )
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []
+
+
+class TestDetectScraper404RatioDryRun:
+    def test_dry_run_creates_nothing(self):
+        """dry_run=True (BR-ANOM-006) writes nothing; check _state.adding, not pk.
+
+        BlockRule.id is a UUIDField with default=uuid.uuid4, so pk is
+        always populated even on an unsaved instance; _state.adding is the
+        only reliable signal that a row was never written.
+        """
+        from django_waf.models import BlockRule
+
+        ip = "10.10.10.60"
+        _make_requests(ip, total=25, count_404=25)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180, dry_run=True)
+
+        assert len(created) == 1
+        assert created[0]._state.adding is True
+        assert not BlockRule.objects.filter(rule_type=RuleType.IP, pattern=ip).exists()
+
+
+class TestDetectScraper404RatioActionStaging:
+    def test_default_action_is_challenge(self):
+        """Default DJANGO_WAF_SCRAPER_404_ACTION_BLOCK=False stages at CHALLENGE."""
+        ip = "10.10.10.70"
+        _make_requests(ip, total=25, count_404=25)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_ACTION_BLOCK", False),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert len(created) == 1
+        assert created[0].action == RuleAction.CHALLENGE
+
+    def test_action_block_true_produces_block_rule(self):
+        """DJANGO_WAF_SCRAPER_404_ACTION_BLOCK=True produces a BLOCK rule."""
+        ip = "10.10.10.80"
+        _make_requests(ip, total=25, count_404=25)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_ACTION_BLOCK", True),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert len(created) == 1
+        assert created[0].action == RuleAction.BLOCK
+
+
+class TestDetectScraper404RatioWindow:
+    def test_window_minutes_default_reads_from_setting(self):
+        """window_minutes=None falls back to DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES."""
+        ip = "10.10.10.90"
+        _make_requests(ip, total=25, count_404=25)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES", 180),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+        ):
+            created = detect_scraper_404_ratio()
+
+        assert len(created) == 1
+
+    def test_requests_outside_window_are_excluded(self):
+        """A request timestamped before the cutoff is not counted."""
+        from datetime import timedelta
+
+        ip = "10.10.10.100"
+        old = timezone.now() - timedelta(hours=6)
+        _make_requests(ip, total=25, count_404=25, timestamp=old)
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1690,6 +1690,7 @@ class TestRunAllDetectors:
             "challenge_farm_rules",
             "unsolved_challenge_rules",
             "cloud_spray_rules",
+            "scraper_404_rules",
             "total_rules_created",
         }
 


### PR DESCRIPTION
Adds `detect_scraper_404_ratio`, a sixth anomaly detector that flags an IP whose application-reaching requests are overwhelmingly 404.

## Why

Traced against a live deployment (VendablyCSS, django-waf 2.1.0, three-day window). A residential-proxy scraping botnet defeated every existing detector simultaneously:

| Evasion | Detector defeated |
|---|---|
| 10,874 IPs across ~9,700 distinct /24s (~1.1 IPs per /24) | `detect_subnet_burst` (needs >= 30 req/subnet), `detect_unsolved_challenges` subnet path (needs >= 10 IPs/subnet) |
| 15,426 distinct UA strings, one per request | `detect_cloud_spray` UA path (needs a shared UA) |
| Every request scored exactly 3.50 | Score bands: sits between `SCORE_THRESHOLD_LOG` (2.5) and `SCORE_THRESHOLD_CHALLENGE` (5.0) |

All 15,378 of its requests were `logged` and passed through to the view.

## The signal

404 ratio. A real browser does not sustain a near-100% 404 rate over dozens of requests; these IPs request stale internal URLs from an outdated link graph.

At the defaults, every flagged IP in the trace was a genuine bad actor, covering four shapes the other five detectors miss:

- Empty-UA webshell hunters with randomly-named PHP paths (`/agg.php`, `/adminner.php`) that no path-pattern list can enumerate
- A scanner whose UA is literally `xploit_probe`
- Distributed scrapers hitting dead product URLs
- A **spoofed Googlebot**: correct UA string, `fingerprint_verdict=browser`, but outside Google's ranges

## Verdict scoping is the correctness-critical part

Only `ALLOWED` and `LOGGED` are counted, in both numerator and denominator. `BLOCKED`/`CHALLENGED`/`THROTTLED` never reach a view, so their `response_code` is what the WAF returned; production confirms this (those verdicts show exactly 0.0% 404).

`PASSED` (an AllowRule match) is excluded, and this was verified rather than assumed. Over an identical window:

- **Excluding** `passed`: 0 IPs flagged
- **Including** `passed`: 10 IPs flagged, **every one a verified Bingbot address** (40.77.167.132, 207.46.13.156, ...) re-crawling ~14,897 dead URLs from its own historical index

Including it would auto-challenge Bingbot on any deployment of this shape. The exclusion is also what lets the detector distinguish a real crawler from an impostor: only the genuine crawler earns an AllowRule match via FCrDNS, so the spoofed Googlebot above is caught while `66.249.x` (17,980 distinct 404 paths in the same window) is correctly excluded. Neither a UA-keyed rule (identical string) nor an IP-keyed rule (unstable address) could make that distinction.

## Calibration

The 1440-minute default window was swept live. A 180-minute window flags nothing at any threshold, because this cohort accumulates volume too slowly per IP:

| Window | minreq 10 | 15 | 20 | 30 |
|---|---|---|---|---|
| 180 | 0 | 0 | 0 | 0 |
| 360 | 3 | 2 | 1 | 1 |
| 720 | 4 | 3 | 3 | 2 |
| 1440 | 13 | 10 | 8 | 7 |

Rules stage at `CHALLENGE`, promoting to `BLOCK` only via `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK`, following `detect_cloud_spray`'s UA-path precedent for a coarse aggregate signal.

Measured query cost on the production database: 0.82s over 1.47M rows, running every 15 minutes via the existing `detect_anomalies` beat entry.

## Settings

| Setting | Default |
|---|---|
| `DJANGO_WAF_SCRAPER_404_MIN_REQUESTS` | 20 |
| `DJANGO_WAF_SCRAPER_404_RATIO` | 0.85 |
| `DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES` | 1440 |
| `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK` | False |

## Verification

- Full suite green on Python 3.12/Django 6.0 (sqlite), Python 3.13/Django 6.1, real PostgreSQL, and the Redis integration leg against `redis:6.0-alpine` matching the CI pin
- `ruff==0.15.22` check and format both clean
- Teeth proven by reverting each guard and confirming the corresponding test fails: min-requests floor, ratio floor, and the `PASSED` exclusion. Removing the exclusion produces exactly the incident it prevents, a BlockRule for real Bingbot IP 40.77.167.132
- Detector liveness probe fixture verified to genuinely exercise the detector, with a falsifiability test that decouples fixture size from the threshold

Spec: icvoss/icv-oss-umbrella#docs/waf-scraper-404-spec (BR-ANOM-014)