### PR TITLE
Rule provenance and outcome: the wave 2 chain-of-command work (#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,107 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `django_settings_module = "tests.settings"` and mypy exits 2 having
   checked nothing at all, a no-op that reads as a pass when scripted.
 
+- **A production-outcome report for every detector** (BR-ANOM-015). Closes
+  the fourth link of the chain-of-command rule: a WAF feature must declare
+  what it is, what it does, why it is there, and what its outcome was. The
+  first three were enforced; nothing in the package could answer the
+  fourth. Producing the per-detector picture on a live consumer took ad-hoc
+  ORM queries run against production, which is the gap this closes.
+
+  `django_waf_detector_outcomes` (`--days`, default 30) reports rules
+  created, rules ever hit, hit rate, total hits attributed, most recent
+  rule created, and the existing `auto_rule_review_outcomes` breakdown
+  (BR-ANOM-010). Read-only. Every `DETECTOR_NAMES` entry is zero-filled, so
+  a detector producing nothing is an explicit zero row rather than an
+  absent one, which is the state that hid a dead detector before.
+
+  `BlockRule.detectors` is a superset of the registry, not a mirror of it:
+  `rule_engine._create_escalation_rule` writes `challenge_escalation`,
+  which is not a `DETECTOR_NAMES` member. Those names are reported in a
+  separate section rather than dropped or folded into the registry, and the
+  comma-separated field is parsed by exact membership rather than substring
+  containment, so a name that is a prefix of another cannot be miscounted.
+  The report issues two queries regardless of row count, measured with
+  `CaptureQueriesContext` and pinned by a test; no new index was needed at
+  60,000 rows.
+
+- **Retention for `BlockRule`** (`DJANGO_WAF_RULE_RETENTION_DAYS`, default
+  90). `RequestLog` has had retention and a nightly prune since 1.0;
+  `BlockRule` had expiry but no deletion, so nothing ever removed a row. A
+  live 2.4.0 consumer carried 48,319 rules older than 90 days and none
+  older than 150, the table's own age. The expiry path works and those rows
+  do not enforce, so this is an audit-trail and growth problem rather than
+  an enforcement one, and it is scoped accordingly.
+
+  Ships behind two independent gates, because this is the only path in the
+  package that destroys data. `django_waf_prune_rules` is dry-run by
+  default and needs `--execute` to delete; the scheduled `prune_stale_rules`
+  task is additionally gated on `DJANGO_WAF_RULE_PRUNE_ENABLED` (default
+  `False`), so the exported beat entry cannot delete anything for a
+  consumer who merges `DJANGO_WAF_CELERY_BEAT_SCHEDULE` as documented until
+  they opt in.
+
+  `BlockRuleManager.stale()` deletes a row only when all of: `source=auto`,
+  `is_active=False`, `expires_at` set and older than the window, and
+  `review_status` is `not_applicable` or `expired_unreviewed`. `pending` and
+  `confirmed` are excluded per the plan; `rejected` is excluded too, which
+  the plan did not specify against the five-state enum. A rejected rule
+  records an operator's decision that a pattern must not be blocked, and
+  deleting it erases only the record, leaving the detector free to recreate
+  the rule for the operator to reject again. A never-expiring auto rule is
+  excluded unconditionally: BR-ANOM-007's quarantine path is how one
+  reaches `is_active=False` with no expiry, and that state means awaiting
+  review, not safe to reclaim.
+
+- **`django_waf.W009`**, a boot-time check catching a desync between
+  `DETECTOR_NAMES` and `DETECTOR_NAME_TO_RESULT_KEY` in either direction. A
+  detector must currently be hand-added in seven places and nothing
+  enforced two of them. A name in `DETECTOR_NAMES` with no result key reads
+  to the probe as a permanently silent detector, indistinguishable from a
+  dead one without reading the code; a result key with no `DETECTOR_NAMES`
+  entry is invisible to the probe, to `W008` and to observe-only mode, with
+  nothing failing. Not gated on `DJANGO_WAF_ENABLED`, for the same reason
+  `W008` is not: anomaly detection runs on its own schedule, so gating it
+  would hide the wiring bug from exactly the deployments running detection
+  with enforcement off.
+
 ### Fixed
+
+- **The detector liveness probe reported a healthy detector as SILENT**
+  once a deployment had accumulated any `BlockRule` history. The dry-run
+  branch of `_get_or_create_auto_rule` checks
+  `BlockRule.objects.filter(rule_type, pattern, source=auto, action)` with
+  no `is_active` and no `expires_at` filter, and the probe counts only
+  `created=True`, so a single surviving auto rule on a fixture's exact
+  pattern tuple made that detector report SILENT permanently. Reproduced
+  with one rule expired 365 days earlier and already inactive: it silenced
+  `detect_cloud_spray`, `detect_ua_rotation` and `detect_scraper_404_ratio`,
+  against a control run on an empty table reporting every detector alive.
+  Because nothing deleted `BlockRule` rows, the collision never cleared,
+  which is the same root cause as the retention gap above.
+
+  BR-ANOM-012 had asserted this could not happen, on the grounds that
+  fixture IPs are drawn from TEST-NET documentation ranges. That reasoning
+  holds for `RequestLog` and not for `BlockRule`: an operator,
+  `django_waf_import_rules`, or a threat feed can write an auto-sourced
+  rule on a documentation range, and the probe's forced rollback cannot
+  remove a row it never created.
+
+  Fixed with a keyword-only `count_refresh_as_created` parameter, default
+  `False` everywhere and passed `True` only by `run_detector_probe`. The
+  probe asks whether the detector's logic fired; dry-run asks whether a new
+  row would be written. They are different questions, and the fix answers
+  the first without corrupting the second, so BR-ANOM-006's guarantee that
+  "would create N rules" matches a subsequent real run is unchanged. A
+  detector patched to return nothing still reports SILENT.
+
+- **`django_waf_detect_anomalies` double-counted its own summary** (#99).
+  The results loop iterated `results.items()`, which includes
+  `total_rules_created`, so the pre-summed total was printed as though it
+  were a detector and added to the total a second time. A live run reported
+  two rules as four. Now skipped, pinned by a regression test that
+  reproduces the exact doubling when the fix is reverted.
+
 
 - **`_deduplicate_block_rules` could raise `AttributeError` on a
   concurrent delete** (#111). It called `.pk` on the result of

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -88,13 +88,43 @@ line.
 
 The observe-only detector-name check (``django_waf.W008``) warns when
 ``DJANGO_WAF_ANOMALY_OBSERVE_ONLY_DETECTORS`` (BR-ANOM-008, #45) names a
-value that does not match any of the five anomaly detector function names.
-The setting is checked against
-``django_waf.services.anomaly_detector.DETECTOR_NAMES``, the same constant
-``_get_or_create_auto_rule`` reads to decide observe-only status, so a
-detector rename cannot silently desync the two: a typo or a stale name from
-a renamed detector would otherwise mean the operator believes a detector is
-running observe-only when it is, in fact, enforcing.
+value that does not match any of the six anomaly detector function names
+(five when this check was introduced; ``detect_scraper_404_ratio`` was
+added by BR-ANOM-014 without this docstring being swept). The setting is
+checked against ``django_waf.services.anomaly_detector.DETECTOR_NAMES``,
+the same constant ``_get_or_create_auto_rule`` reads to decide
+observe-only status, so a detector rename cannot silently desync the two:
+a typo or a stale name from a renamed detector would otherwise mean the
+operator believes a detector is running observe-only when it is, in fact,
+enforcing.
+
+The detector-wiring check (``django_waf.W009``) warns when
+``anomaly_detector.DETECTOR_NAMES`` and
+``anomaly_detector.DETECTOR_NAME_TO_RESULT_KEY`` disagree on membership: a
+name in one dict but not the other. A detector must currently be
+hand-added in several places (``DETECTOR_NAMES``,
+``DETECTOR_NAME_TO_RESULT_KEY``, both branches of ``run_all_detectors``'s
+call list, the hand-summed total, the log format string, the hand-written
+return dict, and ``detector_probe._build_fixture_traffic``); only the
+first two are adjacent and already commented against desync. A name added
+to ``DETECTOR_NAMES`` but never wired into ``DETECTOR_NAME_TO_RESULT_KEY``
+(or the reverse) is invisible to this check's own guard test at the Python
+level, but it IS visible to a running system: a detector present in
+``DETECTOR_NAMES`` without a matching result key reads as permanently
+silent to ``services.detector_probe.run_detector_probe`` (``.get(result_
+key, 0)`` never finds anything to count), reporting a wiring bug as a dead
+detector rather than what it actually is. Mirrors ``django_waf.W008``'s
+own pattern: it imports the two constants and checks their shape,
+performing no query and touching no external service, so it is exactly as
+cheap. Like W008, it is NOT gated on ``DJANGO_WAF_ENABLED``: this check
+verifies a static wiring invariant in ``services.anomaly_detector``'s own
+module-level constants (the "single source of truth" the top of that
+module's own comment describes), and the anomaly-detection subsystem it
+protects runs on its own Celery schedule (``detect_anomalies``,
+BR-ANOM-005) entirely independently of whether ``WafMiddleware`` is
+enforcing requests, so gating it on the WAF's per-request master switch
+would hide the misconfiguration from exactly the deployments running
+anomaly detection with the WAF's request-time enforcement switched off.
 
 The Redis version check (``django_waf.E005``) errors when the connected
 Redis server reports a version below the package's own floor, currently
@@ -632,6 +662,73 @@ def check_observe_only_detector_names(app_configs, **kwargs):
             "for this entry.",
             hint=f"Known detector names are: {known}.",
             id="django_waf.W008",
+        )
+    ]
+
+
+@register()
+def check_detector_wiring(app_configs, **kwargs):
+    """Warn (``django_waf.W009``) when ``anomaly_detector.DETECTOR_NAMES``
+    and ``anomaly_detector.DETECTOR_NAME_TO_RESULT_KEY`` disagree on
+    membership.
+
+    A name can land in only one of the two dicts if a detector is added or
+    renamed and the other dict is not updated in the same change: both are
+    hand-maintained module-level constants (see their own comments in
+    ``services/anomaly_detector.py``), and nothing at the Python level
+    enforces they stay in sync. A name in ``DETECTOR_NAMES`` with no
+    matching result key is the more dangerous of the two directions: it
+    reads to ``services.detector_probe.run_detector_probe`` as a
+    permanently silent detector (``result.get(result_key, 0)`` never finds
+    anything to count for it), which is indistinguishable from a genuinely
+    dead detector without reading the code. The reverse (a result key with
+    no matching ``DETECTOR_NAMES`` entry) is invisible to the probe,
+    ``django_waf.W008``, and observe-only mode alike, with nothing
+    failing. Both directions are reported together here.
+
+    Mirrors ``django_waf.W008``'s own pattern (import the constants, check
+    their shape) and is not gated on ``DJANGO_WAF_ENABLED`` for the same
+    reason W008 is not: this validates a static wiring invariant in
+    ``services.anomaly_detector``'s own constants, and the anomaly-
+    detection subsystem it protects runs on its own Celery schedule
+    independently of the WAF's per-request master switch (see the module
+    docstring for the fuller rationale).
+    """
+    from django_waf.services.anomaly_detector import (
+        DETECTOR_NAME_TO_RESULT_KEY,
+        DETECTOR_NAMES,
+    )
+
+    result_key_names = set(DETECTOR_NAME_TO_RESULT_KEY)
+    missing_result_key = sorted(DETECTOR_NAMES - result_key_names)
+    missing_from_detector_names = sorted(result_key_names - DETECTOR_NAMES)
+
+    if not missing_result_key and not missing_from_detector_names:
+        return []
+
+    problems = []
+    if missing_result_key:
+        problems.append(f"in DETECTOR_NAMES but missing from DETECTOR_NAME_TO_RESULT_KEY: {missing_result_key!r}")
+    if missing_from_detector_names:
+        problems.append(
+            f"a key in DETECTOR_NAME_TO_RESULT_KEY but missing from DETECTOR_NAMES: {missing_from_detector_names!r}"
+        )
+
+    return [
+        Warning(
+            "django_waf.services.anomaly_detector.DETECTOR_NAMES and "
+            "DETECTOR_NAME_TO_RESULT_KEY have desynced: " + "; ".join(problems) + ". "
+            "A name missing from DETECTOR_NAME_TO_RESULT_KEY reports as a "
+            "permanently silent detector to django_waf_probe_detectors "
+            "and the detector outcome report, indistinguishable from a "
+            "genuinely dead detector without reading the code.",
+            hint=(
+                "Add the missing entry to whichever constant lacks it in "
+                "services/anomaly_detector.py; both are updated in the "
+                "same change whenever a detector is added, renamed, or "
+                "removed."
+            ),
+            id="django_waf.W009",
         )
     ]
 

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -393,6 +393,40 @@ def _DJANGO_WAF_LOG_RETENTION_DAYS() -> int:
     return _get_setting("DJANGO_WAF_LOG_RETENTION_DAYS", 30)
 
 
+# Number of days to retain an expired, inactive, auto-generated BlockRule
+# before prune_stale_rules (tasks.py) hard-deletes it (wave 2, #99 planning,
+# the wave 2 rule-provenance plan). BlockRule has expiry (BR-LIFE-001, expire_rules sets
+# is_active=False) but, unlike RequestLog, no deletion path existed before
+# this setting: measured on a live 2.4.0 deployment, 48,319 rows were older
+# than 90 days with nothing older than 150 (the table's own age), so nothing
+# was ever removing them. 90 days deliberately exceeds
+# DJANGO_WAF_LOG_RETENTION_DAYS's 30-day default: a BlockRule is a decision
+# record, not a sampled request, and an operator auditing "why was this IP
+# blocked three months ago" needs the rule to still exist longer than the
+# request logs that triggered it. Unbounded growth is not this setting's
+# only cost: a surviving expired-and-inactive, source=auto BlockRule whose
+# pattern matches a detector's probe fixture permanently reports that
+# detector SILENT in django_waf_probe_detectors, because the probe's
+# dry-run existence check filters on neither is_active nor expires_at (see
+# services/detector_probe.py). Retention is therefore also what keeps that
+# probe collision from being permanent.
+def _DJANGO_WAF_RULE_RETENTION_DAYS() -> int:
+    return _get_setting("DJANGO_WAF_RULE_RETENTION_DAYS", 90)
+
+
+# Gate on prune_stale_rules (tasks.py) actually deleting BlockRule rows.
+# Default False: this is the one destructive path in the package, so the
+# scheduled task is safe to include in DJANGO_WAF_CELERY_BEAT_SCHEDULE from
+# day one, at every consumer, without a single row ever being deleted until
+# an operator has read this setting and turned it on deliberately. While
+# False, the task still runs on schedule and still reports a count via its
+# log line, so an operator sees "this many rows are stale" for as long as
+# they like before flipping this on, the same escalation path the command's
+# --dry-run/--execute split offers for a manual run.
+def _DJANGO_WAF_RULE_PRUNE_ENABLED() -> bool:
+    return _get_setting("DJANGO_WAF_RULE_PRUNE_ENABLED", False)
+
+
 # Path to the nginx PID file. When set, reload_nginx() sends SIGHUP to the
 # master process directly: no subprocess, no sudo, no PATH required. Just
 # needs read access to the PID file. Set to None to use the command fallback.
@@ -688,6 +722,22 @@ def _DJANGO_WAF_SITE_PASSWORD_COOKIE_DOMAIN() -> str | None:
 # celery is installed. This module must remain importable even when celery
 # is entirely absent from the environment (e.g. projects that don't use
 # Celery at all still import django_waf.conf indirectly via checks/admin).
+#
+# This dict is exported, not registered: the package never calls
+# ``app.conf.beat_schedule.update(...)`` or otherwise reaches into a
+# consumer's Celery app on its own. A consumer who writes their own
+# CELERY_BEAT_SCHEDULE by hand, rather than merging this dict per the
+# pattern above, gets no error and no warning for a task named here that
+# their own schedule omits: the task simply never runs, silently. This is
+# pre-existing for every entry below (most notably
+# ``flush_rule_hit_counts``, whose own docstring in tasks.py describes the
+# unbounded Redis growth that follows from it never firing) and is not
+# solved by this wave's addition of ``prune_stale_rules``. It is
+# documented here rather than fixed because fixing it means either an
+# AppConfig.ready() check that can inspect a Celery app that may not exist
+# yet at import time, or a system check comparing this dict against
+# whatever the consumer actually configured, and both are a separate,
+# harder change than what this section covers.
 _CELERY_BEAT_INTERVAL_ENTRIES: dict = {
     "django-waf-generate-blocklist": {
         "task": "django_waf.tasks.generate_blocklist",
@@ -736,6 +786,16 @@ if crontab is not None:
         "django-waf-prune-challenge-tokens": {
             "task": "django_waf.tasks.prune_challenge_tokens",
             "schedule": crontab(hour=4, minute=15),
+        },
+        "django-waf-prune-stale-rules": {
+            # Safe to include unconditionally: prune_stale_rules itself is
+            # gated on DJANGO_WAF_RULE_PRUNE_ENABLED (default False, see
+            # conf.py) and reports a count without deleting while disabled.
+            # A consumer who merges this dict as-is (per the module
+            # docstring's documented pattern) never has a row deleted
+            # without first setting that flag deliberately.
+            "task": "django_waf.tasks.prune_stale_rules",
+            "schedule": crontab(hour=4, minute=20),
         },
         "django-waf-sync-threat-feed": {
             "task": "django_waf.tasks.sync_threat_feed",

--- a/src/django_waf/management/commands/django_waf_detect_anomalies.py
+++ b/src/django_waf/management/commands/django_waf_detect_anomalies.py
@@ -33,16 +33,29 @@ class Command(BaseCommand):
         window_minutes: int | None = options["window_minutes"]
 
         if dry_run:
-            self.stdout.write(self.style.WARNING("[dry-run] Analysing anomalies — no rules will be created."))
+            self.stdout.write(self.style.WARNING("[dry-run] Analysing anomalies, no rules will be created."))
 
         try:
             results = run_all_detectors(window_minutes=window_minutes, dry_run=dry_run)
         except Exception as exc:
             raise CommandError(f"Anomaly detection failed: {exc}") from exc
 
-        # run_all_detectors returns a dict keyed by detector name.
+        # run_all_detectors returns a dict keyed by detector result name,
+        # PLUS a "total_rules_created" key holding the pre-summed total
+        # (see its own docstring/return statement). Issue #99: iterating
+        # results.items() unfiltered treated that total as if it were an
+        # eighth detector, both printing it as a fake "detector" line and
+        # adding it a second time to total_created, exactly doubling the
+        # reported count (a live run printed "unsolved_challenge_rules:
+        # would create 2" then "total_rules_created: would create 2" then
+        # concluded "Would have created 4 rule(s)"). total_rules_created is
+        # excluded here so total_created below is summed only from the
+        # real per-detector counts, matching what run_all_detectors itself
+        # already computed.
         total_created = 0
         for detector_name, rules_created in results.items():
+            if detector_name == "total_rules_created":
+                continue
             count = len(rules_created) if isinstance(rules_created, list) else int(rules_created)
             if count:
                 label = "would create" if dry_run else "created"

--- a/src/django_waf/management/commands/django_waf_detector_outcomes.py
+++ b/src/django_waf/management/commands/django_waf_detector_outcomes.py
@@ -1,0 +1,68 @@
+"""
+Management command: django_waf_detector_outcomes
+
+Reports the production outcome of every anomaly detector over a window
+(default 30 days): rules created, rules ever hit, hit rate, total hits
+attributed, and the most recent rule created, plus the BR-ANOM-010 review
+outcome counts for the same period. Read-only: makes no BlockRule write, no
+RequestLog write, and emits no signal.
+
+The missing fourth link of the chain-of-command rule (wave 2 of the
+provenance plan): identity, action and justification already existed for
+every detector; production outcome did not, and getting it previously meant
+ad-hoc ORM queries run directly against a live deployment.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = "Report each anomaly detector's production outcome (rules created, hit rate, review status)."
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=30,
+            help="Window in days to look back over BlockRule.created_at (default: 30).",
+        )
+
+    def handle(self, *args, **options) -> None:
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        days: int = options["days"]
+
+        try:
+            result = report_detector_outcomes(window_days=days)
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        self.stdout.write(f"Detector outcomes, last {result['window_days']} day(s):")
+        self.stdout.write("")
+
+        for name, stats in result["detectors"].items():
+            self._write_detector_row(name, stats)
+
+        if result["unregistered_detectors"]:
+            self.stdout.write("")
+            self.stdout.write(
+                self.style.WARNING("Names found in BlockRule.detectors outside anomaly_detector.DETECTOR_NAMES:")
+            )
+            for name, stats in result["unregistered_detectors"].items():
+                self._write_detector_row(name, stats)
+
+        outcomes = result["review_outcomes"]
+        self.stdout.write("")
+        self.stdout.write(
+            "Review outcomes: pending={pending} confirmed={confirmed} rejected={rejected} "
+            "expired_unreviewed={expired_unreviewed} not_applicable={not_applicable} total={total}".format(**outcomes)
+        )
+
+    def _write_detector_row(self, name: str, stats: dict) -> None:
+        most_recent = stats["most_recent_rule_created"]
+        most_recent_str = most_recent.isoformat() if most_recent is not None else "never"
+        self.stdout.write(
+            f"  {name}: created={stats['rules_created']} ever_hit={stats['rules_ever_hit']} "
+            f"hit_rate={stats['hit_rate']:.2%} total_hits={stats['total_hits']} "
+            f"most_recent={most_recent_str}"
+        )

--- a/src/django_waf/management/commands/django_waf_prune_rules.py
+++ b/src/django_waf/management/commands/django_waf_prune_rules.py
@@ -1,0 +1,83 @@
+"""
+Management command: django_waf_prune_rules
+
+Hard-deletes expired, inactive, auto-generated BlockRule records older than
+the configured retention period. Mirrors the behaviour of the
+prune_stale_rules Celery task (tasks.py) for manual invocation.
+
+Defaults to dry-run, unlike django_waf_prune_logs and
+django_waf_prune_challenges, which default to executing and require an
+explicit --dry-run to preview. This command inverts that convention on
+purpose: a RequestLog row is a sampled, low-value record and a
+ChallengeToken is ephemeral proof-of-work state, but a BlockRule is a
+decision record, and this is the only prune path in the package that hard-
+deletes one. The wave that added it (the wave 2 rule-provenance plan) treats this as the
+package's one genuinely irreversible operator action, so the safe path
+(report a count, delete nothing) has to be what an operator gets by typing
+the command with no flags and no prior reading of --help. An explicit
+--execute is required to actually delete; --dry-run is also accepted, as a
+no-op synonym for the default, so a script written against the other prune
+commands' --dry-run convention still behaves safely here rather than
+deleting on the first unfamiliar flag.
+"""
+
+from django.core.management.base import BaseCommand, CommandError
+
+
+class Command(BaseCommand):
+    help = (
+        "Delete expired, inactive, auto-generated WAF block rules older than the retention "
+        "period. Defaults to reporting the count without deleting; pass --execute to delete."
+    )
+
+    def add_arguments(self, parser) -> None:
+        parser.add_argument(
+            "--days",
+            type=int,
+            default=None,
+            help=("Override retention period in days (default: DJANGO_WAF_RULE_RETENTION_DAYS, typically 90)."),
+        )
+        parser.add_argument(
+            "--execute",
+            action="store_true",
+            default=False,
+            help="Actually delete the matching rows. Without this flag the command only reports "
+            "the count that would be deleted.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Report the number of rules that would be deleted without deleting them "
+            "(this is the default behaviour; the flag is accepted for symmetry with the "
+            "other prune commands and has no additional effect).",
+        )
+
+    def handle(self, *args, **options) -> None:
+        from django_waf import conf
+        from django_waf.models import BlockRule
+
+        days: int = options["days"] if options["days"] is not None else conf.DJANGO_WAF_RULE_RETENTION_DAYS
+        execute: bool = options["execute"]
+
+        if days < 1:
+            raise CommandError("--days must be a positive integer.")
+
+        stale_qs = BlockRule.objects.stale(days=days)
+
+        if not execute:
+            count = stale_qs.count()
+            self.stdout.write(
+                self.style.WARNING(
+                    f"[dry-run] Would delete {count} block rule(s) older than {days} day(s). "
+                    "Pass --execute to actually delete."
+                )
+            )
+            return
+
+        try:
+            deleted_count, _ = stale_qs.delete()
+        except Exception as exc:
+            raise CommandError(f"Rule pruning failed: {exc}") from exc
+
+        self.stdout.write(self.style.SUCCESS(f"Deleted {deleted_count} block rule(s) older than {days} day(s)."))

--- a/src/django_waf/models.py
+++ b/src/django_waf/models.py
@@ -94,6 +94,48 @@ class BlockRuleManager(models.Manager):
         """Return active rules whose expiry time has passed."""
         return self.filter(is_active=True, expires_at__lte=timezone.now())
 
+    def stale(self, days: int) -> models.QuerySet:
+        """Return auto-generated rules safe to hard-delete under retention (wave 2, the rule-provenance wave).
+
+        A row qualifies only when ALL of the following hold:
+
+        - ``source=RuleSource.AUTO``. An operator's hand-authored ``admin``
+          rule or a ``feed``-sourced rule is a deliberate, reviewed
+          artefact; this retention path exists for the class of rows that
+          regenerate themselves on the next detector run (BR-ANOM-007's
+          ``update_or_create`` re-detection path), not for rows a human
+          typed in.
+        - ``is_active=False``: never delete an enforcing rule, quarantined
+          or otherwise. Mirrors ``expired()``'s own is_active gate.
+        - ``expires_at`` is set and at least ``days`` in the past. A rule
+          that never expires (``expires_at is None``) is excluded
+          unconditionally, regardless of ``is_active``: BR-ANOM-007's
+          quarantine path is the one way a ``source=AUTO`` row can be
+          ``is_active=False`` with no ``expires_at``, and that state means
+          "awaiting review", not "safe to reclaim".
+        - ``review_status`` is ``NOT_APPLICABLE`` or ``EXPIRED_UNREVIEWED``.
+          ``PENDING`` and ``CONFIRMED`` are excluded per this wave's plan.
+          ``REJECTED`` is also excluded, deliberately, and is the one
+          divergence from a literal reading of the plan (which named only
+          three states against a five-state enum): a ``REJECTED`` row
+          records an operator's explicit decision that this exact pattern
+          must not be blocked. Deleting it does not undo that decision, it
+          only erases the record of it, so the next time a detector
+          re-observes the same pattern it recreates the rule from
+          scratch and the operator has to reject it again. Keeping
+          ``REJECTED`` rows is the cheaper failure mode: a few extra
+          quarantined rows outlive the retention window, versus an
+          operator re-litigating a decision they already made once.
+        """
+        cutoff = timezone.now() - timedelta(days=days)
+        return self.filter(
+            source=RuleSource.AUTO,
+            is_active=False,
+            expires_at__isnull=False,
+            expires_at__lt=cutoff,
+            review_status__in=[ReviewStatus.NOT_APPLICABLE, ReviewStatus.EXPIRED_UNREVIEWED],
+        )
+
 
 def _validate_rule_pattern(rule_type: str, match_type: str, pattern: str) -> None:
     """Reject a catastrophic or invalid UA regex pattern on any save path.

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -63,6 +63,7 @@ def detect_ua_rotation(
     window_minutes: int = 5,
     threshold: int | None = None,
     dry_run: bool = False,
+    count_refresh_as_created: bool = False,
 ) -> list:
     """Detect IPs using an unusually large number of distinct User-Agent strings.
 
@@ -76,6 +77,9 @@ def detect_ua_rotation(
                    DJANGO_WAF_ANOMALY_THRESHOLD_DISTINCT_UAS.
         dry_run: When True (#38), collects what would be created without
                  writing any BlockRule or emitting the anomaly_detected signal.
+        count_refresh_as_created: Forwarded to ``_get_or_create_auto_rule``
+                 (see its docstring). Default False, no effect on any
+                 caller except ``services.detector_probe``.
 
     Returns:
         List of BlockRule instances that were created (or, in dry-run, would
@@ -120,6 +124,7 @@ def detect_ua_rotation(
             detector_name="detect_ua_rotation",
             confidence=confidence,
             evidence=details,
+            count_refresh_as_created=count_refresh_as_created,
         )
         if created:
             created_rules.append(rule)
@@ -134,7 +139,11 @@ def detect_ua_rotation(
     return created_rules
 
 
-def detect_subnet_burst(window_minutes: int = 15, dry_run: bool = False) -> list:
+def detect_subnet_burst(
+    window_minutes: int = 15,
+    dry_run: bool = False,
+    count_refresh_as_created: bool = False,
+) -> list:
     """Detect /24 (IPv4) or /48 (IPv6) subnets with anomalously high request volume.
 
     Per BR-ANOM-002 (as amended, issue #80): flags a subnet when BOTH of the
@@ -176,6 +185,9 @@ def detect_subnet_burst(window_minutes: int = 15, dry_run: bool = False) -> list
         window_minutes: Time window to analyse (default 15).
         dry_run: When True (#38), collects what would be created without
                  writing any BlockRule or emitting the anomaly_detected signal.
+        count_refresh_as_created: Forwarded to ``_get_or_create_auto_rule``
+                 (see its docstring). Default False, no effect on any
+                 caller except ``services.detector_probe``.
 
     Returns:
         List of BlockRule instances that were created (or, in dry-run, would
@@ -240,6 +252,7 @@ def detect_subnet_burst(window_minutes: int = 15, dry_run: bool = False) -> list
             detector_name="detect_subnet_burst",
             confidence=confidence,
             evidence=details,
+            count_refresh_as_created=count_refresh_as_created,
         )
         if created:
             created_rules.append(rule)
@@ -254,7 +267,11 @@ def detect_subnet_burst(window_minutes: int = 15, dry_run: bool = False) -> list
     return created_rules
 
 
-def detect_challenge_farms(window_hours: int = 24, dry_run: bool = False) -> list:
+def detect_challenge_farms(
+    window_hours: int = 24,
+    dry_run: bool = False,
+    count_refresh_as_created: bool = False,
+) -> list:
     """Detect IPs with high challenge failure rates and low pass rates.
 
     Per BR-ANOM-003: IPs with challenge_failures > 10 and challenge_passes < 2
@@ -264,6 +281,9 @@ def detect_challenge_farms(window_hours: int = 24, dry_run: bool = False) -> lis
         window_hours: Time window to analyse (default 24).
         dry_run: When True (#38), collects what would be created without
                  writing any BlockRule or emitting the anomaly_detected signal.
+        count_refresh_as_created: Forwarded to ``_get_or_create_auto_rule``
+                 (see its docstring). Default False, no effect on any
+                 caller except ``services.detector_probe``.
 
     Returns:
         List of BlockRule instances that were created (or, in dry-run, would
@@ -302,6 +322,7 @@ def detect_challenge_farms(window_hours: int = 24, dry_run: bool = False) -> lis
             detector_name="detect_challenge_farms",
             confidence=confidence,
             evidence=details,
+            count_refresh_as_created=count_refresh_as_created,
         )
         if created:
             created_rules.append(rule)
@@ -322,6 +343,7 @@ def detect_unsolved_challenges(
     referer_ratio: float | None = None,
     subnet_window_minutes: int | None = None,
     dry_run: bool = False,
+    count_refresh_as_created: bool = False,
 ) -> list:
     """Detect IPs, and subnets, that receive challenges but never solve them.
 
@@ -411,6 +433,9 @@ def detect_unsolved_challenges(
                        the per-IP path (#93).
         dry_run: When True (#38), collects what would be created without
                  writing any BlockRule or emitting the anomaly_detected signal.
+        count_refresh_as_created: Forwarded to ``_get_or_create_auto_rule``
+                 (see its docstring). Default False, no effect on any
+                 caller except ``services.detector_probe``.
 
     Returns:
         List of BlockRule instances that were created (or, in dry-run, would
@@ -502,6 +527,7 @@ def detect_unsolved_challenges(
             referer_ratio=effective_referer_ratio,
             expiry=expiry,
             dry_run=dry_run,
+            count_refresh_as_created=count_refresh_as_created,
         )
     )
     created_rules.extend(
@@ -511,6 +537,7 @@ def detect_unsolved_challenges(
             window_minutes=effective_subnet_window_minutes,
             expiry=expiry,
             dry_run=dry_run,
+            count_refresh_as_created=count_refresh_as_created,
         )
     )
 
@@ -527,6 +554,7 @@ def _detect_unsolved_challenges_per_ip(
     referer_ratio: float,
     expiry,
     dry_run: bool,
+    count_refresh_as_created: bool = False,
 ) -> list:
     """The per-IP half of detect_unsolved_challenges. See that function's
     docstring for the three-signal contract this implements unchanged.
@@ -605,6 +633,7 @@ def _detect_unsolved_challenges_per_ip(
             detector_name="detect_unsolved_challenges",
             confidence=confidence,
             evidence=details,
+            count_refresh_as_created=count_refresh_as_created,
         )
         if created:
             created_rules.append(rule)
@@ -631,6 +660,7 @@ def _detect_unsolved_challenges_by_subnet(
     window_minutes: int,
     expiry,
     dry_run: bool,
+    count_refresh_as_created: bool = False,
 ) -> list:
     """The subnet half of detect_unsolved_challenges (#84). See that
     function's docstring for the two-signal, two-stage contract this
@@ -746,6 +776,7 @@ def _detect_unsolved_challenges_by_subnet(
             detector_name="detect_unsolved_challenges",
             confidence=confidence,
             evidence=details,
+            count_refresh_as_created=count_refresh_as_created,
         )
         if created:
             created_rules.append(rule)
@@ -766,7 +797,11 @@ def _detect_unsolved_challenges_by_subnet(
     return created_rules
 
 
-def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
+def detect_cloud_spray(
+    window_minutes: int = 30,
+    dry_run: bool = False,
+    count_refresh_as_created: bool = False,
+) -> list:
     """Detect coordinated low-and-slow scraping from many distinct IPs.
 
     Identifies UAs shared by many distinct IPs (>= DJANGO_WAF_CLOUD_SPRAY_MIN_IPS)
@@ -806,6 +841,9 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
         window_minutes: Time window to analyse (default 30).
         dry_run: When True (#38), collects what would be created without
                  writing any BlockRule or emitting the anomaly_detected signal.
+        count_refresh_as_created: Forwarded to ``_get_or_create_auto_rule``
+                 (see its docstring). Default False, no effect on any
+                 caller except ``services.detector_probe``.
 
     Returns:
         List of BlockRule instances that were created (or, in dry-run, would
@@ -891,6 +929,7 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
                 detector_name="detect_cloud_spray",
                 confidence=ua_confidence,
                 evidence=ua_details,
+                count_refresh_as_created=count_refresh_as_created,
             )
             if ua_created:
                 created_rules.append(ua_rule)
@@ -940,6 +979,7 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
                 detector_name="detect_cloud_spray",
                 confidence=confidence,
                 evidence=details,
+                count_refresh_as_created=count_refresh_as_created,
             )
             if created:
                 created_rules.append(rule)
@@ -958,7 +998,11 @@ def detect_cloud_spray(window_minutes: int = 30, dry_run: bool = False) -> list:
     return created_rules
 
 
-def detect_scraper_404_ratio(window_minutes: int | None = None, dry_run: bool = False) -> list:
+def detect_scraper_404_ratio(
+    window_minutes: int | None = None,
+    dry_run: bool = False,
+    count_refresh_as_created: bool = False,
+) -> list:
     """Detect IPs whose requests are overwhelmingly 404s (BR-ANOM-014).
 
     Traced against a live deployment (VendablyCSS, shopping.vendably.com,
@@ -1056,6 +1100,9 @@ def detect_scraper_404_ratio(window_minutes: int | None = None, dry_run: bool = 
                         DJANGO_WAF_SCRAPER_404_WINDOW_MINUTES.
         dry_run: When True (#38), collects what would be created without
                  writing any BlockRule or emitting the anomaly_detected signal.
+        count_refresh_as_created: Forwarded to ``_get_or_create_auto_rule``
+                 (see its docstring). Default False, no effect on any
+                 caller except ``services.detector_probe``.
 
     Returns:
         List of BlockRule instances that were created (or, in dry-run, would
@@ -1151,6 +1198,7 @@ def detect_scraper_404_ratio(window_minutes: int | None = None, dry_run: bool = 
             detector_name="detect_scraper_404_ratio",
             confidence=confidence,
             evidence=details,
+            count_refresh_as_created=count_refresh_as_created,
         )
         if created:
             created_rules.append(rule)
@@ -1170,7 +1218,11 @@ def detect_scraper_404_ratio(window_minutes: int | None = None, dry_run: bool = 
     return created_rules
 
 
-def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) -> dict:
+def run_all_detectors(
+    window_minutes: int | None = None,
+    dry_run: bool = False,
+    count_refresh_as_created: bool = False,
+) -> dict:
     """Run all anomaly detectors and return a summary of findings.
 
     Args:
@@ -1189,6 +1241,16 @@ def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) 
             BlockRule, activating anything, or emitting the
             anomaly_detected signal. ``run_all_detectors(dry_run=True)``
             makes zero DB writes.
+        count_refresh_as_created: Forwarded to every detector and, through
+            them, to ``_get_or_create_auto_rule`` (see its docstring).
+            Default False, which leaves every existing caller (the
+            ``django_waf_detect_anomalies`` command, the scheduled Celery
+            task) unaffected. Exists solely for
+            ``services.detector_probe.run_detector_probe``, whose liveness
+            question ("did the detector's query fire against its fixture")
+            is genuinely different from dry-run's honesty question ("would
+            a real run insert a NEW row"), and must not be answered by
+            corrupting the second to answer the first.
 
     Returns:
         Dict with keys: ua_rotation_rules, subnet_burst_rules,
@@ -1197,20 +1259,32 @@ def run_all_detectors(window_minutes: int | None = None, dry_run: bool = False) 
         describe what WOULD be created, not what was created.
     """
     if window_minutes is None:
-        ua_rules = detect_ua_rotation(dry_run=dry_run)
-        subnet_rules = detect_subnet_burst(dry_run=dry_run)
-        farm_rules = detect_challenge_farms(dry_run=dry_run)
-        unsolved_rules = detect_unsolved_challenges(dry_run=dry_run)
-        spray_rules = detect_cloud_spray(dry_run=dry_run)
-        scraper_404_rules = detect_scraper_404_ratio(dry_run=dry_run)
+        ua_rules = detect_ua_rotation(dry_run=dry_run, count_refresh_as_created=count_refresh_as_created)
+        subnet_rules = detect_subnet_burst(dry_run=dry_run, count_refresh_as_created=count_refresh_as_created)
+        farm_rules = detect_challenge_farms(dry_run=dry_run, count_refresh_as_created=count_refresh_as_created)
+        unsolved_rules = detect_unsolved_challenges(dry_run=dry_run, count_refresh_as_created=count_refresh_as_created)
+        spray_rules = detect_cloud_spray(dry_run=dry_run, count_refresh_as_created=count_refresh_as_created)
+        scraper_404_rules = detect_scraper_404_ratio(dry_run=dry_run, count_refresh_as_created=count_refresh_as_created)
     else:
         window_hours = max(1, -(-window_minutes // 60))  # ceiling division
-        ua_rules = detect_ua_rotation(window_minutes=window_minutes, dry_run=dry_run)
-        subnet_rules = detect_subnet_burst(window_minutes=window_minutes, dry_run=dry_run)
-        farm_rules = detect_challenge_farms(window_hours=window_hours, dry_run=dry_run)
-        unsolved_rules = detect_unsolved_challenges(window_minutes=window_minutes, dry_run=dry_run)
-        spray_rules = detect_cloud_spray(window_minutes=window_minutes, dry_run=dry_run)
-        scraper_404_rules = detect_scraper_404_ratio(window_minutes=window_minutes, dry_run=dry_run)
+        ua_rules = detect_ua_rotation(
+            window_minutes=window_minutes, dry_run=dry_run, count_refresh_as_created=count_refresh_as_created
+        )
+        subnet_rules = detect_subnet_burst(
+            window_minutes=window_minutes, dry_run=dry_run, count_refresh_as_created=count_refresh_as_created
+        )
+        farm_rules = detect_challenge_farms(
+            window_hours=window_hours, dry_run=dry_run, count_refresh_as_created=count_refresh_as_created
+        )
+        unsolved_rules = detect_unsolved_challenges(
+            window_minutes=window_minutes, dry_run=dry_run, count_refresh_as_created=count_refresh_as_created
+        )
+        spray_rules = detect_cloud_spray(
+            window_minutes=window_minutes, dry_run=dry_run, count_refresh_as_created=count_refresh_as_created
+        )
+        scraper_404_rules = detect_scraper_404_ratio(
+            window_minutes=window_minutes, dry_run=dry_run, count_refresh_as_created=count_refresh_as_created
+        )
 
     total = (
         len(ua_rules)
@@ -1390,6 +1464,7 @@ def _get_or_create_auto_rule(
     detector_name: str = "",
     confidence: Decimal | None = None,
     evidence: dict | None = None,
+    count_refresh_as_created: bool = False,
 ) -> tuple:
     """Create or refresh an auto-generated BlockRule, avoiding duplicates.
 
@@ -1426,6 +1501,36 @@ def _get_or_create_auto_rule(
     built for the anomaly_detected signal. Neither key is touched when the
     corresponding argument is omitted, so a caller not yet passing them sees
     unchanged behaviour.
+
+    ``count_refresh_as_created`` (default ``False``, added for
+    ``services.detector_probe.run_detector_probe``): dry-run's ``created``
+    return value answers "would a subsequent real run create a NEW row",
+    which is ``False`` whenever ANY existing ``(rule_type, pattern,
+    source=AUTO, action)`` row is found, including one that is expired and
+    inactive, because a real run would refresh that row via
+    ``_update_or_create_auto_rule`` rather than insert a second one. The
+    probe's liveness question is different: "did this detector's logic
+    fire against its fixture", which is true whether the resulting row is a
+    fresh insert or a refresh of a stale leftover. Left at its default,
+    this parameter changes nothing: a leftover ``BlockRule`` from an
+    earlier real (non-dry-run) probe invocation, an operator's
+    ``django_waf_import_rules`` run, or a threat feed sync that happens to
+    land on the exact synthetic TEST-NET pattern a fixture builds, makes
+    ``_get_or_create_auto_rule`` report ``created=False`` even though the
+    detector's query genuinely matched, and ``run_detector_probe`` would
+    then misreport a healthy detector as SILENT. Set ``True`` ONLY by the
+    probe path (``run_detector_probe`` forwards it through
+    ``run_all_detectors`` and every ``detect_*`` function down to here): in
+    that case, a matched-but-would-be-refreshed existing row also counts as
+    ``created=True`` for reporting purposes, so the probe's liveness
+    signal reflects whether the query matched, not whether the row
+    happened to be new. This can never affect a real (non-dry-run)
+    invocation, because a real run never reaches the ``dry_run`` branch
+    below at all, and no caller other than the probe ever passes ``True``:
+    ``django_waf_detect_anomalies``'s dry-run "would create N rules" count,
+    which depends on the existing honesty contract, is therefore
+    unaffected regardless of what accumulates in ``BlockRule`` over the
+    life of a deployment.
 
     Provenance (#97): ``detector_name`` (when non-empty) is added to
     ``BlockRule.detectors``, a comma-separated, sorted SET of every detector
@@ -1499,7 +1604,13 @@ def _get_or_create_auto_rule(
     if dry_run:
         existing = BlockRule.objects.filter(**lookup).first()
         if existing is not None:
-            return existing, False
+            # See the docstring's "count_refresh_as_created" section: a
+            # real run would refresh this row rather than insert a new
+            # one, so `created` stays False for every caller by default
+            # (the dry-run honesty contract). Only the probe path, which
+            # opts in explicitly, treats a matched-but-would-be-refreshed
+            # row as evidence the detector's own query fired.
+            return existing, count_refresh_as_created
         defaults["detectors"] = _merge_detector_names("", detector_name)
         return BlockRule(**lookup, **defaults), True
 

--- a/src/django_waf/services/detector_outcomes.py
+++ b/src/django_waf/services/detector_outcomes.py
@@ -1,0 +1,208 @@
+"""
+Detector production-outcome report for django-waf (wave 2, BR-ANOM-015).
+
+Closes the fourth link of the chain-of-command rule: identity, action,
+justification and, until now, nothing reported outcome. ``detect_cloud_spray``
+was the most productive detector in production (2,188 hits attributed, six
+rules created in 24h) while ``django_waf_probe_detectors`` reported it
+SILENT under default settings, and the only way to get the real per-detector
+picture was ad-hoc ORM queries run directly against a production database.
+This module is that query, built once, run repeatably, and zero-filled so a
+detector producing nothing is an explicit zero row rather than a name that
+never appears.
+
+Two things about ``BlockRule.detectors`` this module has to get right, both
+established in ``anomaly_detector._merge_detector_names`` and
+``anomaly_detector._update_or_create_auto_rule`` before this module existed:
+
+1. It is a comma-separated, sorted, deduplicated SET of every detector name
+   that has ever written to the row (additive, #97), not a single owner. A
+   naive substring match (``detectors__contains="detect_cloud_spray"``) would
+   also match a hypothetical ``detect_cloud_spray_v2``, so this module splits
+   on ``,`` and tests exact membership rather than substring containment.
+2. It is a SUPERSET of ``anomaly_detector.DETECTOR_NAMES``.
+   ``rule_engine._create_escalation_rule`` writes ``challenge_escalation`` to
+   this field (pinned by ``tests/test_services.py``,
+   ``test_detector_field_populated_by_every_detector_passing_it``), and
+   ``challenge_escalation`` is not, and never has been, a member of
+   ``DETECTOR_NAMES``: it is not a detector in the sense that word is used
+   elsewhere in this package (it does not run in ``run_all_detectors``, does
+   not appear in the probe, and has no fixture), it is ``rule_engine``'s own
+   two-stage escalation writing a provenance stamp onto a rule it promotes.
+   Dropping it would silently discard real provenance data already present
+   in the table; folding it into the registry would misrepresent it as a
+   seventh detector nothing else in the package treats as one. This module
+   therefore reports it in its own, clearly separate section
+   (``unregistered_detectors``), keyed by whatever name shows up, rather than
+   silently dropping it or silently merging it into a registry row.
+
+Query cost (the plan's own flagged risk, "measure, do not guess"): measured
+against real PostgreSQL with 60,000 ``BlockRule`` rows (exceeding the 54,319
+measured on the production deployment that motivated this wave), a realistic
+mixed detector-name distribution and a 30-day window narrowing the table to
+roughly 1,900 matching rows. The report issues exactly TWO queries, verified
+with ``CaptureQueriesContext`` rather than asserted: ONE scan for the
+per-detector aggregate (``.values_list("detectors", "created_at",
+"hit_count")`` over the window-filtered queryset), aggregated per detector in
+Python, plus the single ``GROUP BY`` that ``auto_rule_review_outcomes``
+(BR-ANOM-010) issues for the review-outcome section this module reuses rather
+than reimplements. The per-detector aggregate is one scan rather than one
+``LIKE``-filtered query per registry entry: ``EXPLAIN ANALYZE`` on a
+single per-name ``detectors__contains`` filter showed a sequential scan
+(the ``db_index=True`` btree index on ``detectors`` cannot serve a
+leading-wildcard ``LIKE '%name%'``, only a prefix match) costing ~5.5ms
+execution time once narrowed by the indexed ``created_at`` filter; multiplied
+across seven names that is comparable in DB time to the single-scan Python
+aggregation this module actually uses, and the single-scan form additionally
+gets exact-membership parsing for free rather than needing seven separate
+non-indexable filters. Both forms complete in well under 200ms at this row
+count, an operator-invoked reporting command's budget, so no new index or
+migration is added in this change: the existing ``db_index=True`` on
+``detectors`` and the composite indexes already on ``BlockRule`` (notably
+``created_at`` itself being individually indexed) are sufficient. If a future
+deployment's row count makes this slow, the fix is a composite index
+targeting the window filter, not a change to how the field is parsed.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from django.utils import timezone
+
+logger = logging.getLogger("django_waf.detector_outcomes")
+
+
+def report_detector_outcomes(window_days: int = 30) -> dict:
+    """Report, per detector, what actually happened in production.
+
+    Read-only: issues one SELECT against ``BlockRule`` and one further
+    query inside ``auto_rule_review_outcomes`` (BR-ANOM-010). Creates and
+    modifies nothing, and emits no signal.
+
+    Args:
+        window_days: How far back, in days, to look at ``BlockRule.created_at``.
+            Default 30, matching the plan's "Why now" table window.
+
+    Returns:
+        Dict with keys:
+            - ``window_days`` (int): echoed back, the window actually used.
+            - ``detectors`` (dict[str, dict]): one entry per name in
+              ``anomaly_detector.DETECTOR_NAMES``, zero-filled. A detector
+              that created nothing in the window still appears here with
+              ``rules_created=0`` rather than being omitted, which is the
+              entire point (an absent row is indistinguishable from a
+              detector nobody noticed had died). Each value is a dict with:
+                - ``rules_created`` (int)
+                - ``rules_ever_hit`` (int): rules with ``hit_count > 0``.
+                - ``hit_rate`` (float): ``rules_ever_hit / rules_created``,
+                  rounded to 4 decimal places, ``0.0`` when
+                  ``rules_created`` is 0 (never a ZeroDivisionError).
+                - ``total_hits`` (int): sum of ``hit_count`` across every
+                  rule attributed to this detector in the window.
+                - ``most_recent_rule_created`` (datetime | None): the
+                  latest ``created_at`` among this detector's rules in the
+                  window, ``None`` when ``rules_created`` is 0.
+            - ``unregistered_detectors`` (dict[str, dict]): same per-entry
+              shape as ``detectors``, for every name found in
+              ``BlockRule.detectors`` within the window that is NOT a
+              member of ``DETECTOR_NAMES`` (e.g. ``challenge_escalation``).
+              Empty dict when none are found. Kept separate from
+              ``detectors`` so a name outside the registry is never
+              silently dropped and never silently misrepresented as a
+              registered detector.
+            - ``review_outcomes`` (dict): the BR-ANOM-010 outcome counts
+              from ``anomaly_detector.auto_rule_review_outcomes``, using
+              ``window_days * 24`` as its own ``window_hours`` so both
+              halves of the report describe the same period.
+    """
+    from django_waf.models import BlockRule
+    from django_waf.services.anomaly_detector import DETECTOR_NAMES, auto_rule_review_outcomes
+
+    if window_days < 1:
+        raise ValueError("window_days must be a positive integer")
+
+    window_start = timezone.now() - timedelta(days=window_days)
+
+    rows = BlockRule.objects.filter(created_at__gte=window_start).values_list("detectors", "created_at", "hit_count")
+
+    accumulators: dict[str, _DetectorAccumulator] = {}
+    for detectors_field, created_at, hit_count in rows:
+        for name in _split_detector_names(detectors_field):
+            accumulators.setdefault(name, _DetectorAccumulator()).add(created_at, hit_count)
+
+    detectors_report = {name: _finalise(accumulators.get(name)) for name in sorted(DETECTOR_NAMES)}
+
+    unregistered_names = sorted(set(accumulators) - DETECTOR_NAMES)
+    unregistered_report = {name: _finalise(accumulators[name]) for name in unregistered_names}
+
+    if unregistered_names:
+        logger.info(
+            "django-waf: detector outcome report found %d name(s) in BlockRule.detectors "
+            "outside anomaly_detector.DETECTOR_NAMES: %s",
+            len(unregistered_names),
+            ", ".join(unregistered_names),
+        )
+
+    return {
+        "window_days": window_days,
+        "detectors": detectors_report,
+        "unregistered_detectors": unregistered_report,
+        "review_outcomes": auto_rule_review_outcomes(window_hours=window_days * 24),
+    }
+
+
+def _split_detector_names(detectors_field: str) -> list[str]:
+    """Split a ``BlockRule.detectors`` value into its member names.
+
+    Exact membership, never substring matching: mirrors how
+    ``anomaly_detector._merge_detector_names`` builds the field (sorted,
+    comma-joined, no empty entries), so a name is only ever counted for a
+    row that actually carries it, never for a row whose field merely
+    contains it as a substring (the ``detect_cloud_spray`` /
+    ``detect_cloud_spray_v2`` prefix-collision this exists to avoid).
+    """
+    return [name for name in detectors_field.split(",") if name]
+
+
+class _DetectorAccumulator:
+    """Running total for one detector name, built while scanning the window's
+    rows once. Not part of this module's public return shape; ``_finalise``
+    converts an instance (or ``None``, for a detector with no rows) into the
+    dict shape ``report_detector_outcomes`` actually returns."""
+
+    __slots__ = ("rules_created", "rules_ever_hit", "total_hits", "most_recent_rule_created")
+
+    def __init__(self) -> None:
+        self.rules_created = 0
+        self.rules_ever_hit = 0
+        self.total_hits = 0
+        self.most_recent_rule_created: datetime | None = None
+
+    def add(self, created_at: datetime, hit_count: int) -> None:
+        self.rules_created += 1
+        self.total_hits += hit_count
+        if hit_count > 0:
+            self.rules_ever_hit += 1
+        if self.most_recent_rule_created is None or created_at > self.most_recent_rule_created:
+            self.most_recent_rule_created = created_at
+
+
+def _finalise(accumulator: _DetectorAccumulator | None) -> dict:
+    if accumulator is None or accumulator.rules_created == 0:
+        return {
+            "rules_created": 0,
+            "rules_ever_hit": 0,
+            "hit_rate": 0.0,
+            "total_hits": 0,
+            "most_recent_rule_created": None,
+        }
+
+    return {
+        "rules_created": accumulator.rules_created,
+        "rules_ever_hit": accumulator.rules_ever_hit,
+        "hit_rate": round(accumulator.rules_ever_hit / accumulator.rules_created, 4),
+        "total_hits": accumulator.total_hits,
+        "most_recent_rule_created": accumulator.most_recent_rule_created,
+    }

--- a/src/django_waf/services/detector_probe.py
+++ b/src/django_waf/services/detector_probe.py
@@ -18,6 +18,29 @@ an unambiguous defect signal instead.
 No environment guard of any kind gates this module. #97's staging skip was
 exactly that class of defect: a probe that quietly does nothing in some
 environments is the next one.
+
+Historical BlockRule rows can still make a healthy detector report SILENT.
+An earlier revision of this module claimed the TEST-NET ranges below make a
+collision "only ever this probe's own prior run", never live traffic. That
+half of the claim holds for ``RequestLog``: the forced rollback guarantees
+no synthetic request row can ever survive a probe invocation. It does NOT
+hold for ``BlockRule``: an operator can seed a rule on a documentation
+range by hand or via ``django_waf_import_rules``, and a collective threat
+feed sync (``services.threat_feed.sync_feed``) has no way to know these
+ranges are reserved for this probe and could in principle write one too.
+``_get_or_create_auto_rule``'s dry-run existence check
+(``services.anomaly_detector``) matches on ``(rule_type, pattern,
+source=AUTO, action)`` alone, with no ``is_active`` or ``expires_at``
+filter, so ANY surviving ``source=AUTO`` row on a fixture's exact pattern,
+however old, however inactive, makes that detector's ``_get_or_create_auto_
+rule`` call report ``created=False``, and the forced rollback below cannot
+remove a row this probe never created in the first place. Fixed by
+threading ``count_refresh_as_created=True`` through to every detector (see
+``run_detector_probe`` below and ``_get_or_create_auto_rule``'s own
+docstring): the probe's liveness question is "did the detector's query
+fire", not "would a real run insert a brand new row", and a matched
+existing row is proof of the former even when it answers "no" to the
+latter.
 """
 
 from __future__ import annotations
@@ -30,12 +53,17 @@ from django.utils import timezone
 logger = logging.getLogger("django_waf.detector_probe")
 
 # TEST-NET ranges (RFC 5737 documentation ranges), one distinct block per
-# detector, so a leftover real BlockRule for the same pattern shape cannot
-# make _get_or_create_auto_rule report created=False (a false red) or,
-# under an inverted assertion, a false green. Real production traffic is
-# never sourced from these ranges, so a collision here can only be this
-# probe's own prior run (uncommitted, per the forced rollback below),
-# never live traffic.
+# detector, chosen so genuine production RequestLog traffic can never land
+# on the same pattern: real clients are never sourced from a documentation
+# range, and the forced rollback below guarantees no synthetic RequestLog
+# row this module writes can ever survive a probe invocation. This does
+# NOT extend to BlockRule: an operator can seed a source=AUTO rule on one
+# of these ranges by hand, via django_waf_import_rules, or via a collective
+# threat feed sync, and such a row is real, persisted, and entirely outside
+# this module's rollback. See the module docstring's "Historical BlockRule
+# rows" section for how count_refresh_as_created (threaded through every
+# detector call below) stops a leftover row like that from making a
+# healthy detector report a false SILENT.
 #
 # Sub-ranges within the three /24s are chosen so each detector's synthetic
 # IPs are disjoint from every other detector's, even though detect_subnet_burst
@@ -143,7 +171,26 @@ def run_detector_probe(dry_run: bool = True) -> dict:
             # exactly the window the fixture timestamps below are built
             # against. A probe passing a small override would silently
             # exercise a different window than it thinks for that one path.
-            result = run_all_detectors(dry_run=dry_run)
+            #
+            # count_refresh_as_created=True (always, never forwarded from
+            # this function's own argument): the probe's liveness question
+            # is "did the detector's query fire against its fixture", which
+            # is answered by a matched existing BlockRule exactly as well
+            # as a freshly inserted one. Without this, a leftover
+            # source=AUTO row on one of this module's TEST-NET patterns
+            # (an old probe run's own writes under --exercise-writes, an
+            # operator import, a threat feed sync) makes
+            # _get_or_create_auto_rule report created=False forever, and
+            # the probe would then misreport a healthy detector as SILENT
+            # on every subsequent run. See the module docstring's
+            # "Historical BlockRule rows" section and
+            # _get_or_create_auto_rule's own docstring. This is always True
+            # here regardless of the ``dry_run`` argument: the exercise-
+            # writes path (dry_run=False) still runs inside the same
+            # forced rollback below, so treating a refresh as "created"
+            # for reporting purposes carries no risk of a real row
+            # surviving either way.
+            result = run_all_detectors(dry_run=dry_run, count_refresh_as_created=True)
         finally:
             # Unconditional: even if fixture construction or detection raises,
             # nothing synthetic may survive this function. No branch below

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -11,6 +11,7 @@ Scheduled tasks (Celery Beat):
   - parse_access_log        — every 10 minutes
   - prune_request_logs      — daily 04:00 (BR-LOG-003)
   - prune_challenge_tokens  — daily 04:15
+  - prune_stale_rules       : daily 04:20 (wave 2, the rule-provenance wave)
   - expire_rules            — every 30 minutes (BR-LIFE-002)
   - update_ip_reputation    — every 6 hours
   - sync_threat_feed        — daily 04:30
@@ -358,6 +359,76 @@ def expire_rules() -> dict:
         "expired_count": total,
         "expired_unreviewed_count": expired_unreviewed_count,
     }
+
+
+@shared_task
+def prune_stale_rules(days: int | None = None) -> dict:
+    """Hard-delete expired, inactive, auto-generated BlockRules older than the retention window.
+
+    Mirrors prune_request_logs' shape. Per DJANGO_WAF_RULE_RETENTION_DAYS
+    (default 90, the wave 2 rule-provenance plan): measured on a live 2.4.0 deployment,
+    48,319 BlockRule rows were older than 90 days with nothing older than
+    150 (the table's own age since expire_rules only deactivates, never
+    deletes). Unbounded row growth is not the only cost: a surviving
+    expired-and-inactive, source=auto row whose pattern coincides with a
+    detector's probe fixture permanently reports that detector SILENT in
+    django_waf_probe_detectors, because the probe's dry-run existence check
+    filters on neither is_active nor expires_at. This task is what stops
+    that collision from being permanent as well as what bounds the table.
+
+    The predicate (BlockRuleManager.stale(), see models.py for the full
+    reasoning) never deletes an active rule, an unexpired rule, a rule
+    still PENDING review, one an operator CONFIRMED, or one an operator
+    REJECTED. A rejection is a decision the operator already made once,
+    and deleting its record only forces them to make it again the next
+    time a detector re-observes the same pattern. It is scoped to
+    source=AUTO only: a hand-authored admin rule or a feed-sourced rule is
+    never touched by this task regardless of age, is_active, or
+    review_status, since neither regenerates itself on the next detector
+    run the way an auto rule does.
+
+    This is the one destructive task in the package: unlike
+    prune_request_logs (sampled, low-value rows) and
+    prune_challenge_tokens (ephemeral proof-of-work state), a deleted
+    BlockRule is a decision record. Gated on DJANGO_WAF_RULE_PRUNE_ENABLED
+    (default False): while disabled, this task still runs on schedule and
+    still counts and logs how many rows are stale, but deletes nothing, so
+    a consumer who merges DJANGO_WAF_CELERY_BEAT_SCHEDULE unmodified gets a
+    standing visibility signal rather than either silent inaction or
+    silent deletion. An operator turns deletion on deliberately once
+    satisfied with what the count reports. See
+    management/commands/django_waf_prune_rules.py for the equivalent
+    report-first default on the manual path.
+
+    Args:
+        days: Number of days to retain. Defaults to DJANGO_WAF_RULE_RETENTION_DAYS.
+
+    Returns:
+        Dict with keys: deleted_count, dry_run.
+
+    Scheduled: daily at 04:20, immediately after prune_challenge_tokens'
+    04:15 slot, keeping the retention-sweep tasks clustered in the
+    package's quiet-hours window rather than scattered across the day.
+    """
+    from django_waf import conf
+    from django_waf.models import BlockRule
+
+    retention_days = days if days is not None else conf.DJANGO_WAF_RULE_RETENTION_DAYS
+    stale_qs = BlockRule.objects.stale(days=retention_days)
+
+    if not conf.DJANGO_WAF_RULE_PRUNE_ENABLED:
+        count = stale_qs.count()
+        logger.info(
+            "django-waf: %d stale BlockRule record(s) older than %d days would be pruned "
+            "(DJANGO_WAF_RULE_PRUNE_ENABLED is False, nothing deleted)",
+            count,
+            retention_days,
+        )
+        return {"deleted_count": 0, "dry_run": True}
+
+    deleted, _ = stale_qs.delete()
+    logger.info("django-waf: pruned %d stale BlockRule record(s) older than %d days", deleted, retention_days)
+    return {"deleted_count": deleted, "dry_run": False}
 
 
 @shared_task

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -57,6 +57,12 @@ def _run_observe_only_detector_names_check():
     return check_observe_only_detector_names(app_configs=None)
 
 
+def _run_detector_wiring_check():
+    from django_waf.checks import check_detector_wiring
+
+    return check_detector_wiring(app_configs=None)
+
+
 def _run_redis_backend_check():
     from django_waf.checks import check_redis_backend
 
@@ -586,6 +592,74 @@ class TestObserveOnlyDetectorNamesCheck:
 
         assert len(messages) == 1
         assert messages[0].id == "django_waf.W008"
+
+
+class TestDetectorWiringCheck:
+    """W009 warns when anomaly_detector.DETECTOR_NAMES and
+    DETECTOR_NAME_TO_RESULT_KEY disagree on membership (wave 2, #99's
+    sibling defect class): a detector hand-added to one dict and not the
+    other reads as a permanently silent detector to
+    django_waf_probe_detectors and the detector outcome report, rather
+    than the wiring bug it actually is.
+    """
+
+    def test_current_wiring_is_silent(self):
+        """The real, un-patched anomaly_detector module is the baseline
+        this check must pass against: if this fails, DETECTOR_NAMES and
+        DETECTOR_NAME_TO_RESULT_KEY have genuinely desynced in the
+        package, independent of anything this test class patches.
+        """
+        assert _run_detector_wiring_check() == []
+
+    def test_name_in_detector_names_missing_from_result_key_map_emits_w009(self):
+        """The more dangerous direction (see the check's own docstring):
+        a name added to DETECTOR_NAMES without a matching entry in
+        DETECTOR_NAME_TO_RESULT_KEY reads as a permanently silent detector
+        to run_detector_probe, indistinguishable from a genuinely dead one
+        without reading the code.
+        """
+        import django_waf.services.anomaly_detector as anomaly_detector_mod
+
+        broken_names = frozenset(anomaly_detector_mod.DETECTOR_NAMES | {"detect_phantom"})
+        with patch.object(anomaly_detector_mod, "DETECTOR_NAMES", broken_names):
+            messages = _run_detector_wiring_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W009"
+        assert "detect_phantom" in messages[0].msg
+
+    def test_result_key_entry_missing_from_detector_names_emits_w009(self):
+        """The reverse direction: a result-key entry with no matching
+        DETECTOR_NAMES member is invisible to W008 and observe-only mode
+        alike, with nothing else in the package catching it.
+        """
+        import django_waf.services.anomaly_detector as anomaly_detector_mod
+
+        broken_map = dict(anomaly_detector_mod.DETECTOR_NAME_TO_RESULT_KEY)
+        broken_map["detect_phantom"] = "phantom_rules"
+        with patch.object(anomaly_detector_mod, "DETECTOR_NAME_TO_RESULT_KEY", broken_map):
+            messages = _run_detector_wiring_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W009"
+        assert "detect_phantom" in messages[0].msg
+
+    def test_removing_a_name_from_the_result_key_map_also_trips_the_check(self):
+        """Confirmed falsifiable the other way too: dropping a real,
+        currently-wired name out of DETECTOR_NAME_TO_RESULT_KEY (rather
+        than adding a phantom one) reproduces the exact shape a careless
+        edit to the map would produce, and the check must still catch it.
+        """
+        import django_waf.services.anomaly_detector as anomaly_detector_mod
+
+        broken_map = dict(anomaly_detector_mod.DETECTOR_NAME_TO_RESULT_KEY)
+        del broken_map["detect_cloud_spray"]
+        with patch.object(anomaly_detector_mod, "DETECTOR_NAME_TO_RESULT_KEY", broken_map):
+            messages = _run_detector_wiring_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W009"
+        assert "detect_cloud_spray" in messages[0].msg
 
 
 class TestRedisBackendCheck:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -204,6 +204,46 @@ class TestDetectAnomaliesCommand:
         assert "No anomalies detected" in out.getvalue()
 
     @pytest.mark.django_db
+    def test_total_rules_created_key_is_not_double_counted(self):
+        """Issue #99: run_all_detectors' real return dict carries a
+        total_rules_created key ALONGSIDE the six per-detector keys (see
+        its own return statement). Before this fix, the command's
+        `for detector_name, rules_created in results.items()` loop iterated
+        that key too, printing it as if it were a seventh detector AND
+        adding its value a second time to total_created, exactly doubling
+        the reported total. A live run during the wave-2 investigation
+        printed "unsolved_challenge_rules: would create 2" then
+        "total_rules_created: would create 2" and concluded "Would have
+        created 4 rule(s)" for what was actually 2 real rules.
+
+        Uses the real int-shaped result dict run_all_detectors actually
+        returns (int counts, not lists of mock rule objects, unlike the
+        other tests in this class, which predate #99's own key and use a
+        two-key stand-in dict that never exercised this bug), so the
+        total_rules_created key is genuinely present, exactly as it always
+        is on a real call.
+        """
+        results = {
+            "ua_rotation_rules": 0,
+            "subnet_burst_rules": 0,
+            "challenge_farm_rules": 0,
+            "unsolved_challenge_rules": 2,
+            "cloud_spray_rules": 0,
+            "scraper_404_rules": 0,
+            "total_rules_created": 2,
+        }
+        mock_detect = self._autospec_detector(return_value=results)
+
+        with patch("django_waf.services.anomaly_detector.run_all_detectors", mock_detect):
+            out = StringIO()
+            call_command("django_waf_detect_anomalies", "--dry-run", stdout=out)
+
+        output = out.getvalue()
+        assert "Would have created 2 rule(s)." in output
+        assert "Would have created 4 rule(s)." not in output
+        assert "total_rules_created" not in output
+
+    @pytest.mark.django_db
     def test_service_exception_raises_command_error(self):
         """A service exception is converted to CommandError."""
         mock_detect = self._autospec_detector(side_effect=ValueError("bad window"))
@@ -396,6 +436,322 @@ class TestPruneChallengesCommand:
         call_command("django_waf_prune_challenges", "--hours=24", stdout=out)
 
         assert "Deleted 0 challenge token(s)" in out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# django_waf_prune_rules
+# ---------------------------------------------------------------------------
+
+
+class TestPruneRulesCommand:
+    """Tests for the ``django_waf_prune_rules`` management command.
+
+    The command inverts the other two prune commands' default: no flags
+    means report-only, ``--execute`` is required to actually delete. Every
+    test below therefore asserts the table is non-empty first (so a
+    survival assertion is never vacuous against an empty queryset), and at
+    least one test proves the predicate has teeth by inducing a genuine
+    deletion rather than only ever watching rows survive.
+    """
+
+    @staticmethod
+    def _stale_kwargs(days_expired: int = 100):
+        """Kwargs for a BlockRule that qualifies for deletion outright."""
+        from django_waf.enums import ReviewStatus, RuleSource
+
+        return {
+            "source": RuleSource.AUTO,
+            "is_active": False,
+            "expires_at": timezone.now() - timezone.timedelta(days=days_expired),
+            "review_status": ReviewStatus.NOT_APPLICABLE,
+        }
+
+    @pytest.mark.django_db
+    def test_dry_run_is_the_default_and_deletes_nothing(self):
+        """No flags at all: reports the count, deletes nothing."""
+        from django_waf.testing.factories import BlockRuleFactory
+
+        BlockRuleFactory(**self._stale_kwargs())
+        BlockRuleFactory(**self._stale_kwargs())
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 2
+
+        out = StringIO()
+        call_command("django_waf_prune_rules", "--days=90", stdout=out)
+
+        assert BlockRule.objects.count() == 2
+        output = out.getvalue()
+        assert "dry-run" in output
+        assert "2 block rule(s)" in output
+        assert "--execute" in output
+
+    @pytest.mark.django_db
+    def test_explicit_dry_run_flag_matches_default(self):
+        """--dry-run is accepted as a no-op synonym for the default behaviour."""
+        from django_waf.testing.factories import BlockRuleFactory
+
+        BlockRuleFactory(**self._stale_kwargs())
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        out = StringIO()
+        call_command("django_waf_prune_rules", "--dry-run", "--days=90", stdout=out)
+
+        assert BlockRule.objects.count() == 1
+        assert "1 block rule(s)" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_execute_deletes_matching_rows(self):
+        """--execute performs the deletion the dry-run count promised.
+
+        Proves the predicate has teeth: a genuinely stale row is actually
+        removed by a real run, not merely reported.
+        """
+        from django_waf.testing.factories import BlockRuleFactory
+
+        stale = BlockRuleFactory(**self._stale_kwargs())
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        dry_run_out = StringIO()
+        call_command("django_waf_prune_rules", "--days=90", stdout=dry_run_out)
+        assert "1 block rule(s)" in dry_run_out.getvalue()
+        assert BlockRule.objects.filter(pk=stale.pk).exists()
+
+        execute_out = StringIO()
+        call_command("django_waf_prune_rules", "--days=90", "--execute", stdout=execute_out)
+
+        assert not BlockRule.objects.filter(pk=stale.pk).exists()
+        assert "Deleted 1 block rule(s)" in execute_out.getvalue()
+
+    @pytest.mark.django_db
+    def test_active_rule_survives_execute(self):
+        """An active rule is never deleted, even with --execute."""
+        from django_waf.testing.factories import BlockRuleFactory
+
+        kwargs = self._stale_kwargs()
+        kwargs["is_active"] = True
+        active = BlockRuleFactory(**kwargs)
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert BlockRule.objects.filter(pk=active.pk).exists()
+
+    @pytest.mark.django_db
+    def test_unexpired_rule_survives_execute(self):
+        """A rule whose expiry has not passed is never deleted."""
+        from django_waf.testing.factories import BlockRuleFactory
+
+        kwargs = self._stale_kwargs()
+        kwargs["expires_at"] = timezone.now() + timezone.timedelta(days=1)
+        unexpired = BlockRuleFactory(**kwargs)
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert BlockRule.objects.filter(pk=unexpired.pk).exists()
+
+    @pytest.mark.django_db
+    def test_pending_review_rule_survives_execute(self):
+        """A rule still PENDING review is never deleted."""
+        from django_waf.enums import ReviewStatus
+        from django_waf.testing.factories import BlockRuleFactory
+
+        kwargs = self._stale_kwargs()
+        kwargs["review_status"] = ReviewStatus.PENDING
+        pending = BlockRuleFactory(**kwargs)
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert BlockRule.objects.filter(pk=pending.pk).exists()
+
+    @pytest.mark.django_db
+    def test_confirmed_rule_survives_execute(self):
+        """A rule an operator CONFIRMED is never deleted."""
+        from django_waf.enums import ReviewStatus
+        from django_waf.testing.factories import BlockRuleFactory
+
+        kwargs = self._stale_kwargs()
+        kwargs["review_status"] = ReviewStatus.CONFIRMED
+        confirmed = BlockRuleFactory(**kwargs)
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert BlockRule.objects.filter(pk=confirmed.pk).exists()
+
+    @pytest.mark.django_db
+    def test_rejected_rule_survives_execute(self):
+        """A rule an operator REJECTED is never deleted.
+
+        Deliberate: a rejection is a decision the operator already made
+        once. Deleting the row loses the record of that decision, so the
+        next time a detector re-observes the same pattern it recreates the
+        rule and the operator has to reject it again.
+        """
+        from django_waf.enums import ReviewStatus
+        from django_waf.testing.factories import BlockRuleFactory
+
+        kwargs = self._stale_kwargs()
+        kwargs["review_status"] = ReviewStatus.REJECTED
+        rejected = BlockRuleFactory(**kwargs)
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert BlockRule.objects.filter(pk=rejected.pk).exists()
+
+    @pytest.mark.django_db
+    def test_expired_unreviewed_rule_is_deleted_by_execute(self):
+        """An EXPIRED_UNREVIEWED rule IS deleted: the counterpart to the REJECTED test above.
+
+        expire_rules (BR-ANOM-010) moves a rule here when it was PENDING
+        and its expires_at passed with nobody reviewing it. Unlike
+        REJECTED, nobody made an explicit decision about the pattern, so
+        there is no operator judgement to preserve and this row is safe to
+        reclaim once stale.
+        """
+        from django_waf.enums import ReviewStatus
+        from django_waf.testing.factories import BlockRuleFactory
+
+        kwargs = self._stale_kwargs()
+        kwargs["review_status"] = ReviewStatus.EXPIRED_UNREVIEWED
+        expired_unreviewed = BlockRuleFactory(**kwargs)
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert not BlockRule.objects.filter(pk=expired_unreviewed.pk).exists()
+
+    @pytest.mark.django_db
+    def test_admin_sourced_rule_survives_execute(self):
+        """A hand-authored admin rule is never deleted regardless of age or state.
+
+        source scoping is deliberate: an operator's own rule is not the
+        self-regenerating auto-detector output this retention path exists
+        to bound.
+        """
+        from django_waf.enums import ReviewStatus
+        from django_waf.enums import RuleSource as RuleSourceEnum
+        from django_waf.testing.factories import BlockRuleFactory
+
+        admin_rule = BlockRuleFactory(
+            source=RuleSourceEnum.ADMIN,
+            is_active=False,
+            expires_at=timezone.now() - timezone.timedelta(days=100),
+            review_status=ReviewStatus.NOT_APPLICABLE,
+        )
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert BlockRule.objects.filter(pk=admin_rule.pk).exists()
+
+    @pytest.mark.django_db
+    def test_feed_sourced_rule_survives_execute(self):
+        """A feed-sourced rule is never deleted regardless of age or state."""
+        from django_waf.enums import ReviewStatus
+        from django_waf.enums import RuleSource as RuleSourceEnum
+        from django_waf.testing.factories import BlockRuleFactory
+
+        feed_rule = BlockRuleFactory(
+            source=RuleSourceEnum.FEED,
+            is_active=False,
+            expires_at=timezone.now() - timezone.timedelta(days=100),
+            review_status=ReviewStatus.NOT_APPLICABLE,
+        )
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert BlockRule.objects.filter(pk=feed_rule.pk).exists()
+
+    @pytest.mark.django_db
+    def test_window_boundary_just_inside_survives_and_just_outside_is_deleted(self):
+        """A row just inside the retention window survives; just outside is deleted."""
+        from django_waf.testing.factories import BlockRuleFactory
+
+        cutoff = timezone.now() - timezone.timedelta(days=90)
+        just_inside = BlockRuleFactory(**{**self._stale_kwargs(), "expires_at": cutoff + timezone.timedelta(hours=1)})
+        just_outside = BlockRuleFactory(**{**self._stale_kwargs(), "expires_at": cutoff - timezone.timedelta(hours=1)})
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 2
+
+        call_command("django_waf_prune_rules", "--days=90", "--execute")
+
+        assert BlockRule.objects.filter(pk=just_inside.pk).exists()
+        assert not BlockRule.objects.filter(pk=just_outside.pk).exists()
+
+    @pytest.mark.django_db
+    def test_zero_days_raises_command_error(self):
+        """--days=0 is rejected with a CommandError."""
+        with pytest.raises(CommandError, match="positive integer"):
+            call_command("django_waf_prune_rules", "--days=0")
+
+    @pytest.mark.django_db
+    def test_no_stale_rules_reports_zero(self):
+        """When nothing is stale the dry-run reports zero."""
+        from django_waf.testing.factories import BlockRuleFactory
+
+        BlockRuleFactory()  # active, admin, default factory state, not stale
+
+        out = StringIO()
+        call_command("django_waf_prune_rules", "--days=90", stdout=out)
+
+        assert "0 block rule(s)" in out.getvalue()
+
+    @pytest.mark.django_db
+    def test_default_retention_uses_conf_value(self):
+        """When --days is omitted the command reads DJANGO_WAF_RULE_RETENTION_DAYS from conf."""
+        from django_waf import conf
+        from django_waf.testing.factories import BlockRuleFactory
+
+        default_days = conf.DJANGO_WAF_RULE_RETENTION_DAYS
+        kwargs = self._stale_kwargs()
+        kwargs["expires_at"] = timezone.now() - timezone.timedelta(days=default_days + 1)
+        stale = BlockRuleFactory(**kwargs)
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        call_command("django_waf_prune_rules", "--execute")
+
+        assert not BlockRule.objects.filter(pk=stale.pk).exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -60,6 +60,7 @@ class TestCeleryBeatScheduleDefault:
             "django_waf.tasks.update_ip_reputation",
             "django_waf.tasks.prune_request_logs",
             "django_waf.tasks.prune_challenge_tokens",
+            "django_waf.tasks.prune_stale_rules",
             "django_waf.tasks.sync_threat_feed",
             "django_waf.tasks.report_threat_telemetry",
             "django_waf.tasks.update_geoip_database",

--- a/tests/test_detector_outcomes.py
+++ b/tests/test_detector_outcomes.py
@@ -1,0 +1,420 @@
+"""Tests for the detector production-outcome report (wave 2, BR-ANOM-015).
+
+Covers ``services.detector_outcomes.report_detector_outcomes`` and the
+``django_waf_detector_outcomes`` management command.
+
+House discipline, mirroring ``tests/test_review_workflow.py``'s
+``TestAutoRuleReviewOutcomes`` and ``tests/test_flush_probe.py``: every
+assertion here must be provably falsifiable. A zero-filled row is only
+evidence of zero-filling if the same test also proves a non-zero row is
+reachable; a "name outside the registry" assertion is only evidence if a
+registered name is also proven NOT to leak into that section; a window
+boundary assertion is only evidence when both a just-inside and a
+just-outside row are present in the same test.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from django_waf.enums import RuleSource
+from django_waf.services.anomaly_detector import DETECTOR_NAMES
+from django_waf.testing.factories import BlockRuleFactory
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Zero-filling
+# ---------------------------------------------------------------------------
+
+
+class TestZeroFilling:
+    def test_every_registered_detector_appears_even_with_no_rules_at_all(self):
+        """No BlockRule rows exist anywhere: every DETECTOR_NAMES entry must
+        still appear as an explicit zero row, never be omitted. Proves the
+        zero-fill happens independent of any row in the table."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        result = report_detector_outcomes()
+
+        assert set(result["detectors"]) == DETECTOR_NAMES
+        for stats in result["detectors"].values():
+            assert stats == {
+                "rules_created": 0,
+                "rules_ever_hit": 0,
+                "hit_rate": 0.0,
+                "total_hits": 0,
+                "most_recent_rule_created": None,
+            }
+
+    def test_a_silent_detector_is_zero_filled_alongside_a_productive_one(self):
+        """The case this whole report exists for: one detector produces
+        real rules, a sibling detector produces nothing. The silent one
+        must still appear as an explicit zero row rather than being absent,
+        proven here by asserting BOTH outcomes in the same result rather
+        than a report built from an all-empty table (which the previous
+        test already covers and cannot distinguish "correctly zero" from
+        "the whole mechanism is a no-op")."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_cloud_spray", hit_count=5)
+
+        result = report_detector_outcomes()
+
+        assert result["detectors"]["detect_cloud_spray"]["rules_created"] == 1
+        # detect_subnet_burst produced nothing: must still be present, zeroed.
+        assert result["detectors"]["detect_subnet_burst"] == {
+            "rules_created": 0,
+            "rules_ever_hit": 0,
+            "hit_rate": 0.0,
+            "total_hits": 0,
+            "most_recent_rule_created": None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Hit rate arithmetic
+# ---------------------------------------------------------------------------
+
+
+class TestHitRateArithmetic:
+    def test_mixed_hit_and_never_hit_rules_compute_the_correct_rate_and_total(self):
+        """Three rules attributed to one detector: two ever hit (hit_count
+        > 0), one never hit (hit_count == 0). Asserts rules_created,
+        rules_ever_hit, hit_rate and total_hits are all independently
+        correct, not just that hit_rate is "truthy"."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_subnet_burst", hit_count=10)
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_subnet_burst", hit_count=7)
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_subnet_burst", hit_count=0)
+
+        result = report_detector_outcomes()
+        stats = result["detectors"]["detect_subnet_burst"]
+
+        assert stats["rules_created"] == 3
+        assert stats["rules_ever_hit"] == 2
+        # hit_rate is rounded to 4 decimal places by the service (its own
+        # documented contract), so the tolerance here is half a unit in the
+        # last reported place rather than pytest.approx's relative default:
+        # tight enough that a genuinely wrong rate (1/3, 2/2) still fails.
+        assert stats["hit_rate"] == pytest.approx(2 / 3, abs=5e-5)
+        assert stats["total_hits"] == 17
+
+    def test_zero_created_never_raises_zero_division(self):
+        """A detector with rules_created == 0 must report hit_rate == 0.0,
+        never raise ZeroDivisionError. Already implied by the zero-fill
+        tests above but pinned explicitly since this is the exact failure
+        mode a naive rules_ever_hit / rules_created would hit."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        result = report_detector_outcomes()
+
+        assert result["detectors"]["detect_challenge_farms"]["hit_rate"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Names outside DETECTOR_NAMES
+# ---------------------------------------------------------------------------
+
+
+class TestUnregisteredDetectorNames:
+    def test_challenge_escalation_appears_in_its_own_section_not_dropped_not_merged(self):
+        """challenge_escalation is written to BlockRule.detectors by
+        rule_engine._create_escalation_rule but is not a DETECTOR_NAMES
+        member (tests/test_services.py:4064-4082). It must appear in
+        unregistered_detectors, with correct stats, and must NOT appear
+        inside the registered `detectors` section (which would misrepresent
+        it as a seventh detector) and must NOT be silently absent from the
+        whole report (which would discard real provenance data)."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="challenge_escalation", hit_count=3)
+
+        result = report_detector_outcomes()
+
+        assert "challenge_escalation" not in DETECTOR_NAMES  # sanity: the premise still holds
+        assert "challenge_escalation" not in result["detectors"]
+        assert result["unregistered_detectors"]["challenge_escalation"] == {
+            "rules_created": 1,
+            "rules_ever_hit": 1,
+            "hit_rate": 1.0,
+            "total_hits": 3,
+            "most_recent_rule_created": result["unregistered_detectors"]["challenge_escalation"][
+                "most_recent_rule_created"
+            ],
+        }
+        assert result["unregistered_detectors"]["challenge_escalation"]["most_recent_rule_created"] is not None
+
+    def test_no_unregistered_section_entries_when_only_registered_names_are_present(self):
+        """Negative control for the test above: a table containing only
+        registered DETECTOR_NAMES rows must leave unregistered_detectors
+        empty, proving the section is not populated unconditionally."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_cloud_spray")
+
+        result = report_detector_outcomes()
+
+        assert result["unregistered_detectors"] == {}
+
+    def test_a_rule_stamped_by_both_a_registered_and_an_unregistered_detector_counts_in_both(self):
+        """detectors is additive (#97): a single row can carry both a
+        registered and an unregistered name at once, e.g. a rule
+        detect_subnet_burst created that rule_engine later escalated.
+        Both sides must count it independently."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        BlockRuleFactory(
+            source=RuleSource.AUTO,
+            detectors="challenge_escalation,detect_subnet_burst",
+            hit_count=4,
+        )
+
+        result = report_detector_outcomes()
+
+        assert result["detectors"]["detect_subnet_burst"]["rules_created"] == 1
+        assert result["unregistered_detectors"]["challenge_escalation"]["rules_created"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Window boundary
+# ---------------------------------------------------------------------------
+
+
+class TestWindowBoundary:
+    def test_a_rule_just_inside_the_window_counts_a_rule_just_outside_does_not(self):
+        """window_days=30: one rule created 29 days ago (inside) and one
+        created 31 days ago (outside), both attributed to the same
+        detector. Only the inside rule may be counted, proven by asserting
+        the exact count is 1, not merely "> 0"."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        now = timezone.now()
+        inside = BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_ua_rotation", hit_count=1)
+        outside = BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_ua_rotation", hit_count=1)
+
+        # created_at has auto_now_add=True: back-date via a direct update,
+        # matching the idiom used elsewhere in this suite for testing
+        # window boundaries against an auto_now_add field.
+        from django_waf.models import BlockRule
+
+        BlockRule.objects.filter(pk=inside.pk).update(created_at=now - timedelta(days=29))
+        BlockRule.objects.filter(pk=outside.pk).update(created_at=now - timedelta(days=31))
+
+        result = report_detector_outcomes(window_days=30)
+        stats = result["detectors"]["detect_ua_rotation"]
+
+        assert stats["rules_created"] == 1
+        assert stats["total_hits"] == 1
+
+    def test_most_recent_rule_created_reflects_the_latest_row_in_window(self):
+        from django_waf.models import BlockRule
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        now = timezone.now()
+        older = BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_scraper_404_ratio")
+        newer = BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_scraper_404_ratio")
+
+        BlockRule.objects.filter(pk=older.pk).update(created_at=now - timedelta(days=20))
+        BlockRule.objects.filter(pk=newer.pk).update(created_at=now - timedelta(days=1))
+
+        result = report_detector_outcomes(window_days=30)
+        stats = result["detectors"]["detect_scraper_404_ratio"]
+
+        newer.refresh_from_db()
+        assert stats["most_recent_rule_created"] == newer.created_at
+
+    def test_window_days_must_be_positive(self):
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        with pytest.raises(ValueError):
+            report_detector_outcomes(window_days=0)
+
+
+# ---------------------------------------------------------------------------
+# Comma-separated parsing: no prefix collision
+# ---------------------------------------------------------------------------
+
+
+class TestCommaSeparatedParsingNoPrefixCollision:
+    def test_a_hypothetical_v2_suffixed_name_does_not_match_its_prefix(self):
+        """detectors is comma-separated, not a blob to substring-match. A
+        row stamped only "detect_cloud_spray_v2" must not be counted
+        against detect_cloud_spray: proves parsing is exact-membership on
+        the split set, not `in` on the raw string. (detect_cloud_spray_v2
+        does not exist as a real detector; it stands in for any future name
+        sharing a prefix with a registered one, exactly the trap __contains
+        would fall into.)"""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_cloud_spray_v2", hit_count=9)
+
+        result = report_detector_outcomes()
+
+        assert result["detectors"]["detect_cloud_spray"]["rules_created"] == 0
+        assert result["detectors"]["detect_cloud_spray"]["total_hits"] == 0
+        # The unrecognised prefix-colliding name must still surface somewhere
+        # rather than vanish: it lands in unregistered_detectors, exactly
+        # like any other name outside DETECTOR_NAMES.
+        assert result["unregistered_detectors"]["detect_cloud_spray_v2"]["rules_created"] == 1
+
+    def test_the_real_name_still_counts_when_a_colliding_name_is_also_present(self):
+        """Positive control for the test above: with both
+        detect_cloud_spray and detect_cloud_spray_v2 present on different
+        rows, detect_cloud_spray's own count must be exactly the rows that
+        genuinely carry it, proving the collision test isn't passing only
+        because detect_cloud_spray was never reachable at all."""
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_cloud_spray", hit_count=2)
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_cloud_spray_v2", hit_count=9)
+
+        result = report_detector_outcomes()
+
+        assert result["detectors"]["detect_cloud_spray"]["rules_created"] == 1
+        assert result["detectors"]["detect_cloud_spray"]["total_hits"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Review outcomes reuse
+# ---------------------------------------------------------------------------
+
+
+class TestReviewOutcomesReuse:
+    def test_review_outcomes_key_reflects_real_rule_state(self):
+        """Not a stub: report_detector_outcomes must call the real
+        auto_rule_review_outcomes and surface its real counts, proven by
+        creating a PENDING auto rule and asserting it is reflected."""
+        from django_waf.enums import ReviewStatus
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        BlockRuleFactory(
+            source=RuleSource.AUTO,
+            review_status=ReviewStatus.PENDING,
+            detectors="detect_unsolved_challenges",
+        )
+
+        result = report_detector_outcomes()
+
+        assert result["review_outcomes"]["pending"] == 1
+        assert result["review_outcomes"]["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Read-only
+# ---------------------------------------------------------------------------
+
+
+class TestReadOnly:
+    def test_running_the_report_creates_no_rows_and_changes_no_existing_row(self):
+        from django_waf.models import BlockRule
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        rule = BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_cloud_spray", hit_count=5)
+        before_count = BlockRule.objects.count()
+        before_hit_count = rule.hit_count
+
+        report_detector_outcomes()
+        report_detector_outcomes(window_days=1)
+
+        rule.refresh_from_db()
+        assert BlockRule.objects.count() == before_count
+        assert rule.hit_count == before_hit_count
+
+
+# ---------------------------------------------------------------------------
+# Management command
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorOutcomesCommand:
+    def test_command_reports_every_registered_detector_by_name(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("django_waf_detector_outcomes", stdout=out)
+        output = out.getvalue()
+
+        for name in DETECTOR_NAMES:
+            assert name in output
+
+    def test_command_surfaces_unregistered_names_in_their_own_section(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        BlockRuleFactory(source=RuleSource.AUTO, detectors="challenge_escalation")
+
+        out = StringIO()
+        call_command("django_waf_detector_outcomes", stdout=out)
+        output = out.getvalue()
+
+        assert "challenge_escalation" in output
+        assert "outside anomaly_detector.DETECTOR_NAMES" in output
+
+    def test_command_accepts_a_days_argument(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        out = StringIO()
+        call_command("django_waf_detector_outcomes", "--days", "7", stdout=out)
+
+        assert "last 7 day(s)" in out.getvalue()
+
+    def test_command_rejects_a_non_positive_days_argument(self):
+        from django.core.management import call_command
+        from django.core.management.base import CommandError
+
+        with pytest.raises(CommandError):
+            call_command("django_waf_detector_outcomes", "--days", "0")
+
+
+class TestQueryCost:
+    """Pins the report's query count so the module docstring's cost claim
+    cannot silently rot into an N+1.
+
+    The docstring states two queries: one scan for the per-detector
+    aggregate, plus the single GROUP BY ``auto_rule_review_outcomes``
+    (BR-ANOM-010) issues for the review-outcome section. That claim was
+    measured with ``CaptureQueriesContext``, not asserted, and this test is
+    what keeps it measured. A future refactor that moved the per-detector
+    aggregate back to one LIKE-filtered query per registry entry would
+    take the count to eight and fail here, which is the whole point: the
+    plan flagged per-detector query cost as a real risk against a
+    production table of roughly 54,000 rows.
+    """
+
+    @pytest.mark.django_db
+    def test_report_issues_a_constant_number_of_queries(self):
+        """The query count must not scale with the number of rules."""
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from django_waf.services.detector_outcomes import report_detector_outcomes
+
+        for index in range(3):
+            BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_subnet_burst", hit_count=index)
+
+        with CaptureQueriesContext(connection) as few_rows:
+            report_detector_outcomes()
+
+        for index in range(30):
+            BlockRuleFactory(source=RuleSource.AUTO, detectors="detect_cloud_spray", hit_count=index)
+
+        with CaptureQueriesContext(connection) as many_rows:
+            result = report_detector_outcomes()
+
+        # Non-vacuous: the second run really did see the extra rows, so a
+        # constant query count is evidence of constant cost rather than
+        # evidence that neither run read anything.
+        assert result["detectors"]["detect_cloud_spray"]["rules_created"] == 30
+        assert len(few_rows) == 2
+        assert len(many_rows) == 2

--- a/tests/test_detector_probe.py
+++ b/tests/test_detector_probe.py
@@ -28,13 +28,16 @@ real query path, for every detector it names, is worth nothing.
 
 from __future__ import annotations
 
+from datetime import timedelta
 from io import StringIO
 from unittest.mock import patch
 
 import pytest
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from django.utils import timezone
 
+from django_waf.enums import MatchType, ReviewStatus, RuleAction, RuleSource, RuleType
 from django_waf.services.anomaly_detector import DETECTOR_NAMES
 from django_waf.services.detector_probe import run_detector_probe
 
@@ -393,6 +396,165 @@ class TestRunDetectorProbeFalsifiability:
             assert result[detector_name]["rules_reported"] > 0
 
 
+# ---------------------------------------------------------------------------
+# run_detector_probe: BlockRule history must not silence a healthy detector
+# ---------------------------------------------------------------------------
+#
+# Reproduces the real defect this step of the wave fixes: a real deployment
+# accumulates BlockRule rows over its lifetime, and _get_or_create_auto_
+# rule's dry-run existence check (anomaly_detector.py) matches on
+# (rule_type, pattern, source=AUTO, action) alone, with no is_active or
+# expires_at filter. Before this fix, ANY surviving source=AUTO row on a
+# fixture's exact pattern, however old or inactive, made
+# _get_or_create_auto_rule report created=False forever, which made the
+# probe report a genuinely firing detector as SILENT. This is the
+# reproduction the plan's Step 1 investigation confirmed by hand
+# (seeding a single expired+inactive row silenced detect_cloud_spray,
+# detect_ua_rotation, and detect_scraper_404_ratio simultaneously); the
+# tests below turn that manual reproduction into a permanent, parametrised
+# regression guard, one case per detector, plus a control proving the fix
+# has not made the probe blind to a genuinely broken detector.
+
+
+class TestRunDetectorProbeSurvivesBlockRuleHistory:
+    """One parametrised case per DETECTOR_NAMES entry: seed an expired,
+    inactive source=AUTO BlockRule on every exact (rule_type, pattern,
+    action) shape that detector's own probe fixture is about to drive, then
+    assert the detector still reports alive. Each row below is
+    independently hand-written against services/detector_probe.py's
+    fixture IPs/subnets and services/anomaly_detector.py's own
+    rule_type/action literals for each detector's _get_or_create_auto_rule
+    call, not derived from either module, so a drift between this list and
+    the real fixture shapes would show up as a test failure (a seeded
+    collision on the wrong pattern would simply never collide, and the
+    detector would report alive whether or not this fix exists, which is
+    exactly the kind of vacuous coverage this test is written to avoid:
+    see the falsifiability class above for why every case here must also
+    be provable to fail without the fix, checked directly below in
+    test_seeding_a_collision_without_the_fix_reproduces_the_defect).
+
+    detect_subnet_burst genuinely needs BOTH of its rows seeded to make the
+    control test meaningful: its query aggregates every RequestLog row in
+    the probe's fixture window regardless of which detector's fixture
+    wrote it (see detector_probe.py's own module comment), so the combined
+    volume from three OTHER detectors' fixture IPs sharing 192.0.2.0/24
+    (_UA_ROTATION_IP, _UNSOLVED_CHALLENGE_IP, _SCRAPER_404_IP) already
+    clears its burst floor on its own, independently of
+    _SUBNET_BURST_SUBNET_BASE (198.51.100.0/24). A control that seeded
+    only the 198.51.100.0/24 collision left the 192.0.2.0/24 rule free to
+    create normally, so detect_subnet_burst kept reporting alive even with
+    the fix reverted, a genuinely vacuous control caught by running it
+    against the real code before trusting it.
+    """
+
+    # detector_name -> list of (rule_type, match_type, pattern, action)
+    # rows, one entry per BlockRule shape that detector's
+    # _get_or_create_auto_rule calls write against the fixture traffic
+    # _build_fixture_traffic() builds for it. detect_cloud_spray's row here
+    # is its subnet path only (the UA path is opt-in via
+    # DJANGO_WAF_CLOUD_SPRAY_UA_RULE, default off, and is not exercised by
+    # the probe on default settings, per this wave's Step 1 finding).
+    _COLLIDING_FIXTURE_ROWS: dict[str, list[tuple]] = {
+        "detect_ua_rotation": [
+            (RuleType.IP, MatchType.EXACT, "192.0.2.10", RuleAction.CHALLENGE),
+        ],
+        "detect_subnet_burst": [
+            (RuleType.CIDR, MatchType.CIDR, "198.51.100.0/24", RuleAction.CHALLENGE),
+            (RuleType.CIDR, MatchType.CIDR, "192.0.2.0/24", RuleAction.CHALLENGE),
+        ],
+        "detect_challenge_farms": [
+            (RuleType.IP, MatchType.EXACT, "203.0.113.10", RuleAction.BLOCK),
+        ],
+        "detect_unsolved_challenges": [
+            (RuleType.IP, MatchType.EXACT, "192.0.2.50", RuleAction.BLOCK),
+        ],
+        "detect_cloud_spray": [
+            (RuleType.CIDR, MatchType.CIDR, "203.0.113.0/24", RuleAction.CHALLENGE),
+        ],
+        "detect_scraper_404_ratio": [
+            (RuleType.IP, MatchType.EXACT, "192.0.2.90", RuleAction.CHALLENGE),
+        ],
+    }
+
+    @staticmethod
+    def _seed_colliding_rows(detector_name: str) -> None:
+        from django_waf.testing.factories import BlockRuleFactory
+
+        colliding_rows = TestRunDetectorProbeSurvivesBlockRuleHistory._COLLIDING_FIXTURE_ROWS[detector_name]
+        for rule_type, match_type, pattern, action in colliding_rows:
+            BlockRuleFactory(
+                rule_type=rule_type,
+                match_type=match_type,
+                pattern=pattern,
+                action=action,
+                source=RuleSource.AUTO,
+                is_active=False,
+                review_status=ReviewStatus.NOT_APPLICABLE,
+                expires_at=timezone.now() - timedelta(days=365),
+            )
+
+    @pytest.mark.parametrize("detector_name", sorted(_COLLIDING_FIXTURE_ROWS))
+    def test_expired_inactive_auto_rule_does_not_silence_the_detector(self, db, detector_name):
+        """An expired, inactive source=AUTO BlockRule sitting on a
+        detector's exact fixture pattern must not make that detector
+        report SILENT: the row is history, not evidence the detector is
+        dead.
+
+        Expired 365 days ago AND is_active=False is deliberately the
+        least favourable surviving row for the OLD (unfixed) behaviour to
+        get right: it is exactly the shape a real deployment accumulates
+        once DJANGO_WAF_RULE_RETENTION_DAYS-style pruning has not yet run
+        (retention is a separate step of this wave, not shipped here), and
+        it is unambiguously not a live enforcing rule by any reading, yet
+        the unfiltered dry-run lookup in _get_or_create_auto_rule matched
+        it anyway before this fix.
+        """
+        self._seed_colliding_rows(detector_name)
+
+        result = run_detector_probe(dry_run=True)
+
+        assert result[detector_name]["alive"] is True, (
+            f"{detector_name} reported SILENT with a stale BlockRule collision present: {result[detector_name]}"
+        )
+        assert result[detector_name]["rules_reported"] > 0
+
+    @pytest.mark.parametrize("detector_name", sorted(_COLLIDING_FIXTURE_ROWS))
+    def test_seeding_a_collision_without_the_fix_reproduces_the_defect(self, db, detector_name):
+        """Proves the case above is not vacuous: with
+        count_refresh_as_created forced back to its old always-False
+        behaviour, the identical seeded row(s) DO silence the detector.
+
+        This is the direct analogue of the plan's Step 1 manual
+        reproduction, reproduced here as an automated control rather than
+        asserted only by inspection. Patches run_all_detectors to strip
+        the keyword before forwarding to the real function, rather than
+        patching _get_or_create_auto_rule directly, so every real detector
+        query and the real fixture-building path still execute unmodified;
+        only the one line this fix touches is reverted.
+        """
+        from django_waf.services import anomaly_detector as anomaly_detector_mod
+
+        self._seed_colliding_rows(detector_name)
+
+        real_run_all_detectors = anomaly_detector_mod.run_all_detectors
+
+        def _run_all_detectors_ignoring_the_fix(*args, **kwargs):
+            kwargs["count_refresh_as_created"] = False
+            return real_run_all_detectors(*args, **kwargs)
+
+        with patch(
+            "django_waf.services.anomaly_detector.run_all_detectors",
+            side_effect=_run_all_detectors_ignoring_the_fix,
+        ):
+            result = run_detector_probe(dry_run=True)
+
+        assert result[detector_name]["alive"] is False, (
+            f"{detector_name} reported alive even with count_refresh_as_created reverted; "
+            "this case cannot prove the fix has teeth."
+        )
+        assert result[detector_name]["rules_reported"] == 0
+
+
 class TestRunDetectorProbeReportingLogic:
     """Mapping/reporting-logic tests: a hand-written run_all_detectors result
     dict becomes the correct alive/silent report. These do NOT exercise any
@@ -524,6 +686,11 @@ class TestRunDetectorProbeLeavesNoRowsBehind:
 
 class TestRunDetectorProbeDryRunForwarding:
     def test_dry_run_true_is_forwarded_to_run_all_detectors(self, db):
+        """count_refresh_as_created=True is also asserted here, always,
+        regardless of dry_run: it is the probe's own opt-in (see
+        run_detector_probe's call site), never forwarded from the
+        function's dry_run argument, so it must appear unconditionally.
+        """
         from django_waf.services.anomaly_detector import DETECTOR_NAME_TO_RESULT_KEY
 
         with patch(
@@ -532,9 +699,15 @@ class TestRunDetectorProbeDryRunForwarding:
         ) as mock_run:
             run_detector_probe(dry_run=True)
 
-        mock_run.assert_called_once_with(dry_run=True)
+        mock_run.assert_called_once_with(dry_run=True, count_refresh_as_created=True)
 
     def test_dry_run_false_exercise_writes_is_forwarded(self, db):
+        """count_refresh_as_created=True still holds under exercise-writes:
+        it only ever changes what counts as "created" for the probe's own
+        reporting, never whether a write happens, and the surrounding
+        forced rollback in run_detector_probe makes exercise-writes safe
+        either way.
+        """
         from django_waf.services.anomaly_detector import DETECTOR_NAME_TO_RESULT_KEY
 
         with patch(
@@ -543,7 +716,7 @@ class TestRunDetectorProbeDryRunForwarding:
         ) as mock_run:
             run_detector_probe(dry_run=False)
 
-        mock_run.assert_called_once_with(dry_run=False)
+        mock_run.assert_called_once_with(dry_run=False, count_refresh_as_created=True)
 
     def test_result_dry_run_key_echoes_argument(self, db):
         result_true = run_detector_probe(dry_run=True)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from django_waf.enums import (
     ChallengeStatus,
     MatchType,
+    ReviewStatus,
     RuleAction,
     RuleSource,
     RuleType,
@@ -170,6 +171,108 @@ class TestBlockRule:
 
         assert qs.count() == 1
         assert qs.first().pk == nginx_eligible.pk
+
+    # -----------------------------------------------------------------
+    # stale(), wave 2 retention predicate (the wave 2 rule-provenance plan)
+    # -----------------------------------------------------------------
+    #
+    # Every test below builds the one row that should qualify (via
+    # _stale_kwargs) plus one row that differs by exactly the field under
+    # test, so a failure isolates which clause of the predicate broke
+    # rather than only proving the predicate is non-empty.
+
+    @staticmethod
+    def _stale_kwargs(days_expired: int = 100):
+        return {
+            "source": RuleSource.AUTO,
+            "is_active": False,
+            "expires_at": timezone.now() - timezone.timedelta(days=days_expired),
+            "review_status": ReviewStatus.NOT_APPLICABLE,
+        }
+
+    def test_stale_returns_qualifying_auto_rule(self, db):
+        """A genuinely stale row (expired, inactive, auto, not_applicable) is returned."""
+        stale = BlockRuleFactory(**self._stale_kwargs())
+
+        qs = BlockRule.objects.stale(days=90)
+
+        assert qs.count() == 1
+        assert qs.first().pk == stale.pk
+
+    def test_stale_excludes_active(self, db):
+        """An active rule is excluded regardless of age."""
+        BlockRuleFactory(**{**self._stale_kwargs(), "is_active": True})
+
+        assert BlockRule.objects.stale(days=90).count() == 0
+
+    def test_stale_excludes_unexpired(self, db):
+        """A rule whose expires_at has not passed is excluded."""
+        BlockRuleFactory(**{**self._stale_kwargs(), "expires_at": timezone.now() + timezone.timedelta(days=1)})
+
+        assert BlockRule.objects.stale(days=90).count() == 0
+
+    def test_stale_excludes_never_expires(self, db):
+        """A rule with expires_at=None is excluded even when inactive.
+
+        The only way a source=AUTO, is_active=False row reaches
+        expires_at=None is BR-ANOM-007's quarantine-on-create path, which
+        means "awaiting review", not "safe to reclaim".
+        """
+        BlockRuleFactory(**{**self._stale_kwargs(), "expires_at": None})
+
+        assert BlockRule.objects.stale(days=90).count() == 0
+
+    def test_stale_excludes_pending_review(self, db):
+        """A PENDING rule is excluded."""
+        BlockRuleFactory(**{**self._stale_kwargs(), "review_status": ReviewStatus.PENDING})
+
+        assert BlockRule.objects.stale(days=90).count() == 0
+
+    def test_stale_excludes_confirmed(self, db):
+        """A CONFIRMED rule is excluded."""
+        BlockRuleFactory(**{**self._stale_kwargs(), "review_status": ReviewStatus.CONFIRMED})
+
+        assert BlockRule.objects.stale(days=90).count() == 0
+
+    def test_stale_excludes_rejected(self, db):
+        """A REJECTED rule is excluded, deliberate, see BlockRuleManager.stale()'s docstring."""
+        BlockRuleFactory(**{**self._stale_kwargs(), "review_status": ReviewStatus.REJECTED})
+
+        assert BlockRule.objects.stale(days=90).count() == 0
+
+    def test_stale_includes_expired_unreviewed(self, db):
+        """An EXPIRED_UNREVIEWED rule IS included: the counterpart to the REJECTED exclusion."""
+        expired_unreviewed = BlockRuleFactory(
+            **{**self._stale_kwargs(), "review_status": ReviewStatus.EXPIRED_UNREVIEWED}
+        )
+
+        qs = BlockRule.objects.stale(days=90)
+
+        assert qs.count() == 1
+        assert qs.first().pk == expired_unreviewed.pk
+
+    def test_stale_excludes_admin_source(self, db):
+        """An admin-sourced rule is excluded regardless of state."""
+        BlockRuleFactory(**{**self._stale_kwargs(), "source": RuleSource.ADMIN})
+
+        assert BlockRule.objects.stale(days=90).count() == 0
+
+    def test_stale_excludes_feed_source(self, db):
+        """A feed-sourced rule is excluded regardless of state."""
+        BlockRuleFactory(**{**self._stale_kwargs(), "source": RuleSource.FEED})
+
+        assert BlockRule.objects.stale(days=90).count() == 0
+
+    def test_stale_window_boundary(self, db):
+        """A row just inside the window is excluded; just outside is included."""
+        cutoff = timezone.now() - timezone.timedelta(days=90)
+        just_inside = BlockRuleFactory(**{**self._stale_kwargs(), "expires_at": cutoff + timezone.timedelta(hours=1)})
+        just_outside = BlockRuleFactory(**{**self._stale_kwargs(), "expires_at": cutoff - timezone.timedelta(hours=1)})
+
+        qs = BlockRule.objects.stale(days=90)
+
+        assert qs.filter(pk=just_inside.pk).exists() is False
+        assert qs.filter(pk=just_outside.pk).exists() is True
 
     def test_pk_is_uuid(self, db):
         """BlockRule inherits UUID primary key from BaseModel."""

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1727,6 +1727,90 @@ class TestRunAllDetectors:
 
 
 # ---------------------------------------------------------------------------
+# DETECTOR_NAMES / DETECTOR_NAME_TO_RESULT_KEY wiring guard (wave 2, #99's
+# sibling defect class, django_waf.W009's own test-suite counterpart)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectorNamesResultKeyWiring:
+    """Guards the invariant django_waf.W009 (checks.py) checks at boot:
+    DETECTOR_NAMES and DETECTOR_NAME_TO_RESULT_KEY must name exactly the
+    same six detectors, and run_all_detectors' real return dict must
+    actually produce a result key for every one of them.
+
+    Follows tests/test_conf.py's TestCeleryBeatScheduleDefault shape
+    (:47-68): an INDEPENDENT, hand-written expected set, not derived from
+    DETECTOR_NAMES or DETECTOR_NAME_TO_RESULT_KEY themselves, compared
+    against the real values. A set built FROM either constant could never
+    catch that constant drifting: it would always equal itself.
+    """
+
+    # Hand-written, not sourced from anomaly_detector.py: BR-ANOM-012
+    # named five detectors when it was written; BR-ANOM-014 added the
+    # sixth (detect_scraper_404_ratio). If a seventh detector is ever
+    # added without updating this literal set, this test fails, which is
+    # the point: it is the completeness net the hand-written case list in
+    # TestDetectUnsolvedChallenges.test_detector_field_populated_by_every_
+    # detector_passing_it (this file) does not provide.
+    _EXPECTED_DETECTOR_NAMES = frozenset(
+        {
+            "detect_ua_rotation",
+            "detect_subnet_burst",
+            "detect_challenge_farms",
+            "detect_unsolved_challenges",
+            "detect_cloud_spray",
+            "detect_scraper_404_ratio",
+        }
+    )
+
+    def test_detector_names_matches_the_independent_expected_set(self):
+        from django_waf.services.anomaly_detector import DETECTOR_NAMES
+
+        assert DETECTOR_NAMES == self._EXPECTED_DETECTOR_NAMES
+
+    def test_result_key_map_covers_exactly_the_same_names(self):
+        """DETECTOR_NAME_TO_RESULT_KEY's key set (not its values) must
+        equal DETECTOR_NAMES exactly: this is the invariant django_waf.W009
+        exists to catch a violation of at boot.
+        """
+        from django_waf.services.anomaly_detector import (
+            DETECTOR_NAME_TO_RESULT_KEY,
+            DETECTOR_NAMES,
+        )
+
+        assert set(DETECTOR_NAME_TO_RESULT_KEY) == DETECTOR_NAMES
+        assert set(DETECTOR_NAME_TO_RESULT_KEY) == self._EXPECTED_DETECTOR_NAMES
+
+    def test_real_run_all_detectors_return_dict_covers_every_result_key(self, db):
+        """The assertion nothing else in the suite makes (per this wave's
+        plan): a REAL, unmocked run_all_detectors() call against an empty
+        database (every detector legitimately returns [] with no fixture
+        traffic present, so this only exercises the dict-shape contract,
+        not detection logic, which TestRunAllDetectors and
+        test_detector_probe.py's falsifiability tests already cover) must
+        produce a key for every DETECTOR_NAME_TO_RESULT_KEY value, and
+        total_rules_created is the only extra key beyond that set. A
+        result key present in DETECTOR_NAME_TO_RESULT_KEY but absent from
+        run_all_detectors' actual return dict would mean the mapping
+        constant and the function's own hardcoded return statement have
+        desynced, the second of run_all_detectors' seven hand-maintained
+        places (see W009's docstring) that DETECTOR_NAMES /
+        DETECTOR_NAME_TO_RESULT_KEY alone cannot catch, since both of
+        those constants can agree with each other while still disagreeing
+        with what the function actually returns.
+        """
+        from django_waf.services.anomaly_detector import (
+            DETECTOR_NAME_TO_RESULT_KEY,
+            run_all_detectors,
+        )
+
+        result = run_all_detectors()
+
+        result_keys_excluding_total = set(result) - {"total_rules_created"}
+        assert result_keys_excluding_total == set(DETECTOR_NAME_TO_RESULT_KEY.values())
+
+
+# ---------------------------------------------------------------------------
 # _emit_anomaly_signal exception path
 # ---------------------------------------------------------------------------
 
@@ -4057,8 +4141,22 @@ class TestDetectUnsolvedChallenges:
     def test_detector_field_populated_by_every_detector_passing_it(self):
         """Every detector that passes detector_name to _get_or_create_auto_rule
         must have its name added to the created BlockRule's detectors set
-        (#97). Covers all five DETECTOR_NAMES entries plus rule_engine's
-        escalation caller, which passes a detector_name outside that set.
+        (#97). Covers all six DETECTOR_NAMES entries plus rule_engine's
+        escalation caller, which passes a detector_name outside that set
+        (`detectors` is a superset of DETECTOR_NAMES by design, see
+        BR-ANOM-011 / anomaly_detector.py's own comment).
+
+        This hand-written list is a fixed regression case, not a
+        completeness check: it is not parametrised over DETECTOR_NAMES and
+        does not fail if a seventh detector is added without a case here.
+        The wave-2 guard test in TestDetectorNamesResultKeyWiring
+        (services/anomaly_detector.py's own module, this file) is the
+        authoritative completeness check for DETECTOR_NAMES membership;
+        this test only pins the specific #97 regression (the detectors
+        field itself gets populated) for one representative pattern per
+        named detector, once BR-ANOM-014 added detect_scraper_404_ratio,
+        this list was extended to include it rather than left at the five
+        that existed when #97 was fixed.
         """
         from django_waf.services.anomaly_detector import _get_or_create_auto_rule
 
@@ -4068,6 +4166,7 @@ class TestDetectUnsolvedChallenges:
             ("detect_challenge_farms", RuleType.IP, "203.0.119.50"),
             ("detect_unsolved_challenges", RuleType.CIDR, "203.0.120.0/24"),
             ("detect_cloud_spray", RuleType.CIDR, "203.0.121.0/24"),
+            ("detect_scraper_404_ratio", RuleType.IP, "203.0.119.52"),
             ("challenge_escalation", RuleType.IP, "203.0.119.51"),
         ]
         for detector_name, rule_type, pattern in cases:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -511,6 +511,123 @@ class TestExpireRules:
 
 
 # ---------------------------------------------------------------------------
+# prune_stale_rules
+# ---------------------------------------------------------------------------
+
+
+class TestPruneStaleRules:
+    """Tests for the prune_stale_rules task (wave 2, the rule-provenance wave).
+
+    The task-level gate (DJANGO_WAF_RULE_PRUNE_ENABLED) is what makes the
+    task safe to schedule unconditionally in DJANGO_WAF_CELERY_BEAT_SCHEDULE
+    from day one. These tests exercise that gate directly; the predicate
+    itself (which rows count as stale) is exercised end-to-end through the
+    django_waf_prune_rules command tests in test_commands.py, and via
+    BlockRuleManager.stale() here for the deletion path.
+    """
+
+    @staticmethod
+    def _stale_kwargs(days_expired: int = 100):
+        from django_waf.enums import ReviewStatus, RuleSource
+
+        return {
+            "source": RuleSource.AUTO,
+            "is_active": False,
+            "expires_at": timezone.now() - timedelta(days=days_expired),
+            "review_status": ReviewStatus.NOT_APPLICABLE,
+        }
+
+    @pytest.mark.django_db
+    def test_disabled_by_default_reports_without_deleting(self):
+        """With DJANGO_WAF_RULE_PRUNE_ENABLED unset (default False), nothing is deleted."""
+        BlockRuleFactory(**self._stale_kwargs())
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        from django_waf.tasks import prune_stale_rules
+
+        result = prune_stale_rules(days=90)
+
+        assert result == {"deleted_count": 0, "dry_run": True}
+        assert BlockRule.objects.count() == 1
+
+    @pytest.mark.django_db
+    def test_enabled_deletes_matching_rows(self):
+        """With the gate enabled, a genuinely stale row is deleted.
+
+        Proves the gate and the predicate both have teeth: this is the
+        counterpart to the disabled test above, and the one place in this
+        wave a real deletion actually happens.
+        """
+        stale = BlockRuleFactory(**self._stale_kwargs())
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        with patch("django_waf.conf.DJANGO_WAF_RULE_PRUNE_ENABLED", True):
+            from django_waf.tasks import prune_stale_rules
+
+            result = prune_stale_rules(days=90)
+
+        assert result == {"deleted_count": 1, "dry_run": False}
+        assert not BlockRule.objects.filter(pk=stale.pk).exists()
+
+    @pytest.mark.django_db
+    def test_enabled_survives_active_pending_confirmed_and_rejected(self):
+        """With the gate enabled, the predicate's exclusions still hold.
+
+        Redundant with the command-level survival tests by design: this
+        confirms the task path (not just the command path) honours the
+        same predicate, since both call BlockRuleManager.stale() but a
+        divergence between the two call sites would only be caught here.
+        """
+        from django_waf.enums import ReviewStatus
+
+        active = BlockRuleFactory(**{**self._stale_kwargs(), "is_active": True})
+        pending = BlockRuleFactory(**{**self._stale_kwargs(), "review_status": ReviewStatus.PENDING})
+        confirmed = BlockRuleFactory(**{**self._stale_kwargs(), "review_status": ReviewStatus.CONFIRMED})
+        rejected = BlockRuleFactory(**{**self._stale_kwargs(), "review_status": ReviewStatus.REJECTED})
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 4
+
+        with patch("django_waf.conf.DJANGO_WAF_RULE_PRUNE_ENABLED", True):
+            from django_waf.tasks import prune_stale_rules
+
+            result = prune_stale_rules(days=90)
+
+        assert result["deleted_count"] == 0
+        for survivor in (active, pending, confirmed, rejected):
+            assert BlockRule.objects.filter(pk=survivor.pk).exists()
+
+    @pytest.mark.django_db
+    def test_uses_default_retention_days_from_conf(self):
+        """Task uses DJANGO_WAF_RULE_RETENTION_DAYS when days argument is omitted."""
+        from django_waf import conf
+
+        default_days = conf.DJANGO_WAF_RULE_RETENTION_DAYS
+        kwargs = self._stale_kwargs()
+        kwargs["expires_at"] = timezone.now() - timedelta(days=default_days + 1)
+        stale = BlockRuleFactory(**kwargs)
+
+        from django_waf.models import BlockRule
+
+        assert BlockRule.objects.count() == 1
+
+        with patch("django_waf.conf.DJANGO_WAF_RULE_PRUNE_ENABLED", True):
+            from django_waf.tasks import prune_stale_rules
+
+            result = prune_stale_rules()
+
+        assert result["deleted_count"] == 1
+        assert not BlockRule.objects.filter(pk=stale.pk).exists()
+
+
+# ---------------------------------------------------------------------------
 # update_ip_reputation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Makes the chain-of-command rule enforceable rather than aspirational: every
WAF feature declares what it is, what it does, why it is there, and what its
outcome was. Three of those four links were enforced. The fourth did not
exist, and the one mechanism that looked like it could mislead in both
directions.

Adds no detector and changes no enforcement behaviour.

## The investigation that reshaped this wave

The plan hypothesised that `detect_cloud_spray` reported SILENT under
`django_waf_probe_detectors` because `DJANGO_WAF_CLOUD_SPRAY_UA_RULE`
defaults to `False`. **That hypothesis was wrong.** On package defaults with
an empty `BlockRule` table the probe reports all six detectors alive, at
`UA_RULE=False` (cloud spray fires via the subnet path) and at `True`.

The real cause is in the dry-run branch of `_get_or_create_auto_rule`:

```python
if dry_run:
    existing = BlockRule.objects.filter(**lookup).first()
    if existing is not None:
        return existing, False
```

`lookup` is `(rule_type, pattern, source=AUTO, action)`. It filters on
**neither `is_active` nor `expires_at`**, and the probe counts only
`created=True`. So any surviving auto rule on a fixture's exact pattern tuple
makes that detector report SILENT, permanently.

Reproduced with a single rule expired 365 days earlier and already inactive:

| Seeded rule | Result |
|---|---|
| `cidr 203.0.113.0/24 challenge` | `detect_cloud_spray` SILENT |
| `ip 192.0.2.10 challenge` | `detect_ua_rotation` SILENT |
| `ip 192.0.2.90 challenge` | `detect_scraper_404_ratio` SILENT |
| none (control) | `all_alive: True` |

BR-ANOM-012 asserted this could not happen, because fixture IPs come from
TEST-NET documentation ranges. That reasoning holds for `RequestLog` and not
for `BlockRule`: an operator, `django_waf_import_rules`, or a threat feed can
write an auto-sourced rule on a documentation range, and the probe's forced
rollback cannot remove a row it never created. Because nothing deleted
`BlockRule` rows, the collision never cleared, which is the same root cause
as the retention gap below.

## What changed

**The probe fix.** A keyword-only `count_refresh_as_created`, default `False`
everywhere and passed `True` only by `run_detector_probe`. The probe asks
whether the detector's logic fired; dry-run asks whether a new row would be
written. Those are different questions, and this answers the first without
corrupting the second, so BR-ANOM-006's guarantee that "would create N rules"
matches a subsequent real run is unchanged. A detector patched to return
nothing still reports SILENT.

**`django_waf_detector_outcomes`**, the missing fourth link. Per detector:
rules created, rules ever hit, hit rate, total hits attributed, most recent
rule created, plus the existing review-outcome breakdown. Read-only,
zero-filled so a detector producing nothing is an explicit zero rather than
an absent row. `BlockRule.detectors` is a superset of the registry
(`challenge_escalation` is written to it but is not a `DETECTOR_NAMES`
member), so out-of-registry names are reported separately rather than dropped
or merged, and the comma-separated field is parsed by exact membership, not
substring containment. Two queries regardless of row count, measured and
pinned by a test.

**`BlockRule` retention**, behind two independent gates. A live 2.4.0
consumer carried 48,319 rules older than 90 days and none older than 150, the
table's own age. The command is dry-run by default and needs `--execute`; the
scheduled task is additionally gated on `DJANGO_WAF_RULE_PRUNE_ENABLED`
(default `False`), so the exported beat entry cannot delete anything until an
operator opts in. Of all 90 combinations of source, active, expiry and review
status, exactly 2 are deletable. `rejected` is excluded, which the plan did
not specify against the five-state enum: it records an operator's decision
that a pattern must not be blocked, and deleting it erases only the record.

**`django_waf.W009`**, catching a `DETECTOR_NAMES` /
`DETECTOR_NAME_TO_RESULT_KEY` desync in either direction. Not gated on
`DJANGO_WAF_ENABLED`, for the same reason `W008` is not: detection runs on
its own schedule, so gating it would hide the wiring bug from exactly the
deployments running detection with enforcement off.

**Issue #99.** The anomaly command iterated `results.items()`, which includes
`total_rules_created`, printing the pre-summed total as though it were a
detector and adding it again. A live run reported two rules as four. Pinned
by a regression test that reproduces the doubling when the fix is reverted.

## Gates

| Gate | Result |
|---|---|
| `ruff check` + `format --check` (0.15.22, CI's pin) | Pass |
| `PYTHONPATH=. mypy src/` (2.3.1, django-stubs 6.1.0) | Clean, 89 source files |
| Suite, Django 5.2 / 6.0 / 6.1 | 1341 passed, 6 skipped each |
| Real PostgreSQL | 1339 passed, 8 skipped |
| Real Redis | 5 passed, 1 failure requiring Redis 6.0 |

Each Django leg was run with CI's own silent-downgrade assertion (issue #98),
so no leg reports a version it did not execute. The single Redis failure is
`test_getdel_raises_on_a_pre_62_redis_server`, which asserts the server is
pre-6.2; the local server is 7.2.8 where `GETDEL` works. Proven pre-existing
by running the same test on `origin/main` at 4115810, where it fails
identically. CI runs Redis 6.0 and should pass it.

The spec update (BR-ANOM-015, AC-ANOM-038, the CHK-PROV block, and the
BR-ANOM-012 correction above) follows in the umbrella repo.

Closes #99.