### PR TITLE
The typing-and-liveness wave: mypy in CI, py.typed, and a flush-path probe (#111, #108, #100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,10 +234,17 @@ jobs:
       # Guard against the exit-2-checked-nothing failure described above: a
       # real run analyses the whole src/ tree. If this count collapses, the
       # gate has stopped checking rather than started passing.
+      # Match on the "N source files" suffix, which BOTH summary forms end
+      # with: "Success: no issues found in 86 source files" on a clean run,
+      # and "Found 3 errors in 2 files (checked 86 source files)" otherwise.
+      # An earlier version of this guard keyed on the word "checked", which
+      # appears only in the second form, so it extracted 0 on exactly the
+      # runs that passed and failed this job on its first green tree.
       - name: Assert mypy actually analysed the source tree
         run: |
-          out="$(PYTHONPATH=. mypy src/ --no-error-summary 2>&1 || true)"
-          count="$(PYTHONPATH=. mypy src/ 2>&1 | grep -oE 'checked [0-9]+ source file' | grep -oE '[0-9]+' || echo 0)"
+          summary="$(PYTHONPATH=. mypy src/ 2>&1 | tail -1)"
+          echo "mypy summary: ${summary}"
+          count="$(printf '%s' "${summary}" | grep -oE '[0-9]+ source files?' | grep -oE '^[0-9]+' || echo 0)"
           echo "mypy analysed ${count} source files"
           if [ "${count}" -lt 80 ]; then
             echo "::error::mypy analysed only ${count} source files; expected 80+."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,3 +199,51 @@ jobs:
       - run: pip install "ruff==0.15.22"
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
+
+  # Dedicated leg. mypy is configured in pyproject.toml with the django-stubs
+  # plugin and documented in the README as the project's type gate, but until
+  # issue #111 no workflow ran it, so a type regression could reach main with
+  # every check green. The declared bar and the enforced bar had diverged.
+  #
+  # PYTHONPATH=. is load-bearing, not decoration. [tool.django-stubs] sets
+  # django_settings_module = "tests.settings", a dotted path resolved from the
+  # repo root. Without the repo root on the path the plugin cannot import the
+  # settings module, and mypy exits 2 having checked NOTHING. That failure is
+  # easy to misread as a pass when a run is scripted, so this leg asserts the
+  # file count below rather than trusting the exit status alone.
+  #
+  # mypy and django-stubs are pinned exactly, like ruff in the lint leg above:
+  # a type checker that floats will fail a branch that has not changed, on
+  # somebody else's release, in a job nobody touched.
+  typecheck:
+    name: Type check (mypy + django-stubs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # The api, celery and geoip extras are installed so the optional-import
+      # modules (django_waf.api.*, tasks.py, the GeoIP service) are actually
+      # analysed. Without them mypy skips those files as unresolvable imports
+      # and the gate silently covers less than it appears to.
+      - name: Install dependencies
+        run: pip install -e ".[dev,celery,api,geoip]" "mypy==2.3.1" "django-stubs==6.1.0"
+
+      # Guard against the exit-2-checked-nothing failure described above: a
+      # real run analyses the whole src/ tree. If this count collapses, the
+      # gate has stopped checking rather than started passing.
+      - name: Assert mypy actually analysed the source tree
+        run: |
+          out="$(PYTHONPATH=. mypy src/ --no-error-summary 2>&1 || true)"
+          count="$(PYTHONPATH=. mypy src/ 2>&1 | grep -oE 'checked [0-9]+ source file' | grep -oE '[0-9]+' || echo 0)"
+          echo "mypy analysed ${count} source files"
+          if [ "${count}" -lt 80 ]; then
+            echo "::error::mypy analysed only ${count} source files; expected 80+."
+            echo "::error::The run is a no-op, not a pass (see issue #111: missing PYTHONPATH exits 2 having checked nothing)."
+            exit 1
+          fi
+
+      - name: Type check
+        run: PYTHONPATH=. mypy src/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,79 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A liveness probe for the Redis hit-count flush path** (#100, BR-LIFE-005).
+  The companion to the detector probe shipped in 2.2.0, covering the
+  subsystem that one cannot reach. `flush_rule_hit_counts` called Redis
+  `GETDEL`, which needs 6.2+; production ran 6.0.16, every call raised into
+  a bare except, and 40,936 scheduled task runs reported success while
+  flushing nothing. The defect survived tests, review and release because
+  `{"flushed": 0, "keys_seen": 0, "errors": 0}` is simultaneously the
+  healthy result on a quiet site, the Redis-unreachable result, and what
+  the bug produced. Zero against unknown traffic is ambiguous; zero against
+  a counter the probe just wrote itself is not.
+
+  `run_flush_probe()` (`services/flush_probe.py`) drives one hit end to end
+  through the real producer (`rule_engine._record_rule_hit`) and the real
+  consumer (`flush_rule_hit_counts`), then asserts it reached
+  `BlockRule.hit_count`. It calls the real producer deliberately: the key
+  literal `waf:rule_hits:` is duplicated with no shared constant between
+  producer and consumer, so a probe hardcoding a third copy could not
+  detect the two drifting apart. Ships with an hourly `probe_flush_path`
+  task and beat entry, plus a `django_waf_probe_flush_path` management
+  command that exits non-zero on a dead path, for a cron or k8s wrapper.
+
+  Safe to run against a live site, which took work rather than luck.
+  `flush_rule_hit_counts` scans `waf:rule_hits:*` and flushes every key it
+  finds, so the probe's own run also sweeps up real counters, whose
+  database updates would land inside the probe's rolled-back transaction
+  while their Redis keys were deleted regardless. The probe therefore
+  snapshots every other key first and restores each one afterwards, to
+  Redis only and never to the row, leaving the count pending for the next
+  scheduled flush. Restoring both double-counts, which an implementation of
+  this probe did before review caught it: a real counter of 5 reached
+  `hit_count = 10` after one probe run plus one flush.
+
+- **A PEP 561 `py.typed` marker** (#108). The package has always been
+  annotated but never advertised it, so a consumer type-checking its own
+  code saw `Any` for everything imported from `django_waf`. Verified on the
+  built wheel rather than the source tree: against the published 2.4.0
+  wheel a consumer's mypy reports `import-untyped` and `Revealed type is
+  "Any"`, and against this build it resolves the real signature.
+
+- **A `typecheck` CI job** (#111), with mypy and django-stubs pinned
+  exactly, as the `lint` job already pins ruff. mypy was configured with
+  the django-stubs plugin and documented in the README, but no workflow ran
+  it, so a type regression could reach `main` with every check green. The
+  job asserts mypy analysed 80+ source files before trusting its exit
+  status: without `PYTHONPATH=.` the plugin cannot resolve
+  `django_settings_module = "tests.settings"` and mypy exits 2 having
+  checked nothing at all, a no-op that reads as a pass when scripted.
+
+### Fixed
+
+- **`_deduplicate_block_rules` could raise `AttributeError` on a
+  concurrent delete** (#111). It called `.pk` on the result of
+  `qs.first()`, which is `None` if the queryset empties between the
+  `qs.count() <= 1` guard and the fetch. Found by the mypy pass rather than
+  in production; it now fetches once and returns early.
+
+- **`verify_challenge_solution` accepted a `None` difficulty** (#111),
+  passing it into the proof-of-work check rather than rejecting it. It now
+  raises `ChallengeInvalidError`, since a difficulty that was never issued
+  cannot be verified against.
+
+### Changed
+
+- mypy now reports zero errors across 86 source files, down from 31 in 19
+  (#111). Third-party stub noise (`rest_framework.*`, `celery.*`,
+  `django_redis.*`) is suppressed with a per-module override rather than a
+  blanket `ignore_missing_imports`, which would also silence genuine
+  missing-import findings in this package's own code.
+
 ## [2.4.0] - 2026-09-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -648,9 +648,23 @@ pytest --cov=src --cov-report=term-missing
 ruff check src/ tests/
 ruff format src/ tests/
 
-# Type check
-mypy src/
+# Type check. PYTHONPATH=. is required, not optional: the django-stubs
+# plugin resolves `django_settings_module = "tests.settings"` as a dotted
+# path from the repo root, and without it mypy exits 2 having checked
+# nothing at all, which reads like a pass when scripted.
+PYTHONPATH=. mypy src/
 ```
+
+Every one of these runs in CI (`.github/workflows/ci.yml`): `ruff check` and
+`ruff format --check` in the `lint` job, `mypy` in the `typecheck` job, and the
+suite across the Python/Django matrix plus dedicated legs for real Redis and
+real PostgreSQL. A branch green on `pytest` alone is not verified.
+
+## Type information for consumers
+
+The package ships a PEP 561 `py.typed` marker, so a project that type-checks
+its own code sees the real annotations on everything it imports from
+`django_waf` rather than `Any`.
 
 ## Licence
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 where = ["src"]
 
 [tool.setuptools.package-data]
-django_waf = ["templates/**/*.html", "conf/nginx/*.conf.example"]
+django_waf = ["py.typed", "templates/**/*.html", "conf/nginx/*.conf.example"]
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "tests.settings"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,14 @@ python_version = "3.11"
 plugins = ["mypy_django_plugin.main"]
 strict = false
 
+# These third-party packages ship no type stubs and no py.typed marker, so
+# mypy cannot analyse their public interfaces. This suppresses noise about
+# THEIR missing types, not ours: it does not affect how mypy checks imports
+# from our own modules or from packages that do ship types.
+[[tool.mypy.overrides]]
+module = ["rest_framework.*", "celery.*", "django_redis.*"]
+ignore_missing_imports = true
+
 [tool.django-stubs]
 django_settings_module = "tests.settings"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ ignore = ["S101", "S104", "S105", "S106", "S107", "S311", "S603", "S607"]
 "tests/test_testing_fixtures.py" = ["F811"]
 "tests/test_redis_fallback.py" = ["F811"]
 "tests/test_flush_rule_hit_counts.py" = ["F811"]
+"tests/test_flush_probe.py" = ["F811"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -717,6 +717,14 @@ _CELERY_BEAT_INTERVAL_ENTRIES: dict = {
         "task": "django_waf.tasks.probe_detectors",
         "schedule": 3600.0,  # every hour (BR-ANOM-012)
     },
+    "django-waf-probe-flush-path": {
+        "task": "django_waf.tasks.probe_flush_path",
+        "schedule": 3600.0,  # every hour (#100): flush itself runs every 5
+        # minutes, so an hourly probe gives ample margin to catch
+        # sustained breakage well inside a day without adding alert noise
+        # on the same cadence as the thing it checks, matching the
+        # detector probe's own precedent above.
+    },
 }
 
 if crontab is not None:

--- a/src/django_waf/forms/mixin.py
+++ b/src/django_waf/forms/mixin.py
@@ -31,6 +31,18 @@ from django.core.exceptions import ImproperlyConfigured
 if TYPE_CHECKING:  # pragma: no cover
     from django_waf.forms.protection import FormEvaluationResult, FormProtection
 
+    # Typing-only base: at runtime ProtectedForm is a bare mixin (see the
+    # class definition below), always combined by the consumer as
+    # `class ContactForm(ProtectedForm, forms.Form)`. Deriving from
+    # forms.Form here, under TYPE_CHECKING only, tells the checker what
+    # every real usage guarantees (a host class providing Form.clean() and
+    # Form.data) without adding forms.Form to the runtime MRO, which would
+    # change attribute resolution order and __init__ behaviour for
+    # subclasses that also inherit it directly.
+    _ProtectedFormBase = forms.Form
+else:
+    _ProtectedFormBase = object
+
 
 logger = logging.getLogger("django_waf.forms")
 
@@ -42,7 +54,7 @@ logger = logging.getLogger("django_waf.forms")
 _BLOCKED_MESSAGE = "Submission rejected. Please try again."
 
 
-class ProtectedForm:
+class ProtectedForm(_ProtectedFormBase):
     """Django Form mixin that runs WAF defences during clean().
 
     Usage::

--- a/src/django_waf/management/commands/django_waf_export_rules.py
+++ b/src/django_waf/management/commands/django_waf_export_rules.py
@@ -47,14 +47,14 @@ class Command(BaseCommand):
         allow_rules: list[dict] = []
 
         if rule_type in ("block", "all"):
-            qs = BlockRule.objects.all()
+            block_qs = BlockRule.objects.all()
             if source != "all":
-                qs = qs.filter(source=source)
-            block_rules = [_serialise_block_rule(rule) for rule in qs]
+                block_qs = block_qs.filter(source=source)
+            block_rules = [_serialise_block_rule(rule) for rule in block_qs]
 
         if rule_type in ("allow", "all"):
-            qs = AllowRule.objects.all()
-            allow_rules = [_serialise_allow_rule(rule) for rule in qs]
+            allow_qs = AllowRule.objects.all()
+            allow_rules = [_serialise_allow_rule(rule) for rule in allow_qs]
 
         payload = {
             "version": 1,

--- a/src/django_waf/management/commands/django_waf_probe_flush_path.py
+++ b/src/django_waf/management/commands/django_waf_probe_flush_path.py
@@ -1,0 +1,40 @@
+"""
+Management command: django_waf_probe_flush_path
+
+Runs the flush-path liveness probe (#100) against a real counter driven
+through the real producer (``rule_engine._record_rule_hit``) and the real
+consumer (``tasks.flush_rule_hit_counts``), and reports whether it
+demonstrably reached the database. Useful for manual invocation outside
+the Celery schedule, incident response, or a readiness/liveness probe
+wired to an external monitor.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Run the WAF flush-path liveness probe against a real, synthetic hit counter."
+
+    def handle(self, *args, **options) -> None:
+        from django_waf.services.flush_probe import run_flush_probe
+
+        try:
+            result = run_flush_probe()
+        except Exception as exc:
+            raise CommandError(f"Flush probe failed to run: {exc}") from exc
+
+        self.stdout.write(
+            f"  flushed={result['flushed']} keys_seen={result['keys_seen']} errors={result['errors']} "
+            f"hit_count_delta={result['hit_count_delta']} key_deleted={result['key_deleted']}"
+        )
+
+        if result["alive"]:
+            self.stdout.write(self.style.SUCCESS("Flush path alive."))
+            return
+
+        # Non-zero exit on a bad result, unlike most commands in this
+        # package: this command is meant to be wired into a cron wrapper
+        # or a k8s liveness/readiness probe that keys off exit status, so
+        # a broken flush path must fail the process, not just print a
+        # warning.
+        raise CommandError(f"Flush path DEAD: {result['failure_reason']}")

--- a/src/django_waf/management/commands/django_waf_prune_challenges.py
+++ b/src/django_waf/management/commands/django_waf_prune_challenges.py
@@ -27,6 +27,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options) -> None:
+        from datetime import timedelta
+
         from django.utils import timezone
 
         from django_waf.enums import ChallengeStatus
@@ -38,7 +40,7 @@ class Command(BaseCommand):
         if hours < 1:
             raise CommandError("--hours must be a positive integer.")
 
-        cutoff = timezone.now() - timezone.timedelta(hours=hours)
+        cutoff = timezone.now() - timedelta(hours=hours)
         purgeable_qs = ChallengeToken.objects.filter(
             status__in=[ChallengeStatus.PENDING, ChallengeStatus.FAILED],
             expires_at__lt=cutoff,

--- a/src/django_waf/models.py
+++ b/src/django_waf/models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import timedelta
 from decimal import Decimal
 
 from django.db import models
@@ -419,7 +420,7 @@ class RequestLogManager(models.Manager):
 
     def recent(self, hours: int = 24) -> models.QuerySet:
         """Return log entries from the last N hours."""
-        cutoff = timezone.now() - timezone.timedelta(hours=hours)
+        cutoff = timezone.now() - timedelta(hours=hours)
         return self.filter(timestamp__gte=cutoff)
 
     def for_ip(self, ip: str) -> models.QuerySet:
@@ -432,7 +433,7 @@ class RequestLogManager(models.Manager):
 
     def purgeable(self, days: int = 30) -> models.QuerySet:
         """Return log entries older than N days, suitable for deletion."""
-        cutoff = timezone.now() - timezone.timedelta(days=days)
+        cutoff = timezone.now() - timedelta(days=days)
         return self.filter(timestamp__lt=cutoff)
 
     def from_middleware(self) -> models.QuerySet:

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -1587,7 +1587,14 @@ def _deduplicate_block_rules(**lookup) -> int:
     qs = BlockRule.objects.filter(**lookup).order_by("-created_at")
     if qs.count() <= 1:
         return 0
-    keep_pk = qs.first().pk
+    # Fetch the row to keep once rather than re-querying with .first(): the
+    # count() check above is not atomic with what follows, so a concurrent
+    # delete could empty the queryset between the two calls. Guard against
+    # that directly instead of assuming .first() still returns a row.
+    newest = qs.first()
+    if newest is None:
+        return 0
+    keep_pk = newest.pk
     deleted, _ = qs.exclude(pk=keep_pk).delete()
     logger.info("django-waf: deleted %d duplicate BlockRule rows for %s", deleted, lookup)
     return deleted

--- a/src/django_waf/services/challenge_service.py
+++ b/src/django_waf/services/challenge_service.py
@@ -14,9 +14,21 @@ import json
 import logging
 import secrets
 import time
+from datetime import timedelta
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.utils import timezone
+
+if TYPE_CHECKING:
+    # Import for annotations only: the runtime import of ChallengeToken is
+    # deferred inside each function body (see issue_challenge and
+    # verify_challenge_solution below) to avoid importing django_waf.models
+    # before Django app registry setup. A TYPE_CHECKING-guarded import lets
+    # mypy resolve the return type without reintroducing that ordering
+    # requirement at runtime; `from __future__ import annotations` above
+    # means the annotation itself is never evaluated eagerly either.
+    from django_waf.models import ChallengeToken
 
 logger = logging.getLogger("django_waf.challenge_service")
 
@@ -113,7 +125,7 @@ def _digest_has_leading_zero_bits(digest: bytes, bits: int) -> bool:
     return (digest[full_bytes] & mask) == 0
 
 
-def issue_challenge(ip_address: str, redis_client, *, user_agent: str = "") -> object:
+def issue_challenge(ip_address: str, redis_client, *, user_agent: str = "") -> ChallengeToken:
     """Create a new challenge token for the given IP address.
 
     Stores the token in both the DB and Redis. Emits challenge_issued signal.
@@ -133,7 +145,7 @@ def issue_challenge(ip_address: str, redis_client, *, user_agent: str = "") -> o
     token = secrets.token_hex(64)
     difficulty = _pick_difficulty(user_agent)
     ttl = conf.DJANGO_WAF_CHALLENGE_COOKIE_TTL
-    expires_at = timezone.now() + timezone.timedelta(seconds=ttl)
+    expires_at = timezone.now() + timedelta(seconds=ttl)
 
     challenge_token = ChallengeToken.objects.create(
         token=token,
@@ -236,6 +248,17 @@ def verify_challenge_solution(
         raise ChallengeMismatchError(f"Challenge was issued to {stored_ip}, not {ip_address}.")
 
     # --- Proof-of-work verification (BR-CHAL-002, BR-CHAL-003) ---
+    # difficulty is always set by one of the two lookup branches above: the
+    # Redis branch on a successful JSON parse, or the DB branch from the
+    # model's PositiveSmallIntegerField (which has a default and is never
+    # null), which itself raises ChallengeInvalidError before reaching here
+    # if the token does not exist. A None here would mean neither branch
+    # ran, which is a genuine bug in the lookup logic above rather than a
+    # legitimate runtime state, so it fails loudly instead of silently
+    # defaulting to a difficulty value that was never actually issued.
+    if difficulty is None:
+        raise ChallengeInvalidError("Challenge token has no associated difficulty.")
+
     digest = hashlib.sha256(f"{token}{nonce}".encode()).digest()
     if not _digest_has_leading_zero_bits(digest, difficulty):
         # Solution incorrect

--- a/src/django_waf/services/flush_probe.py
+++ b/src/django_waf/services/flush_probe.py
@@ -1,0 +1,392 @@
+"""
+Flush-path liveness probe for django-waf (#100).
+
+Proves that a hit recorded against Redis by the real producer
+(``rule_engine._record_rule_hit``) actually reaches the ``BlockRule`` row
+via the real consumer (``tasks.flush_rule_hit_counts``), end to end,
+against the real Redis client and the real database.
+
+The defect this exists to catch: ``flush_rule_hit_counts`` used to call
+Redis ``GETDEL``, which requires Redis 6.2+. Production ran 6.0.16, so
+every call raised inside a bare ``except Exception: continue``, and
+40,936 scheduled task runs reported success while flushing nothing. It
+passed tests, review and release; only reading production found it.
+
+The trap that makes this class of defect invisible without a probe: on a
+quiet site the healthy result is ``{"flushed": 0, "keys_seen": 0,
+"errors": 0}``, which is IDENTICAL to the Redis-down result and IDENTICAL
+to what the getdel bug produced. Zero against unknown real traffic is
+ambiguous. Zero against a counter this probe just wrote itself is
+unambiguously a defect, which is why this module drives a real counter
+through the real producer and consumer rather than inspecting the flush
+task's return value in isolation.
+
+No environment guard of any kind gates this module, mirroring
+``detector_probe.py``'s own note: #97's staging skip was exactly that
+class of defect, a probe that quietly does nothing in some environments
+is the next one.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django.db import transaction
+
+logger = logging.getLogger("django_waf.flush_probe")
+
+# A TEST-NET address (RFC 5737), distinct from every octet range
+# detector_probe.py uses (192.0.2.10/50/90, 198.51.100.10-15,
+# 203.0.113.10/20-40), so a leftover row from either probe can never
+# collide with, or be mistaken for, the other's. Real production traffic
+# is never sourced from this range, so a match here can only be this
+# probe's own prior run, and the forced rollback below means no prior run
+# can ever leave one behind to match against in the first place.
+_PROBE_PATTERN = "203.0.113.77"
+
+_REDIS_HIT_PREFIX = "waf:rule_hits:"
+
+# The producer's own TTL (rule_engine._record_rule_hit): kept as a local
+# constant purely to restore it on a reconciled real key below, matching
+# what the producer itself would have set. Not shared with the producer
+# via import: this is a probe-side implementation detail of the
+# reconciliation, not a claim about the producer's contract.
+_HIT_COUNTER_TTL_SECONDS = 86400 * 2
+
+
+def run_flush_probe() -> dict:
+    """Drive one hit through the real producer and the real consumer and
+    prove it reached the database.
+
+    Sequence, all inside a single ``transaction.atomic()`` that is
+    unconditionally rolled back before returning (see the ``finally``
+    below):
+
+    1. Create a real, synthetic ``BlockRule`` row. The flush task does
+       ``BlockRule.objects.filter(id=rule_id).update(...)``, which only
+       increments ``flushed`` when a row actually matches; without a real
+       row to own the counter, the probe would report ``flushed=0`` for
+       the mundane reason "no such rule", indistinguishable from the
+       defect it exists to catch.
+    2. Write the Redis counter by calling the REAL producer,
+       ``django_waf.services.rule_engine._record_rule_hit``, never a
+       hand-written ``SET``/``INCR``. This is load-bearing: the key
+       literal ``"waf:rule_hits:"`` is duplicated with no shared constant
+       between the producer (``rule_engine.py``) and the consumer
+       (``tasks.py``). A probe that hardcoded a third copy of that prefix
+       would not catch the two drifting apart; driving the real producer
+       does.
+    3. Run the REAL ``django_waf.tasks.flush_rule_hit_counts``. Never
+       patched, stubbed, or reimplemented.
+    4. Re-read the probe's own ``BlockRule`` row (still inside the atomic
+       block, before the rollback fires) and confirm ``hit_count``
+       advanced by exactly what was written, and ``last_hit_at`` was set.
+    5. Confirm the probe's own Redis key is gone.
+
+    Concurrency and isolation hazard, and why this differs from
+    ``detector_probe.run_detector_probe``:
+
+    ``transaction.set_rollback(True)`` discards the DB work (the
+    synthetic ``BlockRule`` and the ``F()`` update the flush applied to
+    it), but a Redis key is NOT transactional and does not roll back with
+    it. Two consequences follow, handled separately:
+
+    - The probe's OWN key must be explicitly deleted in the ``finally``,
+      so a run that raises before the flush completes cannot leave it
+      behind. ``_record_rule_hit``'s own 2-day TTL is the backstop if even
+      that explicit cleanup somehow fails.
+
+    - ``flush_rule_hit_counts`` does not take a scope argument: it scans
+      ``waf:rule_hits:*`` unconditionally and flushes EVERY key it finds,
+      not just this probe's. On a live site with real traffic, the real
+      flush this probe triggers will therefore also sweep up real rule
+      counters as a side effect. Those real ``BlockRule.hit_count``
+      updates happen to land inside THIS probe's transaction, so without
+      correction they would be rolled back and lost, while the Redis
+      counters that fed them are deleted regardless (Redis deletion is
+      never transactional), which would silently discard real hit counts
+      on every probe run. This is a genuine hazard, not a hypothetical,
+      given the task has no way to scope itself to synthetic keys only.
+
+      The fix: before writing anything, snapshot every OTHER real
+      ``waf:rule_hits:*`` key's value (this is a plain ``GET``, so it
+      cannot itself race the flush's own read/delete in a way that loses
+      data; at worst a concurrent ``INCR`` between this read and the
+      flush's own read is under-counted by this reconciliation by exactly
+      the same margin the flush's own non-atomic GET+DELETE pipeline
+      already accepts, per BR-EVAL-007). After the real flush has run and
+      the transaction has rolled back, re-write each snapshotted Redis
+      key with its original value and the producer's own TTL, so the
+      count is once again pending for the next real flush.
+
+      The reconciliation restores the REDIS KEY ONLY, never the database
+      row. The rollback already returned every real row to where it
+      started, so the count is still owed, and putting it back in Redis
+      hands it to the next scheduled flush, which is the system's own
+      normal path for an unflushed counter. Restoring both would
+      double-count; ``_reconcile_other_keys`` records the measurement
+      behind that. This reconciliation runs unconditionally in the
+      ``finally``, whether the probe itself reports ``alive`` or not, so
+      a failing probe cannot leave real counters lost either.
+
+      Residual risk: a real hit that lands on a given key strictly
+      between this probe's snapshot read and the real flush's own
+      read/delete of that same key is not captured by the snapshot and is
+      lost when the flush deletes the key, exactly as it would be lost by
+      two real concurrent flush runs today (the flush's own GET+DELETE
+      pipeline is explicitly documented as non-atomic against a
+      concurrent ``INCR``). This probe does not widen that existing race;
+      it neither adds an increment of exposure beyond what the flush
+      already accepts, nor closes it. It is stated here rather than
+      papered over.
+
+    Must not corrupt real ``hit_count`` values (issue #100's own
+    constraint): the probe's synthetic row lives entirely inside the
+    rolled-back transaction and is never committed, and the reconciliation
+    above puts every real row back to the value it would have reached had
+    the probe not run at all.
+
+    Returns:
+        Dict with keys:
+            - ``alive`` (bool): the overall verdict. True only when the
+              counter this probe itself wrote demonstrably reached the
+              database with the correct delta and the correct
+              ``last_hit_at``, and the Redis key was cleared.
+            - ``flushed``, ``keys_seen``, ``errors``: echoed verbatim from
+              the real ``flush_rule_hit_counts`` result.
+            - ``hit_count_delta`` (int): what actually landed on the
+              probe's own ``BlockRule.hit_count``, 0 if the flush never
+              applied it.
+            - ``key_deleted`` (bool): whether the probe's own Redis key
+              was gone after the flush ran.
+            - ``failure_reason`` (str | None): ``None`` when ``alive`` is
+              True; otherwise a specific, human-readable reason naming the
+              step that failed, since this is what an operator reads at
+              3am.
+    """
+    from django_waf.models import BlockRule
+    from django_waf.services.rule_engine import _record_rule_hit
+    from django_waf.tasks import flush_rule_hit_counts
+
+    try:
+        from django_redis import get_redis_connection
+
+        from django_waf import conf
+
+        redis_client = get_redis_connection(conf.DJANGO_WAF_REDIS_ALIAS)
+    except Exception as exc:
+        logger.warning("django-waf: flush probe could not obtain a Redis connection: %s", exc)
+        return _failure_result(f"could not obtain a Redis connection: {exc}")
+
+    probe_key = None
+    other_keys_snapshot: dict[str, bytes] = {}
+    hit_count_delta = 0
+    key_deleted = False
+    flush_result: dict = {}
+
+    try:
+        with transaction.atomic():
+            try:
+                rule = BlockRule.objects.create(
+                    name="django-waf flush probe (synthetic, rolled back)",
+                    rule_type="ip",
+                    match_type="exact",
+                    pattern=_PROBE_PATTERN,
+                    action="log_only",
+                    is_active=False,
+                    source="admin",
+                    hit_count=0,
+                )
+                probe_key = f"{_REDIS_HIT_PREFIX}{rule.id}"
+
+                # Snapshot every OTHER real hit-count key before this probe
+                # writes its own or triggers the real flush, so the
+                # reconciliation in `finally` can restore them afterwards.
+                # See the "Concurrency and isolation hazard" section of
+                # this function's docstring for why this is necessary.
+                other_keys_snapshot = _snapshot_other_keys(redis_client, exclude_key=probe_key)
+
+                _record_rule_hit(str(rule.id), redis_client)
+
+                flush_result = flush_rule_hit_counts()
+
+                rule.refresh_from_db()
+                hit_count_delta = rule.hit_count
+                key_deleted = _key_is_absent(redis_client, probe_key)
+            finally:
+                # Unconditional: even if a step above raises, no synthetic
+                # BlockRule row may survive this function. The Redis-side
+                # cleanup and reconciliation happen in the outer finally,
+                # after this rollback has fired, since Redis writes are not
+                # covered by it.
+                transaction.set_rollback(True)
+    finally:
+        _cleanup_probe_key(redis_client, probe_key)
+        _reconcile_other_keys(redis_client, other_keys_snapshot)
+
+    flushed = flush_result.get("flushed", 0)
+    keys_seen = flush_result.get("keys_seen", 0)
+    errors = flush_result.get("errors", 0)
+
+    failure_reason = None
+    if hit_count_delta != 1:
+        failure_reason = (
+            f"expected the probe's BlockRule.hit_count to advance by 1, advanced by "
+            f"{hit_count_delta}: the flush ran (flushed={flushed}, keys_seen={keys_seen}, "
+            f"errors={errors}) but did not apply the counter this probe wrote"
+        )
+    elif not key_deleted:
+        failure_reason = "the probe's Redis hit-count key was still present after the flush ran"
+
+    alive = failure_reason is None
+
+    if alive:
+        logger.info(
+            "django-waf: flush probe alive, hit_count_delta=%d flushed=%d keys_seen=%d errors=%d",
+            hit_count_delta,
+            flushed,
+            keys_seen,
+            errors,
+        )
+    else:
+        logger.warning("django-waf: flush probe FAILED: %s", failure_reason)
+
+    return {
+        "alive": alive,
+        "flushed": flushed,
+        "keys_seen": keys_seen,
+        "errors": errors,
+        "hit_count_delta": hit_count_delta,
+        "key_deleted": key_deleted,
+        "failure_reason": failure_reason,
+    }
+
+
+def _key_is_absent(redis_client, key: str) -> bool:
+    """Whether ``key`` is gone, tolerating a Redis-side read failure here
+    (a broken client at this final check is reported as "key not deleted",
+    a correct and specific failure_reason for run_flush_probe to surface)
+    rather than letting an unhandled exception escape past the rollback
+    and cleanup this function's caller still needs to run."""
+    try:
+        return redis_client.get(key) is None
+    except Exception:
+        logger.warning("django-waf: flush probe could not confirm its own Redis key was cleared", exc_info=True)
+        return False
+
+
+def _failure_result(failure_reason: str) -> dict:
+    return {
+        "alive": False,
+        "flushed": 0,
+        "keys_seen": 0,
+        "errors": 0,
+        "hit_count_delta": 0,
+        "key_deleted": False,
+        "failure_reason": failure_reason,
+    }
+
+
+def _snapshot_other_keys(redis_client, *, exclude_key: str) -> dict[str, bytes]:
+    """Read (never delete) every real ``waf:rule_hits:*`` key's current
+    value, excluding the probe's own key, so it can be restored after the
+    real flush sweeps it up as a side effect. Failure to snapshot is
+    treated as "no other keys": logged at WARNING and the probe proceeds,
+    since refusing to run the liveness check over an unrelated listing
+    failure would defeat the point of a liveness probe.
+    """
+    try:
+        keys = redis_client.keys(f"{_REDIS_HIT_PREFIX}*")
+    except Exception:
+        logger.warning(
+            "django-waf: flush probe could not snapshot existing hit-count keys before running; "
+            "proceeding, any real keys present will not be reconciled",
+            exc_info=True,
+        )
+        return {}
+
+    snapshot: dict[str, bytes] = {}
+    for key in keys:
+        key_str = key.decode() if isinstance(key, bytes) else key
+        if key_str == exclude_key:
+            continue
+        try:
+            value = redis_client.get(key_str)
+        except Exception:
+            logger.warning(
+                "django-waf: flush probe could not snapshot hit-count key %s before running",
+                key_str,
+                exc_info=True,
+            )
+            continue
+        if value is not None:
+            snapshot[key_str] = value
+    return snapshot
+
+
+def _cleanup_probe_key(redis_client, probe_key: str | None) -> None:
+    if probe_key is None:
+        return
+    try:
+        redis_client.delete(probe_key)
+    except Exception:
+        # _record_rule_hit's own 2-day TTL is the backstop here: even if
+        # this explicit cleanup fails, the key cannot accumulate forever.
+        logger.warning("django-waf: flush probe could not clean up its own Redis key %s", probe_key, exc_info=True)
+
+
+def _reconcile_other_keys(redis_client, snapshot: dict[str, bytes]) -> None:
+    """Restore every real hit-count key the probe's own flush run swept up,
+    by re-writing the Redis key with its snapshotted value and the
+    producer's own TTL. Runs unconditionally, whether the probe reports
+    alive or not, so a failing probe cannot leave real counters lost.
+
+    Restoring the REDIS KEY ONLY is deliberate, and restoring the DB row
+    as well would be a defect. The real flush this probe triggers applied
+    each real count to its BlockRule inside the probe's own transaction,
+    which is then rolled back, so the DB row is left exactly where it
+    started and the count is still owed. Putting the count back in Redis
+    leaves it pending for the next real flush (5 minutes away on the
+    default beat), which is the system's own normal path for a counter
+    that has not been flushed yet.
+
+    An earlier revision of this function restored BOTH: it re-applied the
+    count to the row with an F() update AND re-wrote the Redis key. That
+    double-counts every real counter present whenever the probe runs, once
+    from the reconciliation and once more when the next real flush reads
+    the key it just restored. Verified before this was corrected: a real
+    counter of 5 reached hit_count=10 after one probe run followed by one
+    scheduled flush. A liveness probe that corrupts the numbers it exists
+    to protect is worse than no probe, and issue #100 names not corrupting
+    real hit_count values as an explicit constraint.
+    """
+    if not snapshot:
+        return
+
+    for key_str, raw_value in snapshot.items():
+        rule_id = key_str[len(_REDIS_HIT_PREFIX) :]
+        try:
+            count = int(raw_value)
+        except (TypeError, ValueError):
+            logger.error(
+                "django-waf: flush probe could not parse snapshotted hit count for rule %s "
+                "(value=%r), real hit count for this rule may now be understated",
+                rule_id,
+                raw_value,
+                exc_info=True,
+            )
+            continue
+        if count <= 0:
+            continue
+
+        try:
+            redis_client.set(key_str, count, ex=_HIT_COUNTER_TTL_SECONDS)
+        except Exception:
+            logger.error(
+                "django-waf: flush probe could not restore real hit-count key %s (count=%d) "
+                "after its own run swept it up; this rule's hit count is understated by %d",
+                key_str,
+                count,
+                count,
+                exc_info=True,
+            )

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -781,14 +781,25 @@ def _resolve_and_confirm_rdns(ip_address: str, rdns_pattern: str) -> bool:
 
 
 def _action_to_verdict(action: str) -> str:
-    """Map a RuleAction value to the corresponding Verdict value."""
+    """Map a RuleAction value to the corresponding Verdict value.
+
+    ``action`` is typed as ``str`` rather than ``RuleAction`` because callers
+    genuinely pass a plain string here: the value comes from a cached rule
+    dict built from serialised data (see ``_check_block_rules``), not a live
+    model instance, and an unrecognised value is a legitimate input this
+    function must handle by falling back to ``Verdict.BLOCKED`` rather than
+    raising (proven by test_action_to_verdict_unknown_defaults_to_blocked).
+    The mapping itself is keyed by ``RuleAction`` value, so the lookup is
+    done against ``.value`` strings rather than widening the dict to accept
+    arbitrary strings as valid ``RuleAction`` keys.
+    """
     from django_waf.enums import RuleAction, Verdict
 
     mapping = {
-        RuleAction.BLOCK: Verdict.BLOCKED,
-        RuleAction.CHALLENGE: Verdict.CHALLENGED,
-        RuleAction.THROTTLE: Verdict.THROTTLED,
-        RuleAction.LOG_ONLY: Verdict.LOGGED,
+        RuleAction.BLOCK.value: Verdict.BLOCKED,
+        RuleAction.CHALLENGE.value: Verdict.CHALLENGED,
+        RuleAction.THROTTLE.value: Verdict.THROTTLED,
+        RuleAction.LOG_ONLY.value: Verdict.LOGGED,
     }
     return mapping.get(action, Verdict.BLOCKED)
 

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -756,6 +756,68 @@ def flush_rule_hit_counts(self) -> dict:
     return {"flushed": flushed, "keys_seen": keys_seen, "errors": errors}
 
 
+@shared_task
+def probe_flush_path() -> dict:
+    """Run the flush-path liveness probe (#100) and report the result.
+
+    Delegates to ``services.flush_probe.run_flush_probe``, which drives a
+    real counter through the real producer
+    (``rule_engine._record_rule_hit``) and the real consumer
+    (``flush_rule_hit_counts`` above), then asserts the counter
+    demonstrably reached the database. This exists because
+    ``flush_rule_hit_counts`` used to call Redis ``GETDEL`` (needs Redis
+    6.2+); production ran 6.0.16, every call raised, a bare except
+    swallowed it, and 40,936 scheduled task runs reported success while
+    flushing nothing. ``{"flushed": 0, "keys_seen": 0, "errors": 0}`` is
+    both the healthy result on a quiet site AND what that defect produced,
+    so real traffic cannot distinguish them; a counter this probe writes
+    itself can.
+
+    Mirrors ``probe_detectors``'s own freshness note: this package stays
+    stateless and does not persist a last-run timestamp, so a consumer
+    wiring alerting to this probe must alert on the ABSENCE of the
+    structured log line ``run_flush_probe`` emits within the expected
+    cadence, not only on its WARNING content.
+
+    This task never raises: like ``probe_detectors``, its entire purpose
+    is unattended liveness reporting, so a task that itself crashes
+    defeats the reason it exists. Any exception is logged at ERROR with
+    the traceback and reported as a failure result rather than propagated.
+
+    Returns:
+        On success, the dict ``run_flush_probe`` returns: ``alive``,
+        ``flushed``, ``keys_seen``, ``errors``, ``hit_count_delta``,
+        ``key_deleted``, ``failure_reason``. On failure, the same shape
+        with ``alive=False`` and ``failure_reason`` naming that the task
+        itself raised: a probe that could not run proves liveness for
+        nothing.
+
+    Scheduled: hourly, matching the detector probe's own cadence
+    (BR-ANOM-012 precedent). The flush task itself runs every 5 minutes,
+    so an hourly probe gives ample margin to catch sustained breakage
+    well inside a single day, without adding alert noise on the same
+    schedule as the thing it is checking.
+    """
+    from django_waf.services.flush_probe import run_flush_probe
+
+    try:
+        # run_flush_probe itself logs the alive INFO line or the failure
+        # WARNING line; this task does not re-log the same outcome,
+        # mirroring probe_detectors's thin delegation above.
+        return run_flush_probe()
+    except Exception as exc:
+        logger.exception("django-waf: probe_flush_path failed to run")
+        return {
+            "alive": False,
+            "flushed": 0,
+            "keys_seen": 0,
+            "errors": 0,
+            "hit_count_delta": 0,
+            "key_deleted": False,
+            "failure_reason": f"probe_flush_path raised: {exc}",
+        }
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------

--- a/src/django_waf/testing/factories.py
+++ b/src/django_waf/testing/factories.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import timedelta
 from decimal import Decimal
 
 import factory
@@ -133,7 +134,7 @@ class ChallengeTokenFactory(factory.django.DjangoModelFactory):
     difficulty = 4
     nonce = ""
     status = ChallengeStatus.PENDING
-    expires_at = factory.LazyFunction(lambda: timezone.now() + timezone.timedelta(hours=24))
+    expires_at = factory.LazyFunction(lambda: timezone.now() + timedelta(hours=24))
     # challenge_service.verify_challenge_solution() unconditionally sets
     # solved_at on the solve path (BR-CHAL, see challenge_service.py), so a
     # production-shaped SOLVED token always carries a timestamp. EXPIRED and

--- a/src/django_waf/testing/fixtures.py
+++ b/src/django_waf/testing/fixtures.py
@@ -11,7 +11,7 @@ non-Redis fixtures.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
@@ -103,7 +103,14 @@ def block_rule(db) -> BlockRule:
     """Create and return a default BlockRule instance via BlockRuleFactory."""
     from django_waf.testing.factories import BlockRuleFactory
 
-    return BlockRuleFactory()
+    # factory-boy's FactoryMetaClass.__call__ (factory/base.py) carries no
+    # return annotation, so mypy falls back to treating BlockRuleFactory()
+    # as constructing a BlockRuleFactory instance, the factory class itself,
+    # rather than the Django model instance ``factory.create()`` actually
+    # returns at runtime. cast() states what is genuinely returned rather
+    # than widening this fixture's own signature to something looser than
+    # what every caller of it actually receives.
+    return cast("BlockRule", BlockRuleFactory())
 
 
 @pytest.fixture
@@ -111,7 +118,7 @@ def allow_rule(db) -> AllowRule:
     """Create and return a default AllowRule instance via AllowRuleFactory."""
     from django_waf.testing.factories import AllowRuleFactory
 
-    return AllowRuleFactory()
+    return cast("AllowRule", AllowRuleFactory())
 
 
 @pytest.fixture
@@ -119,4 +126,4 @@ def challenge_token(db) -> ChallengeToken:
     """Create and return a default ChallengeToken instance via ChallengeTokenFactory."""
     from django_waf.testing.factories import ChallengeTokenFactory
 
-    return ChallengeTokenFactory()
+    return cast("ChallengeToken", ChallengeTokenFactory())

--- a/src/django_waf/testing/helpers.py
+++ b/src/django_waf/testing/helpers.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from django.http import HttpResponse
+    from django.http import HttpResponseBase
     from django.test import Client
 
 
-def create_blocked_request(client: Client, path: str = "/", ip: str = "192.0.2.99") -> HttpResponse:
+def create_blocked_request(client: Client, path: str = "/", ip: str = "192.0.2.99") -> HttpResponseBase:
     """Create a block rule for ``ip`` and issue a GET request from it.
 
     Args:
@@ -40,7 +40,7 @@ def create_blocked_request(client: Client, path: str = "/", ip: str = "192.0.2.9
     return client.get(path, REMOTE_ADDR=ip)
 
 
-def create_challenged_request(client: Client, path: str = "/", ua: str = "python-requests/2.28") -> HttpResponse:
+def create_challenged_request(client: Client, path: str = "/", ua: str = "python-requests/2.28") -> HttpResponseBase:
     """Create a challenge-action rule for ``ua`` and issue a GET request with it.
 
     Args:

--- a/src/django_waf/urls.py
+++ b/src/django_waf/urls.py
@@ -23,13 +23,16 @@ keeping djangorestframework an optional dependency (the [api] extra).
 
 import logging
 
-from django.urls import include, path
+from django.urls import URLPattern, URLResolver, include, path
 
 from django_waf import conf, views
 
 app_name = "django_waf"
 
-urlpatterns = [
+# Annotated explicitly rather than left to inference: the base list is all
+# path() calls (URLPattern), but the optional API block below appends an
+# include() result (URLResolver), so the list genuinely holds both types.
+urlpatterns: list[URLPattern | URLResolver] = [
     # -----------------------------------------------------------------------
     # Challenge flow — AllowAny
     # -----------------------------------------------------------------------

--- a/src/django_waf/views.py
+++ b/src/django_waf/views.py
@@ -381,17 +381,17 @@ class SitePasswordVerifyView(NoIndexResponseMixin, View):
                 require_https=request.is_secure(),
             ):
                 safe_next = next_param
-            response = redirect(safe_next)
-            sp.set_verified_cookie(response, request)
-            return response
+            redirect_response = redirect(safe_next)
+            sp.set_verified_cookie(redirect_response, request)
+            return redirect_response
 
         ip = _get_ip(request)
         redis_client = _get_redis_client()
         throttled = sp.record_guess_throttle_hit(ip, redis_client)
         if throttled:
-            response = HttpResponse(_("Too many attempts. Please retry later."), status=429)
-            response["Retry-After"] = "60"
-            return response
+            throttle_response = HttpResponse(_("Too many attempts. Please retry later."), status=429)
+            throttle_response["Retry-After"] = "60"
+            return throttle_response
 
         return render(
             request,

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -64,6 +64,7 @@ class TestCeleryBeatScheduleDefault:
             "django_waf.tasks.report_threat_telemetry",
             "django_waf.tasks.update_geoip_database",
             "django_waf.tasks.probe_detectors",
+            "django_waf.tasks.probe_flush_path",
         }
         actual_tasks = {entry["task"] for entry in conf_mod.DJANGO_WAF_CELERY_BEAT_SCHEDULE.values()}
         assert actual_tasks == expected_tasks

--- a/tests/test_flush_probe.py
+++ b/tests/test_flush_probe.py
@@ -1,0 +1,322 @@
+"""Tests for the flush-path liveness probe (#100).
+
+Covers ``services.flush_probe.run_flush_probe`` and the
+``django_waf_probe_flush_path`` management command.
+
+House discipline, mirroring ``tests/test_detector_probe.py``: the crux
+test in this file is the one that proves the probe has teeth, not merely
+that it runs. A probe that patches itself, or that only asserts a
+hand-written zero is reported as zero, proves nothing about whether it
+would have caught the real production defect. The real defect (#78) was
+Redis ``GETDEL`` raising on a pre-6.2 server inside a bare
+``except Exception: continue``, so ``flush_rule_hit_counts`` returned a
+success-shaped ``{"flushed": 0, ...}`` while doing nothing. The current
+implementation no longer calls ``GETDEL`` (it uses a GET+DELETE pipeline
+instead, see ``tests/test_flush_rule_hit_counts_redis_integration.py``),
+so that exact call can no longer be reproduced against fakeredis or a
+Redis 6.0 server: it would simply succeed. What is reproduced here
+instead is the SHAPE of the defect that made it invisible: the read that
+feeds the flush raising inside the same ``except Exception: continue``
+the old ``GETDEL`` call raised inside, so the flush again returns
+success-shaped output while applying nothing. This is the closest
+faithful reproduction available against the current (fixed) source: the
+teeth test below runs the REAL ``run_flush_probe``, the REAL
+``_record_rule_hit`` producer, and the REAL ``flush_rule_hit_counts``
+consumer end to end, with only the pipeline's ``execute()`` call broken
+to fail the way a rejected Redis command fails, and asserts the probe
+goes RED with a ``failure_reason`` naming the real problem (the counter
+never reaching the row), not merely that some assertion fails somewhere.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from django_waf.models import BlockRule
+from django_waf.testing.fixtures import waf_redis_mock  # noqa: F401 (used as a pytest fixture)
+
+from .test_flush_rule_hit_counts import mock_redis_connection
+
+
+@pytest.mark.django_db
+class TestRunFlushProbeFalsifiability:
+    def test_probe_reports_alive_against_the_real_producer_and_consumer(self, waf_redis_mock):
+        """Baseline green: unmocked, the probe reports alive with a
+        positive hit_count_delta. Layer under test: the full real path,
+        _record_rule_hit and flush_rule_hit_counts both execute for real
+        against the real fakeredis client and the real database.
+        """
+        from django_waf.services.flush_probe import run_flush_probe
+
+        with mock_redis_connection(waf_redis_mock):
+            result = run_flush_probe()
+
+        assert result["alive"] is True
+        assert result["hit_count_delta"] == 1
+        assert result["key_deleted"] is True
+        assert result["flushed"] >= 1
+        assert result["failure_reason"] is None
+
+    def test_probe_goes_red_when_the_flush_silently_no_ops(self, waf_redis_mock, monkeypatch):
+        """Teeth: reproduce the historical defect's SHAPE against the real
+        (fixed) flush path and assert the probe fails for the right reason.
+
+        The original #78 defect was ``GETDEL`` raising on a pre-6.2 Redis
+        server inside ``flush_rule_hit_counts``'s per-key
+        ``try/except Exception: continue``, so the task returned
+        ``{"flushed": 0, "keys_seen": N, "errors": N}`` while the counter
+        stayed in Redis, never applied to the row. The current
+        implementation replaced the single GETDEL with a pipelined
+        GET+DELETE, so that literal call can no longer be reproduced
+        against fakeredis (which accepts GETDEL unconditionally regardless
+        of version, per waf_redis_mock's own docstring, and the current
+        code does not call it anyway). What is reproduced here is the same
+        failure shape one level down: the pipeline's own ``execute()``
+        raising, exactly as a rejected Redis command would raise, landing
+        in the SAME ``except Exception: continue`` the old GETDEL call
+        raised inside. This is not a stub of run_flush_probe or of
+        flush_rule_hit_counts: both run for real, with only the Redis
+        client's pipeline execute() call broken.
+        """
+        from django_waf.services.flush_probe import run_flush_probe
+
+        class _RaisingPipeline:
+            def __init__(self, real_pipeline):
+                self._real_pipeline = real_pipeline
+
+            def get(self, key):
+                self._real_pipeline.get(key)
+                return self
+
+            def delete(self, key):
+                self._real_pipeline.delete(key)
+                return self
+
+            def execute(self):
+                # Reproduces the historical failure shape: the read that
+                # feeds the flush raises, exactly as a real pre-6.2 server
+                # raised on GETDEL, landing in flush_rule_hit_counts's own
+                # `except Exception: continue` around this same call.
+                raise Exception("ERR unknown command 'GETDEL', reproduced for #100 teeth test")
+
+        class _BrokenPipelineClient:
+            """Wraps the real fakeredis client so every command except
+            pipeline() passes straight through unmodified (keys(), get(),
+            incr(), expire(), delete() all still work for real), and only
+            the pipelined GET+DELETE the flush relies on is broken. A
+            MagicMock standing in for the whole client would not exercise
+            the real keys()/incr()/expire() calls _record_rule_hit and the
+            flush both depend on before reaching the broken step.
+            """
+
+            def __init__(self, real_client):
+                self._real_client = real_client
+
+            def pipeline(self):
+                return _RaisingPipeline(self._real_client.pipeline())
+
+            def __getattr__(self, name):
+                return getattr(self._real_client, name)
+
+        broken_client = _BrokenPipelineClient(waf_redis_mock)
+
+        blockrule_count_before = BlockRule.objects.count()
+
+        with mock_redis_connection(broken_client):
+            result = run_flush_probe()
+
+        assert result["alive"] is False
+        assert result["hit_count_delta"] == 0
+        assert result["failure_reason"] is not None
+        assert "hit_count" in result["failure_reason"]
+        # The flush's own per-key error counter must reflect the broken
+        # read, not report a clean success-shaped zero: this is exactly
+        # the distinction the original bug erased.
+        assert result["errors"] >= 1
+
+        # No synthetic BlockRule survives a failed run either: the
+        # rollback covers this regardless of the probe's own verdict.
+        assert BlockRule.objects.count() == blockrule_count_before
+
+    def test_probe_cleans_up_its_own_key_and_row_on_success(self, waf_redis_mock):
+        from django_waf.services.flush_probe import run_flush_probe
+
+        blockrule_count_before = BlockRule.objects.count()
+
+        with mock_redis_connection(waf_redis_mock):
+            run_flush_probe()
+
+        assert BlockRule.objects.count() == blockrule_count_before
+        assert waf_redis_mock.keys("waf:rule_hits:*") == []
+
+    def test_probe_cleans_up_on_the_failure_path_too(self, waf_redis_mock):
+        from django_waf.services.flush_probe import run_flush_probe
+
+        class _AlwaysRaisingClient:
+            def __getattr__(self, name):
+                def _raise(*args, **kwargs):
+                    raise RuntimeError("redis unreachable")
+
+                return _raise
+
+        blockrule_count_before = BlockRule.objects.count()
+
+        with mock_redis_connection(_AlwaysRaisingClient()):
+            result = run_flush_probe()
+
+        assert result["alive"] is False
+        assert BlockRule.objects.count() == blockrule_count_before
+
+    def test_probe_does_not_corrupt_a_real_rule_s_hit_count(self, waf_redis_mock):
+        """The reconciliation hazard (docstring in flush_probe.py): the
+        real flush sweeps up every waf:rule_hits:* key it finds, not just
+        the probe's own, so a real counter present when the probe runs
+        must not be lost by the probe's rolled-back transaction.
+
+        The probe restores such a counter to Redis rather than to the
+        row, so immediately after a probe run the row is unchanged and
+        the count is still pending, which is exactly the state an
+        unflushed counter is normally in. Nothing is lost: the companion
+        test below runs the next flush and proves the count lands, once.
+        """
+        from django_waf.services.flush_probe import run_flush_probe
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.testing.factories import BlockRuleFactory
+
+        real_rule = BlockRuleFactory(hit_count=10)
+        for _ in range(3):
+            _record_rule_hit(str(real_rule.id), waf_redis_mock)
+
+        with mock_redis_connection(waf_redis_mock):
+            result = run_flush_probe()
+
+        assert result["alive"] is True
+
+        real_rule.refresh_from_db()
+        assert real_rule.hit_count == 10
+
+        # The count is not lost, it is pending: still in Redis, under the
+        # real producer's own key, for the next scheduled flush to apply.
+        assert waf_redis_mock.get(f"waf:rule_hits:{real_rule.id}") == b"3"
+
+    def test_probe_does_not_double_count_a_real_rule_on_the_next_flush(self, waf_redis_mock):
+        """Regression test. Asserting the hit count immediately after the
+        probe is not sufficient, and an earlier revision passed that check
+        while still corrupting the data.
+
+        The probe's reconciliation puts each real counter back into Redis
+        so the next scheduled flush can apply it. If it ALSO re-applied
+        the count to the BlockRule row, the count would land twice: once
+        from the reconciliation, once more when the next real flush reads
+        the key the reconciliation just restored. Measured against that
+        earlier revision, a real counter of 5 reached hit_count=10 after
+        one probe run followed by one flush.
+
+        So this test runs the next real flush too, which is what the
+        5-minute beat does in production, and asserts the total is still
+        5. The window between the probe and that flush is exactly where
+        the defect lived.
+        """
+        from django_waf.models import BlockRule
+        from django_waf.services.flush_probe import run_flush_probe
+        from django_waf.services.rule_engine import _record_rule_hit
+        from django_waf.tasks import flush_rule_hit_counts
+
+        real_rule = BlockRule.objects.create(
+            name="real rule",
+            rule_type="ip",
+            match_type="exact",
+            pattern="198.18.0.9",
+            action="block",
+            is_active=True,
+            source="admin",
+            hit_count=0,
+        )
+        for _ in range(5):
+            _record_rule_hit(str(real_rule.id), waf_redis_mock)
+
+        with mock_redis_connection(waf_redis_mock):
+            assert run_flush_probe()["alive"] is True
+
+            # The probe left the count pending in Redis, exactly where an
+            # unflushed counter normally sits. The next scheduled flush is
+            # what applies it, and it must apply it exactly once.
+            flush_rule_hit_counts()
+
+        real_rule.refresh_from_db()
+        assert real_rule.hit_count == 5
+
+    def test_probe_behaves_identically_regardless_of_debug(self, waf_redis_mock, settings):
+        """No environment guard of any kind: DEBUG on or off must not
+        change the probe's verdict or shape."""
+        from django_waf.services.flush_probe import run_flush_probe
+
+        settings.DEBUG = True
+        with mock_redis_connection(waf_redis_mock):
+            result_debug_on = run_flush_probe()
+
+        settings.DEBUG = False
+        with mock_redis_connection(waf_redis_mock):
+            result_debug_off = run_flush_probe()
+
+        assert result_debug_on["alive"] is True
+        assert result_debug_off["alive"] is True
+        assert set(result_debug_on) == set(result_debug_off)
+
+
+@pytest.mark.django_db
+class TestProbeFlushPathTask:
+    def test_task_returns_the_probe_result_on_success(self, waf_redis_mock):
+        from django_waf.tasks import probe_flush_path
+
+        with mock_redis_connection(waf_redis_mock):
+            result = probe_flush_path()
+
+        assert result["alive"] is True
+
+    def test_task_never_raises_and_reports_failure_shaped_output(self, monkeypatch):
+        """probe_flush_path imports run_flush_probe lazily inside its own
+        body (`from django_waf.services.flush_probe import
+        run_flush_probe`), so it must be patched on the module it is
+        imported FROM, not on `django_waf.tasks`, where no such name is
+        ever bound."""
+        from django_waf.services import flush_probe as flush_probe_module
+        from django_waf.tasks import probe_flush_path
+
+        def _boom() -> dict:
+            raise RuntimeError("kaboom")
+
+        monkeypatch.setattr(flush_probe_module, "run_flush_probe", _boom)
+
+        result = probe_flush_path()
+
+        assert result["alive"] is False
+        assert "probe_flush_path raised" in result["failure_reason"]
+
+
+@pytest.mark.django_db
+class TestProbeFlushPathCommand:
+    def test_command_exits_zero_when_alive(self, waf_redis_mock):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        with mock_redis_connection(waf_redis_mock):
+            call_command("django_waf_probe_flush_path", stdout=out)
+
+        assert "Flush path alive" in out.getvalue()
+
+    def test_command_raises_command_error_when_dead(self, waf_redis_mock):
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        class _AlwaysRaisingClient:
+            def __getattr__(self, name):
+                def _raise(*args, **kwargs):
+                    raise RuntimeError("redis unreachable")
+
+                return _raise
+
+        with mock_redis_connection(_AlwaysRaisingClient()), pytest.raises(CommandError):
+            call_command("django_waf_probe_flush_path")

--- a/tests/test_flush_rule_hit_counts_redis_integration.py
+++ b/tests/test_flush_rule_hit_counts_redis_integration.py
@@ -126,6 +126,29 @@ class TestFlushRuleHitCountsAgainstRealRedis:
         assert real_redis_client.get(f"waf:rule_hits:{rule.id}") is None
 
 
+@pytest.mark.django_db
+class TestFlushProbeAgainstRealRedis:
+    """The flush-path liveness probe (#100), against a real Redis 6.0
+    server: the exact server version whose GETDEL rejection caused the
+    original 40,936-run silent failure. Proves ``run_flush_probe`` reports
+    ``alive=True`` against the server the original defect actually failed
+    on, not merely against fakeredis (which, per this file's own module
+    docstring, accepts GETDEL unconditionally regardless of the requested
+    version and so cannot distinguish a working flush path from the
+    original bug).
+    """
+
+    def test_probe_reports_alive_against_a_real_redis_60_server(self, real_redis_client):
+        from django_waf.services.flush_probe import run_flush_probe
+
+        result = run_flush_probe()
+
+        assert result["alive"] is True
+        assert result["hit_count_delta"] == 1
+        assert result["key_deleted"] is True
+        assert result["failure_reason"] is None
+
+
 class TestRedisVersionCheckAgainstRealRedis:
     """get_redis_server_version (redis_client.py) reads via INFO, a command
     fakeredis does not implement at all (confirmed against the pinned


### PR DESCRIPTION
Three issues sharing one shape: a declared quality bar that nothing enforced.

Closes #111, closes #108, closes #100.

## #111, mypy is configured but no workflow runs it

**The issue's count did not reproduce.** It reports 35 errors across 21 files at `35c6c34`. Measured on `a1b376b` with mypy 2.3.1 and django-stubs 6.1.0: **31 across 19**. The difference is toolchain drift since filing, not a mistake in the issue. Both runs were confirmed real (84 source files analysed, not the exit-2 no-op).

One correction to the issue's method note: this repo needs `PYTHONPATH=.`, not `PYTHONPATH=tests`, because `django_settings_module = "tests.settings"` is a dotted path from the repo root.

Now zero errors across 86 source files. Two findings were genuine defects, not annotation noise:

- `_deduplicate_block_rules` called `.pk` on `qs.first()`, which is `None` if the queryset empties between the `count()` guard and the fetch. A live `AttributeError` under a concurrent delete.
- `verify_challenge_solution` passed a possibly-`None` difficulty into the proof-of-work check. It now raises `ChallengeInvalidError`; both lookup branches were confirmed to set difficulty or raise earlier, so this guards a bug state rather than a legitimate path.

Everything else is annotation-only. `ProtectedForm`'s new base is `TYPE_CHECKING`-guarded and the runtime MRO is unchanged, verified as `[ProtectedForm, object]`.

Third-party noise is suppressed per-module (`rest_framework.*`, `celery.*`, `django_redis.*`), not with a blanket `ignore_missing_imports` that would also hide real missing-import findings in our own code.

The new `typecheck` job pins mypy and django-stubs exactly, as `lint` already pins ruff, and **asserts mypy analysed 80+ files before trusting its exit status**. Without `PYTHONPATH=.` mypy exits 2 having checked nothing, which reads as a pass when scripted, so the gate had to be able to detect its own no-op.

## #108, no py.typed

Verified on the artefact, not the source tree:

| Wheel | `py.typed` | Consumer's mypy on `resolve_client_ip` |
|---|---|---|
| Published 2.4.0 | absent | `import-untyped` error, `Revealed type is "Any"` |
| Built from this branch | present | `Revealed type is "def (request: Any) -> str"`, clean |

## #100, no liveness probe for the Redis flush path

`run_flush_probe()` drives one hit end to end through the **real** producer (`_record_rule_hit`) and the **real** consumer (`flush_rule_hit_counts`), then asserts it reached `BlockRule.hit_count`. Its own service, task, hourly beat entry and `django_waf_probe_flush_path` command, rather than folded into the detector probe, so the two subsystems fail independently and each names itself in the alert.

Calling the real producer is load-bearing: the key literal `waf:rule_hits:` is duplicated with **no shared constant** between `rule_engine.py` and `tasks.py`, so a probe hardcoding a third copy could not detect the two drifting apart.

### A defect found in this probe during review

`flush_rule_hit_counts` takes no scope argument: it scans `waf:rule_hits:*` and flushes every key it finds. So on a live site the probe's run also sweeps up real counters, whose DB updates land in the probe's rolled-back transaction while their Redis keys are deleted regardless. The probe snapshots other keys first and restores them after.

The first implementation restored **both** the database row and the Redis key. That double-counts: once from the reconciliation, once more when the next scheduled flush reads the key just restored. Measured before fixing: **a real counter of 5 reached `hit_count = 10`** after one probe run plus one flush. That directly defeats #100's own constraint that the probe must not corrupt real `hit_count` values.

The fix restores the Redis key only. The rollback already returned each row to where it started, so the count is still owed, and returning it to Redis leaves it pending for the next flush, which is the system's normal path for an unflushed counter.

The existing test missed this because it asserted the count *immediately after the probe*, where the broken version looks correct. The regression test now spans the probe **and** the following flush.

### Teeth, proven by breaking things

- **The probe**: the Redis read inside the flush is made to raise into the same per-key `except` the unsupported `GETDEL` landed in, while `run_flush_probe`, `_record_rule_hit` and `flush_rule_hit_counts` all still execute for real. Probe reports `alive=False`.
- **The double-count regression test**: reintroduced the defect and confirmed the test fails (`assert 10 == 5`), then restored the fix for green. Proven by watching it fail, not by watching it pass.

### Residual risk, stated not papered over

A real hit landing on a key strictly between the snapshot read and the flush's own read/delete of that key is lost. This is the same window `BR-LIFE-004` already documents and accepts for the non-atomic `GET`+`DEL` pipeline. The probe neither widens nor closes it.

No environment guard of any kind gates the probe; #97's staging skip was precisely the class of defect a liveness probe exists to catch.

## Verification

Every gate CI runs, plus both integration legs against real servers:

| Gate | Result |
|---|---|
| `ruff check` / `ruff format --check` | pass, 148 files |
| `PYTHONPATH=. mypy src/` | **86 source files, zero errors** |
| `pytest --cov` | **1272 passed, 6 skipped, 93.34%** (gate 90%) |
| Real Redis 6.0.7 (`-m redis_integration`) | 6 passed, incl. new `TestFlushProbeAgainstRealRedis` |
| Real PostgreSQL 16 | 1270 passed, 8 skipped |

Redis 6.0 specifically, not latest: Redis 7 would hide the original `GETDEL` defect exactly as fakeredis did.

One test fix: `test_conf.py`'s beat-schedule expectation was stale against the new `probe_flush_path` entry. Test gap, not a production defect.

Each of the three commits is independently coherent for bisect: mypy reports 31 errors at the first, clean at the second, clean at the third.

## Spec

`BR-LIFE-005`, `AC-LIFE-004..006`, services section 7b, a runbook entry and ten `CHK-TL-*` items are in a companion umbrella PR. `py.typed` and the CI leg are recorded in the CHANGELOG and CHECKLIST rather than invented into the business rules, since that spec documents runtime behaviour, not tooling.