### PR TITLE
chore(release): 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.4.0] - 2026-09-02
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.3.0"
+version = "2.4.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release 2.4.0. Bumps the version and dates the CHANGELOG entry for the sixth anomaly detector, `detect_scraper_404_ratio` (BR-ANOM-014), merged in #117.

## What ships

One new feature: a detector that flags IPs whose application-reaching requests are overwhelmingly 404, catching a residential-proxy scraping botnet that defeated all five existing detectors simultaneously. Four new settings, all with defaults, and one new `AnomalyType` value.

## Behaviour change for existing consumers

**A sixth detector now runs on every `detect_anomalies` pass** (the existing 15-minute beat entry). Consumers who have not set `DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES = True` will see it create enforcing rules, as the other five already do.

It stages at `CHALLENGE`, not `BLOCK`. To promote it, set `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK = True`. To observe before enforcing, add `detect_scraper_404_ratio` to `DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS`.

Verified-crawler traffic (`Verdict.PASSED`, an AllowRule match) is excluded from the count, so a legitimate crawler producing a high 404 rate against stale URLs is never flagged.

| Setting | Default |
|---|---|
| `DJANGO_WAF_SCRAPER_404_MIN_REQUESTS` | 20 |
| `DJANGO_WAF_SCRAPER_404_RATIO` | 0.85 |
| `DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES` | 1440 |
| `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK` | False |

Added query cost, measured on a 1.47M-row production table: 0.82s per pass.

## Release gate

Run before opening this PR, per the umbrella's six preconditions:

1. **Version and CHANGELOG** — `pyproject.toml` at 2.4.0 (the only place the version lives; `__init__` reads it from package metadata). `[Unreleased]` renamed to `[2.4.0] - 2026-09-02`, nothing left dangling.
2. **Suite green on every leg** — all 10 CI legs passed on the tagged content at #117: 7 Python/Django matrix combinations (3.11 to 3.13 across 5.2/6.0/6.1), real PostgreSQL 16, real Redis 6.0, and lint. This PR adds no code.
3. **Publish gate simulated** — `publish.yml` installs a different dependency set from `ci.yml`, so a green CI does not imply a green publish. Replicated exactly: built the wheel, installed it with `[dev,celery]` plus `Django~=5.2.0` into a clean Python 3.12 venv, ran the suite. **1261 passed, 5 skipped.** Confirmed `django_waf` resolved from site-packages rather than `src/`, so the artefact was genuinely under test.
4. **Artefact verified** — `twine check` PASSED. Unzipped the wheel and confirmed it carries `detect_scraper_404_ratio`, all four `SCRAPER_404` settings, the `SCRAPER_404` enum value, all 6 migrations and the 8 template/data files. Then imported it from the clean venv.
5. **Workflow at the tagged commit** — this PR does not touch `.github/workflows/`, and `publish.yml` at this commit is the one released 2.3.0 successfully.
6. **Consumer-visible change named** — see the section above.

`py.typed` is absent from the wheel. That is issue #108, pre-existing and unchanged by this release, not a regression.