### PR TITLE
Challenge recovery and the block-response hook (#102, #74)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,87 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A replaceable block response** (#74, BR-EVAL-012).
+  `DJANGO_WAF_BLOCK_RESPONSE_HANDLER` takes a dotted path to a callable
+  `handler(request, result) -> HttpResponse`, and the middleware returns
+  whatever it produces, unaltered. Unset (the default), the response is
+  exactly `HttpResponseForbidden("Access denied.")`, byte for byte what
+  every prior release returned; the built-in response is now produced by a
+  single named method that both the no-hook path and every fallback path
+  return, so the two cannot drift apart.
+
+  The need is specific rather than cosmetic: a multi-tenant host serving
+  unbound custom domains is fingerprinted as running this WAF by the fixed
+  403 body, and previously had no supported seam. On this path
+  `result.verdict` is always `BLOCKED` and `result.retry_after` always
+  `None`. `result.matched_rule_id` is a `UUID` or `None`, never a
+  `BlockRule`: the rule row is deliberately never loaded, because the block
+  decision comes from the Redis fast path and reading the row per blocked
+  request would hand an attacker a query amplifier. A handler needing the
+  rule must query for it.
+
+  Three failure modes fall back to the built-in 403 and log at ERROR,
+  distinguished so you can tell which happened: the path will not import,
+  the handler raises, or it returns something that is not an
+  `HttpResponse`. The import guard catches more than `ImportError` on
+  purpose, since importing your handler's module runs that module's own
+  top-level code and can raise anything. The request stays blocked in all
+  three cases: a broken hook must not turn a block into a pass. The path is
+  resolved on each blocked request rather than once at import, so
+  `override_settings` works.
+
+  **If you subclass `WafMiddleware` and override the private
+  `_handle_verdict`, you will not pick this up.** Your override keeps
+  working exactly as before and nothing breaks, but it will not honour the
+  new setting until you either rebase onto the new `_handle_verdict` or
+  call `self._build_block_response(request, result)` yourself where you
+  currently build the 403.
+
+  **Country blocks are deliberately not covered**, and still return the
+  same fixed 403. `_check_country_block` decides before `evaluate_request()`
+  runs, so it has no `EvaluationResult` to hand a `(request, result)`
+  handler, and synthesising a fake one to satisfy the signature would be a
+  worse defect than the gap. That means a country block still fingerprints
+  the WAF on exactly the unbound custom domains this hook is about; until
+  #76 closes that, exempt the path or gate country blocking at the edge.
+
+- **`django_waf.E007`**, a boot-time check for a challenge flow with
+  nowhere to send anyone (#102, BR-EVAL-011).
+
+  **This is an Error and it will fail `manage.py check`** for a deployment
+  with the WAF enabled, a challenge reachable from settings, neither
+  `DJANGO_WAF_CHALLENGE_URL` nor `DJANGO_WAF_VERIFY_URL` set, and
+  `django_waf.urls` not routed under the `django_waf` namespace. That is a
+  real break on upgrade, and it is reporting a fault that was already live:
+  a deployment in that state was serving **500s** to any legitimate visitor
+  the WAF challenged, because `_get_challenge_paths()` called
+  `reverse("django_waf:challenge")` and nothing caught the resulting
+  `NoReverseMatch`. Two fixes, either one sufficient: route the URLs, with
+  `path("waf/", include("django_waf.urls", namespace="django_waf"))`, or set
+  **both** `DJANGO_WAF_CHALLENGE_URL` and `DJANGO_WAF_VERIFY_URL` to the
+  literal paths your WAF views are mounted at.
+
+  Setting only one of the two is not enough and the check still fires. The
+  two settings are consumed on separate lines, each falling back to its own
+  `reverse()` call, so a half-configured project is still broken on the
+  other route: the check names precisely which route is unresolvable rather
+  than reporting one you have already pointed somewhere valid.
+
+  Three conditions must all hold before it fires, which is what makes a
+  false positive on a working deployment hard to construct. The WAF must be
+  enabled. A challenge must be reachable from settings, meaning either
+  `DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE < DJANGO_WAF_SCORE_THRESHOLD_BLOCK`
+  or `DJANGO_WAF_CHALLENGE_NO_REFERER = True`, so a project running the WAF
+  purely for blocking and throttling is silent. And at least one URL
+  override must be empty, since setting both means `reverse()` is never
+  called and an unrouted urlconf is harmless. Two limitations are stated
+  rather than hidden: a `BlockRule` with `action = "challenge"` also
+  produces a challenge and no boot check can see one that does not exist
+  yet, and the check resolves against whichever `ROOT_URLCONF` is active at
+  check time, which under django-hosts or per-request urlconfs may not be
+  the one serving traffic. Setting both URL overrides is the escape for
+  that case, and is what the package already recommends there.
+
 - **A liveness probe for the Redis hit-count flush path** (#100, BR-LIFE-005).
   The companion to the detector probe shipped in 2.2.0, covering the
   subsystem that one cannot reach. `flush_rule_hit_counts` called Redis
@@ -122,6 +203,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with enforcement off.
 
 ### Fixed
+
+- **A challenged visitor was served a 500 on a deployment with the WAF
+  URLs unrouted** (#102, BR-EVAL-011). The CHALLENGED branch of
+  `_handle_verdict` called `_get_challenge_paths()` unguarded, and no
+  `NoReverseMatch` handler existed anywhere in `middleware.py`, so with
+  `django_waf.urls` routed nowhere and no explicit URL override set, the
+  exception escaped the middleware entirely. The visitor affected is a
+  legitimate one who merely tripped a detector: the WAF's own
+  misconfiguration turned a challenge into an error page.
+
+  The branch now catches `NoReverseMatch` narrowly, passes the request
+  through to the view, and logs at ERROR naming the client IP, the path,
+  and both fixes. Failing open is the right direction here, not a
+  compromise: there is no route to send the visitor to, so half-blocking
+  them behind a redirect to a page that does not exist is strictly worse
+  than letting them through. It is the same fail-open posture BR-EVAL-007
+  already sets for Redis outages and evaluation errors. Caught narrowly
+  rather than as a bare `Exception`, so any other failure in that branch
+  still surfaces. `django_waf.E007` above reports the same
+  misconfiguration at boot, and both are needed: an operator who ignores
+  the check must still not serve 500s.
 
 - **The detector liveness probe reported a healthy detector as SILENT**
   once a deployment had accumulated any `BlockRule` history. The dry-run

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -172,6 +172,21 @@ all (BR-EVAL-002 already makes a present-but-enabled middleware a total
 pass-through), so the absence of a middleware nobody asked to run is not a
 misconfiguration, matching the gating rationale #95 established for every
 other check in this module.
+
+The challenge-routing check (``django_waf.E007``) errors when the WAF can
+issue a challenge but has no URL to send the challenged visitor to (#102).
+``WafMiddleware._get_challenge_paths`` resolves
+``DJANGO_WAF_CHALLENGE_URL or reverse("django_waf:challenge")``, so with
+the explicit setting empty and ``django_waf.urls`` routed nowhere,
+``reverse()`` raises ``NoReverseMatch``. Before #102 that escaped the
+middleware uncaught and served a **500** to a legitimate visitor who
+merely tripped a detector; the request path now catches it and fails open
+per BR-EVAL-007, but a WAF that quietly stops challenging anyone is still
+a control that is not doing what its operator believes. This is an Error
+rather than a Warning for the same reason ``django_waf.E006`` is: the
+deployment is misconfigured in a way that silently degrades the control,
+and the layered gate below makes a false positive on a working deployment
+very hard to construct.
 """
 
 from __future__ import annotations
@@ -464,6 +479,134 @@ def check_middleware_present(app_configs, **kwargs):
                 "run the WAF yet."
             ),
             id="django_waf.E006",
+        )
+    ]
+
+
+@register()
+def check_challenge_urls_resolvable(app_configs, **kwargs):
+    """Error (``django_waf.E007``) when the WAF can issue a challenge but
+    neither ``reverse("django_waf:challenge")`` nor an explicit URL
+    override can produce a path to send the challenged visitor to (#102).
+
+    Guards, cheapest first, in the layered ladder ``django_waf.E005``
+    established:
+
+    1. **The WAF is enabled.** With ``DJANGO_WAF_ENABLED = False`` the
+       middleware returns at BR-EVAL-002 before any verdict is produced,
+       so no challenge is ever issued and there is nothing to route. Same
+       gating rationale #95 established for every other check here.
+    2. **A challenge is actually issuable.** ``DJANGO_WAF_ENABLED`` alone
+       does not imply it: a project can run the WAF purely for blocking
+       and throttling. The two settings-readable producers of a
+       ``Verdict.CHALLENGED`` are the score band in
+       ``rule_engine._score_to_verdict``, which can only return CHALLENGED
+       when ``DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE <
+       DJANGO_WAF_SCORE_THRESHOLD_BLOCK`` (raise the challenge threshold to
+       or above the block threshold and the band is empty, every scoring
+       request goes straight from LOGGED to BLOCKED), and
+       ``DJANGO_WAF_CHALLENGE_NO_REFERER``. If neither can fire, the check
+       is silent.
+    3. **At least one explicit URL setting is empty.** The two settings are
+       consumed on separate lines of ``_get_challenge_paths``, each
+       ``setting or reverse(...)`` in its own right, so they silence
+       ``reverse()`` one route at a time and not as a pair. A project that
+       sets **both** ``DJANGO_WAF_CHALLENGE_URL`` and
+       ``DJANGO_WAF_VERIFY_URL`` to literal paths never calls ``reverse()``
+       at all, and an unrouted urlconf is harmless to it: that is the
+       documented escape hatch, and the reason this can be an Error rather
+       than a Warning. Setting only one is **not** an escape. The other
+       line still calls ``reverse()`` and still raises on an unrouted
+       urlconf, which is a live routing gap the operator is least likely to
+       spot precisely because they believe they have configured it.
+
+    Only then is ``reverse()`` attempted, and only for the routes whose own
+    override is empty, inside ``try/except NoReverseMatch``. Skipping the
+    overridden route keeps the reported failure honest: a partially
+    configured project is told which single route is unresolvable, not one
+    it has already pointed somewhere valid.
+
+    **Known limitation, stated rather than papered over.** Condition 2 is
+    settings-only and therefore not exhaustive: a ``BlockRule`` row with
+    ``action = "challenge"`` (admin-created, feed-supplied, or written by
+    the anomaly detectors) also produces a CHALLENGED verdict, and no boot
+    check can know whether such a row exists or will be created later.
+    Silence under condition 2 therefore means "no challenge is reachable
+    from settings alone", not "no challenge can ever be issued". That
+    asymmetry is deliberate: the check errs towards firing, because the
+    failure it prevents is a live routing gap, and the deployment that
+    silences it wrongly is one that has already told the package it does
+    not want scored or no-referer challenges.
+
+    **The other known limitation**, shared with every check in this module
+    but sharpest here: this resolves against whichever ``ROOT_URLCONF`` is
+    active at check time. A project using per-request or per-host urlconfs
+    (django-hosts, or a middleware that sets ``request.urlconf``) may serve
+    traffic from a urlconf that is not the one this check saw, in either
+    direction: routes present here and absent there, or the reverse.
+    Setting ``DJANGO_WAF_CHALLENGE_URL`` and ``DJANGO_WAF_VERIFY_URL`` to
+    literal paths is the escape, and it is the correct configuration for
+    such a project anyway, since ``_get_challenge_paths`` is documented to
+    recommend exactly that for multi-urlconf deployments.
+    """
+    from django.urls import NoReverseMatch, reverse
+
+    from django_waf import conf
+
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
+
+    score_band_can_challenge = conf.DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE < conf.DJANGO_WAF_SCORE_THRESHOLD_BLOCK
+    if not score_band_can_challenge and not conf.DJANGO_WAF_CHALLENGE_NO_REFERER:
+        return []
+
+    if conf.DJANGO_WAF_CHALLENGE_URL and conf.DJANGO_WAF_VERIFY_URL:
+        return []
+
+    # The two settings are consumed on separate lines of
+    # _get_challenge_paths, each falling back to its own reverse() call
+    # independently, so a half-configured project is still broken: with only
+    # DJANGO_WAF_CHALLENGE_URL set, the verify line still calls
+    # reverse("django_waf:verify") and still raises. Only the route whose own
+    # override is empty is attempted here, so the message names precisely
+    # what is unresolvable rather than reporting a route the operator has
+    # already configured.
+    routes_to_resolve = []
+    if not conf.DJANGO_WAF_CHALLENGE_URL:
+        routes_to_resolve.append("django_waf:challenge")
+    if not conf.DJANGO_WAF_VERIFY_URL:
+        routes_to_resolve.append("django_waf:verify")
+
+    unresolvable = []
+    for route in routes_to_resolve:
+        try:
+            reverse(route)
+        except NoReverseMatch:
+            unresolvable.append(route)
+
+    if not unresolvable:
+        return []
+
+    return [
+        Error(
+            "The WAF is enabled and can issue a challenge, but "
+            f"{', '.join(repr(name) for name in unresolvable)} cannot be "
+            "reversed and carries no explicit URL override: the challenge "
+            "flow breaks for any visitor the WAF challenges. "
+            "django_waf.urls is not routed under the 'django_waf' namespace "
+            "in the active ROOT_URLCONF.",
+            hint=(
+                "Include django_waf.urls in your URLconf, e.g. "
+                "path('waf/', include('django_waf.urls', namespace='django_waf')), "
+                "or set BOTH DJANGO_WAF_CHALLENGE_URL and DJANGO_WAF_VERIFY_URL "
+                "to the literal paths the WAF views are mounted at (the "
+                "recommended approach for projects with per-host or "
+                "per-request urlconfs, where this check cannot see the "
+                "urlconf that actually serves traffic). Setting only one of "
+                "the two is not enough: they are resolved independently, so "
+                "the other still calls reverse() and still fails."
+            ),
+            id="django_waf.E007",
         )
     ]
 

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -628,6 +628,27 @@ def _DJANGO_WAF_BLOCKED_COUNTRIES() -> list:
     return _get_setting("DJANGO_WAF_BLOCKED_COUNTRIES", [])
 
 
+# Dotted path to a callable returning the response for a BLOCKED verdict
+# (BR-EVAL-011). Empty (the default) keeps the built-in
+# ``HttpResponseForbidden("Access denied.")``, byte for byte.
+#
+# The path is imported at call time, on the blocked request, not at import
+# time, so ``override_settings`` and the pytest ``settings`` fixture work
+# exactly as they do for every other setting in this module.
+#
+# The handler takes ``(request, result)`` and returns an ``HttpResponse``.
+# See ``django_waf.middleware.WafMiddleware._build_block_response`` for the
+# full contract, including what happens when the path will not import, the
+# handler raises, or it returns a non-response: all three fall back to the
+# built-in response and log at ERROR. The WAF never 500s on its own
+# misconfiguration.
+#
+# This is the only dotted-path setting in the package; every other setting
+# resolves to a scalar, list or dict.
+def _DJANGO_WAF_BLOCK_RESPONSE_HANDLER() -> str:
+    return _get_setting("DJANGO_WAF_BLOCK_RESPONSE_HANDLER", "")
+
+
 # Enable the optional DRF API under waf/api/ (requires the [api] extra).
 def _DJANGO_WAF_API_ENABLED() -> bool:
     return _get_setting("DJANGO_WAF_API_ENABLED", False)

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -13,7 +13,8 @@ import logging
 import random
 
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
-from django.urls import reverse
+from django.urls import NoReverseMatch, reverse
+from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 
 logger = logging.getLogger("django_waf.middleware")
@@ -54,6 +55,12 @@ class WafMiddleware:
         ``DJANGO_WAF_CHALLENGE_URL`` / ``DJANGO_WAF_VERIFY_URL`` to literal paths,
         which is the recommended approach for multi-urlconf projects that
         don't mount the django_waf URLs on every host.
+
+        Raises ``NoReverseMatch`` when neither setting is set and the
+        ``django_waf`` namespace is not routed. Callers on the request path
+        must catch it and fail open (BR-EVAL-007); ``_handle_verdict``'s
+        CHALLENGED branch does. ``django_waf.E007`` reports the same
+        misconfiguration at boot.
         """
         from django_waf import conf
 
@@ -220,6 +227,14 @@ class WafMiddleware:
                 return None
 
             self._log_country_block(request, ip_address, user_agent, path, country)
+            # NOT routed through DJANGO_WAF_BLOCK_RESPONSE_HANDLER (#74).
+            # That hook's contract is (request, result), and this path has no
+            # EvaluationResult at all: the country decision is taken here,
+            # before evaluate_request() ever runs. Synthesising a fake result
+            # just to satisfy the signature would be a worse defect than the
+            # gap, so the gap is deliberate and recorded. A consumer needing
+            # a custom shape here should exempt the path or gate country
+            # blocking at the edge. Tracked as #76.
             return HttpResponseForbidden("Access denied.")
         except Exception:
             logger.exception("django-waf: error during country-block check — failing open")
@@ -362,6 +377,122 @@ class WafMiddleware:
         except Exception:
             logger.exception("django-waf: error creating RequestLog record for country block")
 
+    def _default_block_response(self) -> HttpResponse:
+        """Return the package's built-in BLOCKED response.
+
+        Kept as a single named source so the hook's fallback path and the
+        no-hook path cannot drift apart: both return this, byte for byte.
+        """
+        return HttpResponseForbidden("Access denied.")
+
+    def _build_block_response(self, request, result) -> HttpResponse:
+        """Return the response for a BLOCKED verdict (BR-EVAL-011).
+
+        With ``DJANGO_WAF_BLOCK_RESPONSE_HANDLER`` unset (the default) this
+        is exactly ``HttpResponseForbidden("Access denied.")``, unchanged
+        from every release before the hook existed.
+
+        HANDLER CONTRACT
+
+        ``DJANGO_WAF_BLOCK_RESPONSE_HANDLER`` is a dotted path to a
+        callable with this signature::
+
+            def handler(request: HttpRequest, result: EvaluationResult) -> HttpResponse
+
+        ``request`` is the live ``HttpRequest``. The handler runs before the
+        view, so nothing downstream has touched it.
+
+        ``result`` is the ``EvaluationResult`` NamedTuple from
+        ``django_waf.services.rule_engine``, carrying ``verdict``,
+        ``action``, ``matched_rule_id``, ``matched_rule_type``,
+        ``anomaly_score`` and ``retry_after``. ``verdict`` is always
+        ``Verdict.BLOCKED`` here, and ``retry_after`` is always ``None``
+        (it is populated on THROTTLED verdicts only).
+
+        **``result.matched_rule_id`` is a ``UUID`` or ``None``, not a
+        ``BlockRule`` instance.** The rule object is never loaded on this
+        path, deliberately: the block decision comes from the Redis fast
+        path, and reading the rule row per blocked request would hand an
+        attacker a query amplifier. A handler that needs the rule itself
+        must query for it, and should weigh that cost against the traffic
+        it is blocking.
+
+        The return value must be an ``HttpResponse``, of any subclass and
+        any status code. The middleware returns it unaltered.
+
+        The dotted path is resolved with ``import_string`` on each blocked
+        request rather than once at import time, following the package's
+        call-time settings resolution (see ``django_waf.conf``), so
+        ``override_settings`` and the pytest ``settings`` fixture work.
+        Blocked requests are the rare path, so the import-cache lookup this
+        costs is nowhere near the clean-request hot path.
+
+        FAILURE BEHAVIOUR
+
+        A misconfigured WAF must never break a request. That is the same
+        fail-open posture BR-EVAL-007 sets for evaluation. All three
+        failure modes fall back to ``_default_block_response()`` and log at
+        ERROR, classified distinctly so an operator can tell which one
+        happened:
+
+        1. the dotted path will not import, for any reason: a typo, a moved
+           module, or the handler module's own top-level code raising
+           something that is not an ``ImportError``;
+        2. the handler raises;
+        3. the handler returns something that is not an ``HttpResponse``.
+
+        The request is still blocked in all three cases. Falling back to
+        the built-in 403 is the safe direction: a broken hook must not turn
+        a block into a pass.
+
+        SCOPE
+
+        BLOCKED verdicts only. THROTTLED and CHALLENGED keep their own
+        responses, and ``_check_country_block``'s direct 403 is out of
+        scope (see the comment at that return).
+        """
+        from django_waf import conf
+
+        dotted_path = conf.DJANGO_WAF_BLOCK_RESPONSE_HANDLER
+        if not dotted_path:
+            return self._default_block_response()
+
+        try:
+            handler = import_string(dotted_path)
+        except Exception:
+            # Deliberately broader than ImportError. import_string raises
+            # ImportError for a bad path, but importing the handler's module
+            # runs that module's own top-level code, which can raise anything
+            # (ImproperlyConfigured from a settings read, a SyntaxError under
+            # a stale .pyc, an AppRegistryNotReady). None of those may reach
+            # the client as a 500 on a request the WAF is already blocking.
+            logger.exception(
+                "django-waf: DJANGO_WAF_BLOCK_RESPONSE_HANDLER %r could not be imported. "
+                "Falling back to the built-in block response.",
+                dotted_path,
+            )
+            return self._default_block_response()
+
+        try:
+            response = handler(request, result)
+        except Exception:
+            logger.exception(
+                "django-waf: block response handler %r raised. Falling back to the built-in block response.",
+                dotted_path,
+            )
+            return self._default_block_response()
+
+        if not isinstance(response, HttpResponse):
+            logger.error(
+                "django-waf: block response handler %r returned %s, not an HttpResponse. "
+                "Falling back to the built-in block response.",
+                dotted_path,
+                type(response).__name__,
+            )
+            return self._default_block_response()
+
+        return response
+
     def _handle_verdict(self, request, result, ip_address, user_agent, path, redis_client):
         from django_waf.enums import Verdict
 
@@ -382,7 +513,7 @@ class WafMiddleware:
             except Exception:
                 logger.exception("django-waf: error recording block verdict")
             _emit_request_blocked(result, ip_address, user_agent, path)
-            return HttpResponseForbidden("Access denied.")
+            return self._build_block_response(request, result)
 
         if verdict == Verdict.THROTTLED:
             _emit_request_throttled(result, ip_address)
@@ -398,7 +529,33 @@ class WafMiddleware:
             return response
 
         if verdict == Verdict.CHALLENGED:
-            challenge_path, verify_path = self._get_challenge_paths()
+            try:
+                challenge_path, verify_path = self._get_challenge_paths()
+            except NoReverseMatch:
+                # BR-EVAL-007: the WAF must never break a request because of
+                # its own misconfiguration. With django_waf.urls routed
+                # nowhere and no explicit URL override set,
+                # _get_challenge_paths() calls reverse("django_waf:challenge")
+                # and raises NoReverseMatch, which before #102 escaped
+                # __call__ uncaught and served a 500 to a legitimate visitor
+                # who merely tripped a detector. There is no route to send
+                # them to, so half-blocking them behind a redirect to a page
+                # that does not exist is strictly worse than letting the
+                # request through: fail open and tell the operator loudly
+                # what to fix. Caught narrowly rather than as a bare
+                # Exception so any other failure in this branch still
+                # surfaces.
+                logger.error(
+                    "django-waf: cannot resolve the challenge/verify URLs, so a CHALLENGED "
+                    "verdict for %s on %s is being passed through to the view instead "
+                    "(BR-EVAL-007 fail-open). Route django_waf.urls in your URLconf under "
+                    "the 'django_waf' namespace, or set DJANGO_WAF_CHALLENGE_URL and "
+                    "DJANGO_WAF_VERIFY_URL to literal paths if this project mounts the WAF "
+                    "views elsewhere (or on only some hosts).",
+                    ip_address,
+                    path,
+                )
+                return self._get_response(request)
 
             # Suppress challenge redirect when already on a challenge/verify
             # path to prevent infinite redirect loops. BLOCKED and THROTTLED

--- a/tests/block_handler_import_boom.py
+++ b/tests/block_handler_import_boom.py
@@ -1,0 +1,17 @@
+"""A block-response handler module whose own import fails, and not with an
+ImportError.
+
+Exists solely so ``tests/test_block_response_hook.py`` can prove the
+middleware's import guard is broader than ``except ImportError``. A real
+consumer hits this shape when the handler module reads a setting at import
+time (``ImproperlyConfigured``), touches the app registry too early
+(``AppRegistryNotReady``), or ships a stale ``.pyc``.
+
+Nothing else may import this module.
+"""
+
+from __future__ import annotations
+
+from django.core.exceptions import ImproperlyConfigured
+
+raise ImproperlyConfigured("this handler module cannot be imported")

--- a/tests/test_block_response_hook.py
+++ b/tests/test_block_response_hook.py
@@ -1,0 +1,445 @@
+"""Tests for DJANGO_WAF_BLOCK_RESPONSE_HANDLER, the block-response hook (#74).
+
+BR-EVAL-011. A consumer needing a different block-response shape (a
+multi-tenant host returning its own anonymous 404 rather than the WAF's
+fingerprinting 403) sets a dotted path here instead of subclassing
+``WafMiddleware`` and overriding the private ``_handle_verdict``.
+
+Scope under test:
+
+- unset setting is byte-identical to the pre-hook behaviour;
+- a handler set by dotted path replaces the block response;
+- all three failure modes (path will not import, handler raises, handler
+  returns a non-response) fall back to the built-in response and log at
+  ERROR rather than 500ing.
+
+The handlers live at module level in this file precisely so the tests can
+address them by a real dotted path (``tests.test_block_response_hook.X``)
+and exercise ``import_string`` for real, rather than patching it out. A
+patched ``import_string`` would prove the middleware calls something, not
+that a consumer's setting actually resolves.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.http import HttpResponse, HttpResponseNotFound
+from django.test import RequestFactory, override_settings
+
+# ---------------------------------------------------------------------------
+# Handlers addressed by dotted path from the tests below
+# ---------------------------------------------------------------------------
+
+# Records what each handler was called with, so a test can assert the
+# signature the middleware actually passes rather than trusting the
+# docstring. Reset by the autouse fixture.
+CALLS: list[tuple] = []
+
+
+def working_handler(request, result):
+    """The documented happy path: return a consumer-shaped 404."""
+    CALLS.append((request, result))
+    return HttpResponseNotFound("Not found.")
+
+
+def raising_handler(request, result):
+    """A handler with a bug in it."""
+    CALLS.append((request, result))
+    raise RuntimeError("handler exploded")
+
+
+def non_response_handler(request, result):
+    """A handler returning the wrong type (a common consumer mistake: a
+    template string, or forgetting to wrap a render)."""
+    CALLS.append((request, result))
+    return "<html>blocked</html>"
+
+
+@pytest.fixture(autouse=True)
+def _reset_calls():
+    CALLS.clear()
+    yield
+    CALLS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirroring tests/test_middleware.py's conventions)
+# ---------------------------------------------------------------------------
+
+
+def _make_result(verdict: str, **kwargs) -> MagicMock:
+    result = MagicMock()
+    result.verdict = verdict
+    result.matched_rule_id = None
+    result.matched_rule_type = ""
+    result.anomaly_score = None
+    result.action = None
+    result.retry_after = None
+    for key, value in kwargs.items():
+        setattr(result, key, value)
+    return result
+
+
+def _mock_redis():
+    redis = MagicMock()
+    redis.get.return_value = None
+    return redis
+
+
+def _run_blocked_request():
+    """Drive a full BLOCKED request through the middleware and return the
+    response.
+
+    Goes through ``__call__`` rather than calling ``_build_block_response``
+    directly, so the test proves the hook is wired into the real request
+    path and not merely that a helper method works in isolation.
+    """
+    from django_waf.middleware import WafMiddleware
+
+    factory = RequestFactory()
+    request = factory.get("/page/")
+    request.user = MagicMock(is_authenticated=False)
+    request.COOKIES = {}
+    get_response = MagicMock(return_value=HttpResponse("view response"))
+
+    with (
+        patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+        patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+        patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        patch("django_waf.middleware._emit_request_blocked"),
+    ):
+        mock_redis_fn.return_value = _mock_redis()
+        mock_validate.return_value = False
+        mock_eval.return_value = _make_result("blocked")
+
+        middleware = WafMiddleware(get_response)
+        response = middleware(request)
+
+    # The block must still be a block: the view is never reached, whichever
+    # branch of the hook ran. Without this every test below would pass if
+    # the hook accidentally failed the request open.
+    get_response.assert_not_called()
+    return response
+
+
+# ---------------------------------------------------------------------------
+# The default: unset setting is byte-identical to the pre-hook behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestUnsetHandlerIsUnchanged:
+    """With the setting unset the response is exactly what every release
+    before the hook returned: a 403 whose body is ``Access denied.``.
+
+    Asserted as literal status code and literal bytes, not "some 4xx", so
+    the test is falsifiable by any drift in the default shape. A consumer's
+    own tests and monitoring key on this exact string.
+    """
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_default_is_403_access_denied(self):
+        response = _run_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+
+    @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCK_RESPONSE_HANDLER="")
+    def test_empty_string_handler_is_the_same_as_unset(self):
+        response = _run_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_no_handler_is_ever_called_when_unset(self):
+        _run_blocked_request()
+
+        assert CALLS == []
+
+
+# ---------------------------------------------------------------------------
+# A configured handler replaces the block response
+# ---------------------------------------------------------------------------
+
+
+class TestConfiguredHandler:
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_handler_response_replaces_the_default(self):
+        response = _run_blocked_request()
+
+        assert response.status_code == 404
+        assert response.content == b"Not found."
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_handler_receives_the_request_and_the_evaluation_result(self):
+        """The documented signature is ``(request, result)``.
+
+        Asserting the arguments, not just the response, pins the contract
+        the docstring promises: a handler written against it must keep
+        working.
+        """
+        _run_blocked_request()
+
+        assert len(CALLS) == 1
+        request, result = CALLS[0]
+        assert request.path == "/page/"
+        assert result.verdict == "blocked"
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_setting_is_read_at_call_time_not_import_time(self):
+        """Two requests in one process, differing only by an
+        ``override_settings`` block, must get different responses.
+
+        This is what call-time ``import_string`` resolution buys: a value
+        frozen at module import would make the second assertion fail, and
+        would silently break every consumer test using ``override_settings``.
+        """
+        default_response = _run_blocked_request()
+        assert default_response.status_code == 403
+
+        with override_settings(
+            DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+        ):
+            hooked_response = _run_blocked_request()
+
+        assert hooked_response.status_code == 404
+
+        after_response = _run_blocked_request()
+        assert after_response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Failure modes: never 500, always fall back, always log distinctly
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerFailureFallsBack:
+    """A misconfigured hook must not break a request (BR-EVAL-007's
+    fail-open posture), and must not turn a block into a pass either.
+
+    Every case asserts three things: the built-in response comes back
+    byte-identical, an ERROR is logged naming the dotted path so the
+    operator can find it, and no exception escapes the middleware.
+    """
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.does_not_exist",
+    )
+    def test_unimportable_path_falls_back_and_logs(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+        assert any("could not be imported" in message for message in caplog.messages)
+        assert any("does_not_exist" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.no_such_module_at_all.handler",
+    )
+    def test_unimportable_module_falls_back_and_logs(self, caplog):
+        """A missing module, not just a missing attribute. ``import_string``
+        raises ``ImportError`` for both, but a consumer typo is far more
+        often the module half of the path."""
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+        assert any("could not be imported" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.block_handler_import_boom.handler",
+    )
+    def test_module_raising_a_non_importerror_on_import_falls_back(self, caplog):
+        """The import guard is deliberately broader than ``ImportError``.
+
+        Importing a handler module runs that module's top-level code, which
+        can raise anything: ``ImproperlyConfigured`` from a settings read,
+        ``AppRegistryNotReady``, a ``SyntaxError`` under a stale ``.pyc``.
+        An ``except ImportError`` would let all of those escape as a 500 on
+        a request the WAF had already decided to block, which is the exact
+        failure this hook must not introduce. This test fails against a
+        narrow ``except ImportError``.
+        """
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+        assert any("could not be imported" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.raising_handler",
+    )
+    def test_raising_handler_falls_back_and_logs(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+        # The handler really did run and really did raise: without this the
+        # test would also pass if the path had simply failed to import,
+        # which is a different failure with a different log line.
+        assert len(CALLS) == 1
+        assert any("raised" in message for message in caplog.messages)
+        assert any("raising_handler" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.raising_handler",
+    )
+    def test_raising_handler_does_not_propagate(self):
+        """No exception escapes into a 500. Asserted separately from the
+        logging test because a bare ``pytest.raises``-free call proves the
+        absence directly."""
+        response = _run_blocked_request()
+
+        assert response.status_code == 403
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.non_response_handler",
+    )
+    def test_non_response_return_falls_back_and_logs(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+        assert len(CALLS) == 1
+        assert any("not an HttpResponse" in message for message in caplog.messages)
+        # The log names the offending type so the operator does not have to
+        # guess what the handler returned.
+        assert any("str" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.raising_handler",
+    )
+    def test_failure_classifications_are_distinct(self, caplog):
+        """A raising handler and an unimportable path must not produce the
+        same log line: an operator has to be able to tell which one
+        happened without reading the source.
+        """
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            _run_blocked_request()
+        raised_messages = list(caplog.messages)
+
+        caplog.clear()
+        CALLS.clear()
+
+        with (
+            override_settings(
+                DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.does_not_exist",
+            ),
+            caplog.at_level(logging.ERROR, logger="django_waf.middleware"),
+        ):
+            _run_blocked_request()
+        import_messages = list(caplog.messages)
+
+        assert not any("could not be imported" in message for message in raised_messages)
+        assert not any("raised" in message for message in import_messages)
+
+
+# ---------------------------------------------------------------------------
+# Scope: BLOCKED only
+# ---------------------------------------------------------------------------
+
+
+class TestHookScope:
+    """The hook covers BLOCKED verdicts only (the #74 decision).
+
+    Without these, a later change that routed THROTTLED or CHALLENGED
+    through the hook would go unnoticed, and a consumer's block-shaped
+    handler would start answering rate limits.
+    """
+
+    def _run_with_verdict(self, verdict: str, **result_kwargs):
+        from django_waf.middleware import WafMiddleware
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("view response"))
+
+        with (
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+            patch("django_waf.middleware._emit_request_blocked"),
+            patch("django_waf.middleware._emit_request_throttled"),
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result(verdict, **result_kwargs)
+
+            middleware = WafMiddleware(get_response)
+            return middleware(request)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_throttled_verdict_ignores_the_handler(self):
+        response = self._run_with_verdict("throttled", retry_after=30)
+
+        assert response.status_code == 429
+        assert CALLS == []
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_challenged_verdict_ignores_the_handler(self):
+        response = self._run_with_verdict("challenged")
+
+        assert response.status_code == 302
+        assert CALLS == []
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_blocked_verdict_is_the_positive_control(self):
+        """Pins the two absence assertions above.
+
+        Without this the handler could be dead entirely (a broken setting
+        name, an unwired branch) and both would still pass.
+        """
+        response = self._run_with_verdict("blocked")
+
+        assert response.status_code == 404
+        assert len(CALLS) == 1
+
+
+# ---------------------------------------------------------------------------
+# The setting itself
+# ---------------------------------------------------------------------------
+
+
+class TestSettingDefault:
+    def test_default_is_empty_string(self):
+        from django_waf import conf
+
+        assert conf.DJANGO_WAF_BLOCK_RESPONSE_HANDLER == ""
+
+    @override_settings(DJANGO_WAF_BLOCK_RESPONSE_HANDLER="some.dotted.path")
+    def test_override_settings_is_visible_to_conf(self):
+        from django_waf import conf
+
+        assert conf.DJANGO_WAF_BLOCK_RESPONSE_HANDLER == "some.dotted.path"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+import pytest
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.test import override_settings
@@ -85,6 +86,12 @@ def _run_middleware_present_check():
     from django_waf.checks import check_middleware_present
 
     return check_middleware_present(app_configs=None)
+
+
+def _run_challenge_urls_resolvable_check():
+    from django_waf.checks import check_challenge_urls_resolvable
+
+    return check_challenge_urls_resolvable(app_configs=None)
 
 
 class TestChallengeDifficultyCheck:
@@ -474,6 +481,167 @@ class TestMiddlewarePresentCheck:
         assert len(messages) == 1
         assert messages[0].id == "django_waf.E006"
         assert "MIDDLEWARE" in messages[0].hint
+
+
+class TestChallengeUrlsResolvableCheck:
+    """django_waf.E007 -- errors when the WAF is enabled and can issue a
+    challenge, but neither reverse("django_waf:challenge") nor an explicit
+    URL override yields a path to send the challenged visitor to (#102).
+
+    Every case here points ROOT_URLCONF at a real module rather than
+    building an approximation: ``tests.urls_no_waf`` genuinely omits the
+    include (so Django's own resolver raises NoReverseMatch), and
+    ``tests.urls`` genuinely carries it.
+
+    ``override_settings`` is used throughout rather than patching
+    ``django_waf.conf`` attributes because ROOT_URLCONF must change too, and
+    since #75 conf resolves DJANGO_WAF_* names at call time via module-level
+    ``__getattr__``, so ``override_settings`` reaches both in one idiom.
+    """
+
+    def test_routes_absent_and_waf_enabled_emits_e007_error(self):
+        """The #102 deployment shape: WAF on, challenges reachable from the
+        default score band, no explicit URL override, django_waf.urls routed
+        nowhere. This is the state that served a 500 to a challenged
+        visitor before the middleware guard landed."""
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            ROOT_URLCONF="tests.urls_no_waf",
+            DJANGO_WAF_CHALLENGE_URL="",
+            DJANGO_WAF_VERIFY_URL="",
+        ):
+            messages = _run_challenge_urls_resolvable_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.E007"
+        # Both remedies must be named, in the operator's terms.
+        assert "django_waf.urls" in messages[0].hint
+        assert "DJANGO_WAF_CHALLENGE_URL" in messages[0].hint
+        assert "DJANGO_WAF_VERIFY_URL" in messages[0].hint
+
+    def test_routes_present_and_waf_enabled_is_silent(self):
+        """Passing case (a): the ordinary correctly-wired deployment.
+        tests/urls.py includes django_waf.urls under the namespace, so both
+        routes reverse and there is nothing to report."""
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            ROOT_URLCONF="tests.urls",
+            DJANGO_WAF_CHALLENGE_URL="",
+            DJANGO_WAF_VERIFY_URL="",
+        ):
+            assert _run_challenge_urls_resolvable_check() == []
+
+    def test_routes_absent_and_waf_disabled_is_silent(self):
+        """Passing case (b): with DJANGO_WAF_ENABLED = False the middleware
+        returns at BR-EVAL-002 before any verdict is produced, so no
+        challenge is ever issued and there is no routing gap to report. The
+        #95 gating rationale, and the mistake E004 made before 1.8.1."""
+        with override_settings(
+            DJANGO_WAF_ENABLED=False,
+            ROOT_URLCONF="tests.urls_no_waf",
+            DJANGO_WAF_CHALLENGE_URL="",
+            DJANGO_WAF_VERIFY_URL="",
+        ):
+            assert _run_challenge_urls_resolvable_check() == []
+
+    def test_routes_absent_but_explicit_urls_set_is_silent(self):
+        """Passing case (c): _get_challenge_paths is ``setting or
+        reverse(...)``, so with both overrides set reverse() is never
+        called and the unrouted urlconf is harmless. This is the documented
+        escape for per-host and per-request urlconfs, and the reason E007
+        can be an Error at all rather than a Warning."""
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            ROOT_URLCONF="tests.urls_no_waf",
+            DJANGO_WAF_CHALLENGE_URL="/custom/challenge/",
+            DJANGO_WAF_VERIFY_URL="/custom/verify/",
+        ):
+            assert _run_challenge_urls_resolvable_check() == []
+
+    def test_routes_absent_but_challenges_not_issuable_is_silent(self):
+        """Passing case (d): DJANGO_WAF_ENABLED alone does not imply a
+        challenge can be issued. With the challenge score threshold raised
+        to the block threshold the band in rule_engine._score_to_verdict is
+        empty (a score at or above 7.0 goes straight to BLOCKED, below it to
+        LOGGED), and with DJANGO_WAF_CHALLENGE_NO_REFERER off the other
+        settings-readable producer is gone too. A WAF run purely for
+        blocking and throttling has no challenge to route."""
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            ROOT_URLCONF="tests.urls_no_waf",
+            DJANGO_WAF_CHALLENGE_URL="",
+            DJANGO_WAF_VERIFY_URL="",
+            DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE=7.0,
+            DJANGO_WAF_SCORE_THRESHOLD_BLOCK=7.0,
+            DJANGO_WAF_CHALLENGE_NO_REFERER=False,
+        ):
+            assert _run_challenge_urls_resolvable_check() == []
+
+    def test_no_referer_challenge_alone_keeps_the_check_live(self):
+        """The discriminator for case (d): the empty score band is not on
+        its own enough to silence the check. With no-referer challenges
+        switched on, a CHALLENGED verdict is still reachable
+        (rule_engine step 8) and the routing gap is still real, so E007
+        must fire. Without this, case (d) would pass against a check that
+        keyed on the score band alone and wrongly went quiet for every
+        no-referer deployment."""
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            ROOT_URLCONF="tests.urls_no_waf",
+            DJANGO_WAF_CHALLENGE_URL="",
+            DJANGO_WAF_VERIFY_URL="",
+            DJANGO_WAF_SCORE_THRESHOLD_CHALLENGE=7.0,
+            DJANGO_WAF_SCORE_THRESHOLD_BLOCK=7.0,
+            DJANGO_WAF_CHALLENGE_NO_REFERER=True,
+        ):
+            messages = _run_challenge_urls_resolvable_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.E007"
+
+    @pytest.mark.parametrize(
+        ("challenge_url", "verify_url", "expected_route"),
+        [
+            ("/custom/challenge/", "", "django_waf:verify"),
+            ("", "/custom/verify/", "django_waf:challenge"),
+        ],
+    )
+    def test_only_one_explicit_url_set_still_fires(self, challenge_url, verify_url, expected_route):
+        """Setting one override is not an escape, and this is the case where
+        E007 matters most while being least visible to the operator.
+
+        ``_get_challenge_paths`` consumes the two settings on separate
+        lines, each ``setting or reverse(...)`` in its own right::
+
+            challenge = conf.DJANGO_WAF_CHALLENGE_URL or reverse("django_waf:challenge")
+            verify = conf.DJANGO_WAF_VERIFY_URL or reverse("django_waf:verify")
+
+        so they silence ``reverse()`` one route at a time, never as a pair.
+        A project that sets only ``DJANGO_WAF_CHALLENGE_URL`` still runs the
+        verify line, still calls ``reverse("django_waf:verify")``, and still
+        raises ``NoReverseMatch`` on an unrouted urlconf: a 500 before the
+        middleware guard landed, a silent fail-open pass-through after it.
+        The operator believes they have configured the URLs, so nothing
+        else will tell them.
+
+        The message must name only the genuinely unresolvable route, not the
+        one already pointed somewhere valid.
+        """
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            ROOT_URLCONF="tests.urls_no_waf",
+            DJANGO_WAF_CHALLENGE_URL=challenge_url,
+            DJANGO_WAF_VERIFY_URL=verify_url,
+        ):
+            messages = _run_challenge_urls_resolvable_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.E007"
+        assert expected_route in messages[0].msg
+        # The configured route is not reported: it resolves via its own
+        # override and reverse() is never attempted for it.
+        other_route = "django_waf:challenge" if expected_route == "django_waf:verify" else "django_waf:verify"
+        assert other_route not in messages[0].msg
 
 
 class TestTrustedCookieTrustLevelCheck:
@@ -897,3 +1065,64 @@ class TestManagePyCheckWithWafDisabled:
                 assert "django_waf.E003" in str(exc)
             else:
                 raise AssertionError("expected SystemCheckError from django_waf.E003")
+
+
+class TestManagePyCheckWithUnroutedChallengeUrls:
+    """End-to-end regression pair for django_waf.E007 (#102), mirroring what
+    ``TestManagePyCheckWithWafDisabled`` provides for E003/E004.
+
+    Every other E007 test in this module calls
+    ``check_challenge_urls_resolvable`` directly with ``app_configs=None``,
+    which never exercises the registry path Django's own ``check`` framework
+    uses, nor the behaviour that an Error aborts ``manage.py check``
+    outright via ``SystemCheckError`` rather than being returned as a value
+    in a list. That distinction is the whole cost of shipping this as an
+    Error rather than a Warning, so it is asserted directly.
+
+    Both halves override ``DJANGO_WAF_SITE_PASSWORD_ENABLED = False``
+    explicitly and patch ``is_redis_backend`` to True: with the WAF
+    enabled, E003's gate and E004's gate are each a second possible source
+    of ``SystemCheckError``, so without both the positive half below aborts
+    on E004 (tests/settings.py uses LocMemCache, never django-redis) and
+    the negative half could pass for the wrong reason. This mirrors what
+    ``TestManagePyCheckWithWafDisabled`` does for the same reason.
+    """
+
+    def test_check_command_completes_when_challenge_urls_are_routed(self):
+        """tests/urls.py includes django_waf.urls under its namespace, which
+        is the project default: ``manage.py check`` must complete cleanly
+        with the WAF fully enabled. A clean return is the regression
+        assertion, since an over-eager E007 would abort here."""
+        with (
+            override_settings(
+                DJANGO_WAF_ENABLED=True,
+                ROOT_URLCONF="tests.urls",
+                DJANGO_WAF_CHALLENGE_URL="",
+                DJANGO_WAF_VERIFY_URL="",
+                DJANGO_WAF_SITE_PASSWORD_ENABLED=False,
+            ),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=True),
+        ):
+            call_command("check")
+
+    def test_check_command_aborts_when_challenge_urls_are_unroutable(self):
+        """The positive control for the test above, so a silent
+        assertion-that-never-fails is not hiding an inert check: the same
+        registry path, with django_waf.urls genuinely unrouted, must abort
+        with E007 named in the SystemCheckError."""
+        with (
+            override_settings(
+                DJANGO_WAF_ENABLED=True,
+                ROOT_URLCONF="tests.urls_no_waf",
+                DJANGO_WAF_CHALLENGE_URL="",
+                DJANGO_WAF_VERIFY_URL="",
+                DJANGO_WAF_SITE_PASSWORD_ENABLED=False,
+            ),
+            patch("django_waf.services.redis_client.is_redis_backend", return_value=True),
+        ):
+            try:
+                call_command("check")
+            except SystemCheckError as exc:
+                assert "django_waf.E007" in str(exc)
+            else:
+                raise AssertionError("expected SystemCheckError from django_waf.E007")

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -528,6 +528,141 @@ class TestVerdictDispatch:
 
 
 # ---------------------------------------------------------------------------
+# Unroutable challenge URLs (#102)
+# ---------------------------------------------------------------------------
+
+
+class TestChallengedVerdictWithUnroutedUrlconf:
+    """A CHALLENGED verdict on a deployment that never routed
+    ``django_waf.urls`` must fail open, not 500 (#102, BR-EVAL-007).
+
+    ``_get_challenge_paths`` is ``setting or reverse(...)``, so with
+    ``DJANGO_WAF_CHALLENGE_URL`` and ``DJANGO_WAF_VERIFY_URL`` both empty and
+    the ``django_waf`` namespace absent from the active urlconf,
+    ``reverse("django_waf:challenge")`` raises ``NoReverseMatch``. Before
+    this fix the CHALLENGED branch of ``_handle_verdict`` called it
+    unguarded and the exception escaped ``__call__``, so a legitimate
+    visitor who merely tripped a detector got a 500 rather than a
+    challenge. There is no page to send them to, so the WAF must let the
+    request through and tell the operator loudly.
+
+    ``tests/urls_no_waf.py`` is a real urlconf that genuinely omits the
+    include: the resolver does the failing on its own, rather than the test
+    hand-building a ``NoReverseMatch`` that would pass whether or not the
+    guard exists.
+    """
+
+    def _run_challenged_on_unrouted_urlconf(self, caplog):
+        import logging
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("view response"))
+
+        with (
+            override_settings(
+                DJANGO_WAF_ENABLED=True,
+                ROOT_URLCONF="tests.urls_no_waf",
+                DJANGO_WAF_CHALLENGE_URL="",
+                DJANGO_WAF_VERIFY_URL="",
+            ),
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+            patch("django_waf.middleware._emit_request_blocked"),
+            patch("django_waf.middleware._emit_request_throttled"),
+            caplog.at_level(logging.ERROR, logger="django_waf.middleware"),
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result("challenged")
+
+            middleware = _make_middleware(get_response)
+            response = middleware(request)
+
+        return response, get_response
+
+    def test_challenged_verdict_passes_through_instead_of_500(self, caplog):
+        """The regression assertion for #102: the view is reached and its
+        response returned, rather than NoReverseMatch escaping as a 500."""
+        response, get_response = self._run_challenged_on_unrouted_urlconf(caplog)
+
+        assert response.status_code == 200
+        assert response.content == b"view response"
+        get_response.assert_called_once()
+
+    def test_challenged_verdict_logs_an_error_naming_the_fix(self, caplog):
+        """Failing open silently would leave an operator with a WAF that has
+        quietly stopped challenging anyone. The log must be at ERROR and must
+        name both remedies concretely, not just report that something went
+        wrong."""
+        self._run_challenged_on_unrouted_urlconf(caplog)
+
+        errors = [record.getMessage() for record in caplog.records if record.levelname == "ERROR"]
+        assert errors, "expected an ERROR log when the challenge URLs cannot be resolved"
+        message = "\n".join(errors)
+        assert "django_waf.urls" in message
+        assert "DJANGO_WAF_CHALLENGE_URL" in message
+        assert "DJANGO_WAF_VERIFY_URL" in message
+
+    def test_explicit_url_settings_still_redirect_on_unrouted_urlconf(self, caplog):
+        """The control for the two tests above: the same unrouted urlconf,
+        but with the explicit overrides set. ``reverse()`` is never reached,
+        so the challenge redirect happens exactly as normal. Without this,
+        the pass-through assertion could be satisfied by a middleware that
+        had simply stopped challenging altogether."""
+        import logging
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("view response"))
+
+        with (
+            override_settings(
+                DJANGO_WAF_ENABLED=True,
+                ROOT_URLCONF="tests.urls_no_waf",
+                DJANGO_WAF_CHALLENGE_URL="/custom/challenge/",
+                DJANGO_WAF_VERIFY_URL="/custom/verify/",
+            ),
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+            patch("django_waf.middleware._emit_request_blocked"),
+            patch("django_waf.middleware._emit_request_throttled"),
+            caplog.at_level(logging.ERROR, logger="django_waf.middleware"),
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result("challenged")
+
+            middleware = _make_middleware(get_response)
+            response = middleware(request)
+
+        assert response.status_code == 302
+        assert response["Location"].startswith("/custom/challenge/")
+        get_response.assert_not_called()
+        # Scoped to the fail-open log specifically, not to "no ERROR at all".
+        # The challenge path writes a RequestLog row, and this test carries no
+        # django_db mark (it asserts on the redirect, not on persistence), so
+        # that write raises and _record_request_log logs its own ERROR. A
+        # blanket "no ERROR records" assertion therefore fails for a reason
+        # that has nothing to do with the guard under test. What must be
+        # absent is the NoReverseMatch fail-open message: with both explicit
+        # overrides set, reverse() is never reached, so the guard must not
+        # have fired.
+        fail_open_errors = [
+            record.getMessage()
+            for record in caplog.records
+            if record.levelname == "ERROR" and "cannot resolve the challenge/verify URLs" in record.getMessage()
+        ]
+        assert not fail_open_errors, f"the fail-open guard fired despite explicit URL overrides: {fail_open_errors}"
+
+
+# ---------------------------------------------------------------------------
 # Fail-open behaviour
 # ---------------------------------------------------------------------------
 

--- a/tests/urls_no_waf.py
+++ b/tests/urls_no_waf.py
@@ -1,0 +1,31 @@
+"""A genuine URL configuration that does NOT route django_waf.urls.
+
+This is the #102 deployment shape: a project installs ``django_waf``, adds
+``WafMiddleware`` to ``MIDDLEWARE``, switches the WAF on, and never includes
+``django_waf.urls`` anywhere. ``reverse("django_waf:challenge")`` then raises
+``NoReverseMatch``, which before the fix escaped ``WafMiddleware.__call__``
+and served a 500 to any visitor who tripped a detector.
+
+It exists as a real module rather than as an inline approximation (an empty
+``urlpatterns``, or a mocked ``reverse``) because that is the whole point:
+a test that hand-builds the failure proves only that the mock was configured
+as expected. Pointed at with ``override_settings(ROOT_URLCONF=...)``, this
+module makes Django's real resolver do the failing on its own.
+
+``tests/urls.py`` is the counterpart that DOES include the namespace, and is
+the project default in ``tests/settings.py``.
+"""
+
+from django.http import HttpResponse
+from django.urls import path
+
+
+def noop_view(request):
+    """A simple view that returns a 200 OK response."""
+    return HttpResponse("OK")
+
+
+urlpatterns = [
+    path("", noop_view, name="root"),
+    # Deliberately no path("waf/", include("django_waf.urls", ...)) here.
+]


### PR DESCRIPTION
Wave 3. Two ways the package was worse for a consumer than it should be,
both consumer-facing rather than detection work.

Closes #102. Closes #74.

## #102 was sharper than the issue described

The issue says a challenged visitor "has no way back". The real behaviour was
an uncaught exception. With `django_waf.urls` routed nowhere and no explicit
URL override set, `_get_challenge_paths()` calls
`reverse("django_waf:challenge")` and raises `NoReverseMatch`, and no handler
for it existed anywhere in `middleware.py`. A legitimate visitor who merely
tripped a detector on a misconfigured deployment got a **500**.

The CHALLENGED branch now catches `NoReverseMatch` narrowly and fails open per
BR-EVAL-007: the request goes through to the view and an ERROR names both
fixes. Half-blocking a visitor behind a redirect to a page that does not exist
is strictly worse than letting them through.

`django_waf.E007` reports the same misconfiguration at boot. It fires when the
WAF is enabled, a challenge is reachable from settings, and at least one URL
override is empty, then reverses only the routes whose own override is unset.

The two settings are consumed on separate lines in `_get_challenge_paths`, so
each silences `reverse()` for its own route only. A project setting just one is
**still broken**, and the check says so, naming the route that actually fails.
An earlier draft of this check silenced on either setting and would have gone
quiet on exactly that configuration.

Both-set is the documented escape for per-host and per-request urlconfs, where
the `ROOT_URLCONF` active at check time is not the one serving traffic.
Condition 2 is settings-only and therefore not exhaustive, since a `BlockRule`
row with `action="challenge"` also produces a challenge and no boot check can
know whether one exists. The docstring states both limitations rather than
papering over them.

## #74, the block-response hook

`DJANGO_WAF_BLOCK_RESPONSE_HANDLER`, the package's first dotted-path setting,
resolved at call time via `import_string` so `override_settings` works. Unset,
the response is byte-identical to before.

Import failure, a raising handler, and a non-`HttpResponse` return each fall
back to the built-in 403 with their own log. A broken hook must never turn a
block into a pass, and must never surface as a 500 on a request the WAF is
already blocking. The import guard is deliberately broader than `ImportError`,
because importing the handler's module runs that module's top-level code, which
can raise `ImproperlyConfigured`, `SyntaxError` or `AppRegistryNotReady`.

Scope is BLOCKED verdicts only. `_check_country_block`'s direct 403 is
deliberately excluded and the reason is recorded at that return: it has no
`EvaluationResult` in scope at all, and synthesising one to satisfy the
signature would be a worse defect than the gap. Still tracked under #76.

## Consumer impact

**`E007` is an Error and will fail `manage.py check`** for a deployment with
the WAF enabled, challenges reachable, neither URL override set, and
`django_waf.urls` unrouted. Such a deployment was already serving 500s to
challenged visitors, so the check reports a live fault rather than inventing
one. Both fixes are named in the message and hint.

**Consumers overriding the private `_handle_verdict` will not pick up the
hook** until they rebase onto the new method or call
`self._build_block_response()` themselves. Their override keeps working; it
just will not honour the new setting.

## Verification

Every CI gate, run in clean venvs on the branch's own pins:

| Gate | Result |
|---|---|
| 7-leg matrix (py3.11/3.12/3.13 x Django 5.2/6.0/6.1) | 1372 passed, 6 skipped, coverage 93.51% vs a 90% floor |
| Real Redis 6.0.20 | 6 passed |
| Real PostgreSQL 16.13 | 1370 passed, 8 skipped |
| ruff 0.15.22 (check + format) | clean, 155 files |
| mypy 2.3.1 + django-stubs 6.1.0 | 89 source files, count guard passed |

No leg went unrun. The mypy pass is real, not the exit-2-checked-nothing trap:
a control run without `PYTHONPATH=.` produced a spurious error, confirming the
flag was load-bearing and present.

**Teeth proven on the two tests that matter**, by reverting each fix and
confirming failure. Reverting the guard made the pass-through test fail with
the actual `NoReverseMatch` while the both-overrides-set control still passed.
Restoring the old `or` gate made both parametrised partial-override cases fail
while the other six tests in the class passed. Code restored and checksummed
afterwards.

Two pre-existing test defects were found and fixed in passing: the end-to-end
`call_command("check")` pair was aborting on `E004` rather than the check under
test, and a control test ended in a blanket "no ERROR logs" assertion that was
passing for the wrong reason.

## Follow-ups filed

- #121, no boot check validates the dotted path (a typo surfaces only on the
  first blocked request).
- #76 updated with why country blocks are excluded from the hook.

Spec, `CHECKLIST.md` and `ROADMAP.md` changes land in the umbrella
(BR-EVAL-011, BR-EVAL-012, AC-EVAL-012..015, `django_waf.E007`).