### PR TITLE
chore(release): 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.0] - 2026-09-03
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.4.0"
+version = "2.5.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Releases two merged waves together. Diff is two lines: the version in
`pyproject.toml` and the CHANGELOG heading. No code changes.

`src/django_waf/__init__.py` reads `__version__` from package metadata, so
`pyproject.toml` is the only place the version lives (RELEASING.md).

## What ships

**Added**
- `py.typed` (PEP 561) and a `typecheck` CI job running mypy with django-stubs pinned (#108, #111)
- A liveness probe for the Redis hit-count flush path (#100, BR-LIFE-005)
- A per-detector production-outcome report (BR-ANOM-015)
- Retention for `BlockRule` via `DJANGO_WAF_RULE_RETENTION_DAYS` (default 90)
- `django_waf.W009`, catching detector-registry desync in either direction

**Fixed**
- The detector liveness probe reported a healthy detector as SILENT
- `django_waf_detect_anomalies` double-counted its own summary (#99)
- `_deduplicate_block_rules` could raise `AttributeError`
- `verify_challenge_solution` accepted a `None` difficulty (#111)

Minor rather than patch: new public API plus behaviour changes, per
RELEASING.md's SemVer section.

## Upgrade impact

**Nothing deletes data on upgrade.** Rule retention is the only path in the
package that destroys data and ships behind two independent gates:
`django_waf_prune_rules` is dry-run without `--execute`, and the scheduled
`prune_stale_rules` task is additionally gated on
`DJANGO_WAF_RULE_PRUNE_ENABLED`, which defaults to `False`
(`conf.py:427`, early return at `tasks.py:419`). A consumer who merges
`DJANGO_WAF_CELERY_BEAT_SCHEDULE` as documented deletes nothing until they
opt in.

`W009` is deliberately not gated on `DJANGO_WAF_ENABLED`, matching `W008`:
anomaly detection runs on its own schedule, so gating it would hide the
wiring bug from deployments running detection with enforcement off.

## Pre-tag verification

Run locally against this commit before opening.

| Gate | Result |
|---|---|
| test 3.11/5.2, 3.12/5.2, 3.13/6.1 | 1341 passed, 6 skipped, 93.45% cov |
| test 3.11/6.0, 3.12/6.0, 3.12/6.1 | not run locally; CI covers them |
| lint (ruff check + format) | passed, 152 files |
| typecheck (mypy + django-stubs) | Success, 89 source files |
| real Redis 6.0 integration | 6 passed |
| real PostgreSQL 16 | 1339 passed, 8 skipped |
| publish.yml simulation | 1341 passed, exit 0, 93.88% cov |

The publish gate was simulated separately from CI, since the two install
different dependency sets: a clean venv with `wheel[dev,celery]` plus
`Django~=5.2.0` (resolved 5.2.17), running the suite against the installed
wheel. The wheel was unzipped and confirmed to carry `django_waf/py.typed`,
all 8 templates, both nginx config examples, `icv_waf`, and the four new
wave 1/2 modules; the wheel-resolution guard confirms both shipped modules
import from site-packages rather than the source tree.

`publish.yml` is unchanged since v2.4.0, whose publish run succeeded on it.

One verification note: the Redis leg initially passed against a stray local
Redis 7.4.8 after Docker silently remapped a colliding host port. Caught by
a `redis_version` mismatch and rerun on a free port against a confirmed
6.0.20 server. The 6.0 pin matters because `GETDEL` exists only from 6.2, so
a newer Redis hides the defect that leg exists to catch.