### PR TITLE
fix(forms): remove the dead DJANGO_WAF_FORM_REPLAY_STORE setting (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- **`DJANGO_WAF_FORM_REPLAY_STORE`, a setting that was never read** (#73).
+  The setting was defined in `conf.py` with a default of `"session"` and
+  documented as choosing between a session-backed and a Redis-backed
+  replay store, but no Redis store was ever built: the only implementation
+  (`store_in_session` / `fetch_from_session` / `discard_from_session` in
+  `forms/services/replay.py`) goes straight to the session and never
+  consults the setting at all. Nobody asked for a Redis replay store, and
+  building one now purely to give a dead config key something to do would
+  be backwards: the setting is removed instead.
+
+  This is not a behaviour change for any consumer. A setting nothing reads
+  has no runtime effect to preserve, so a project with
+  `DJANGO_WAF_FORM_REPLAY_STORE = "session"` in its settings keeps working
+  identically after upgrading: Django ignores settings names a package
+  does not define, exactly as it always has for this one. The change is
+  purely that the package no longer claims a knob it never turned.
+
 ## [2.5.0] - 2026-09-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -354,7 +354,6 @@ until a form opts in via the mixin, decorator, or template tag.
 | `DJANGO_WAF_FORM_SIGNUP_VELOCITY_WINDOW` | `86400` | Window for completed-signup counter (24h) |
 | `DJANGO_WAF_FORM_SIGNUP_VELOCITY_LIMIT` | `5` | Successful signups per IP before next attempt is flagged |
 | `DJANGO_WAF_FORM_POW_DIFFICULTY` | `12` | Per-submission PoW difficulty (bits). 12 ≈ 4k SHA-256 hashes ≈ 50ms desktop / ~200ms mobile |
-| `DJANGO_WAF_FORM_REPLAY_STORE` | `"session"` | Where to stash FLAGGED POST data for replay. Only `"session"` is implemented |
 | `DJANGO_WAF_FORM_DEFENCE_WEIGHTS` | (see code) | Per-defence score weights; overridable per-form via `FormProtection(defence_weights={...})` |
 
 **Usage**: Django Form mixin (recommended for new forms):

--- a/docs/specs/forms/PRD.md
+++ b/docs/specs/forms/PRD.md
@@ -726,11 +726,12 @@ DJANGO_WAF_FORM_PROTECTION_ENABLED          = True
 DJANGO_WAF_FORM_FLAG_THRESHOLD              = 2.0
 DJANGO_WAF_FORM_BLOCK_THRESHOLD             = 5.0
 DJANGO_WAF_FORM_CHALLENGE_ON_FLAG           = True
-DJANGO_WAF_FORM_REPLAY_STORE                = "session"  # "session" | "redis"
 DJANGO_WAF_FORM_EMIT_PASSED_SIGNAL          = False      # opt-in; busy sites
                                                       # don't want the hot
                                                       # path firing signals
 ```
+
+Replay storage is the session only; there is no configurable backend.
 
 Plus the **package-wide signing key** (see §7.4):
 
@@ -1134,7 +1135,6 @@ DJANGO_WAF_FORM_PROTECTION_ENABLED          = True
 DJANGO_WAF_FORM_FLAG_THRESHOLD              = 2.0
 DJANGO_WAF_FORM_BLOCK_THRESHOLD             = 5.0
 DJANGO_WAF_FORM_CHALLENGE_ON_FLAG           = True
-DJANGO_WAF_FORM_REPLAY_STORE                = "session"
 DJANGO_WAF_FORM_EMIT_PASSED_SIGNAL          = False  # opt-in; off by default
 
 # Tokens (uses package-wide DJANGO_WAF_SIGNING_KEY for signature)

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -185,13 +185,6 @@ def _DJANGO_WAF_FORM_POW_DIFFICULTY() -> int:
     return _get_setting("DJANGO_WAF_FORM_POW_DIFFICULTY", 12)
 
 
-# Replay-store backend. ``session`` uses Django's session framework
-# (signed cookie + server-side data); ``redis`` uses the same Redis
-# the rest of the WAF talks to. Most sites use session.
-def _DJANGO_WAF_FORM_REPLAY_STORE() -> str:
-    return _get_setting("DJANGO_WAF_FORM_REPLAY_STORE", "session")
-
-
 # Global per-defence score weights. Overridable per-form via the
 # ``defence_weights={...}`` kwarg on ``FormProtection``. The dict
 # collapses what would otherwise be eight separate weight settings

--- a/src/django_waf/forms/services/replay.py
+++ b/src/django_waf/forms/services/replay.py
@@ -2,9 +2,8 @@
 
 When a form submission is FLAGGED and DJANGO_WAF_FORM_CHALLENGE_ON_FLAG
 is True, the orchestrator redirects to /waf/challenge/?next=...&form_
-replay=<token>. The replay token is a signed reference to data
-stashed in the request's session (or Redis, depending on
-DJANGO_WAF_FORM_REPLAY_STORE). On successful challenge, the verify view
+replay=<token>. The replay token is a signed reference to data stashed
+in the request's session. On successful challenge, the verify view
 looks up the data and re-issues the POST.
 
 Sensitive-field omission: password-like fields and file uploads are

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -171,6 +171,16 @@ class TestCallTimeResolution:
         with pytest.raises(AttributeError):
             _ = conf_mod.DJANGO_WAF_NOT_A_REAL_SETTING
 
+    def test_form_replay_store_setting_is_gone(self):
+        """DJANGO_WAF_FORM_REPLAY_STORE was removed (#73): it was defined
+        with a "session" default but never read anywhere in the package,
+        the only replay-store implementation goes straight to the session
+        regardless. Accessing it must raise AttributeError like any other
+        unknown name, so a dead setting cannot silently come back.
+        """
+        with pytest.raises(AttributeError):
+            _ = conf_mod.DJANGO_WAF_FORM_REPLAY_STORE
+
 
 class TestSitePasswordEnabledDerivation:
     """DJANGO_WAF_SITE_PASSWORD_ENABLED recurses through the resolver for


### PR DESCRIPTION
Closes #73.

`DJANGO_WAF_FORM_REPLAY_STORE` was defined in `conf.py` but never read by
any code path. The only replay store implementation goes straight to the
session (`store_in_session` / `fetch_from_session` / `discard_from_session`).
The `replay.py` module docstring meanwhile described a Redis-backed
alternative that does not exist, and the forms PRD offered
`"session" | "redis"` as if it were a choice.

## Removed rather than implemented

Nobody asked for a Redis replay store, and no consumer can be using one:
the setting is unreadable by construction. Building a second storage
backend to justify a dead config key is the wrong way round, so the key
goes and the code becomes honest immediately.

## No behaviour change on upgrade

The setting was never consulted, so removing it changes no runtime
behaviour. A consumer with `DJANGO_WAF_FORM_REPLAY_STORE = "session"` still
in their settings keeps working identically, since Django ignores settings
a package does not define. Not treated as a breaking change on that basis.

## Changed

- `conf.py`: deleted the `_DJANGO_WAF_FORM_REPLAY_STORE` resolver. `_RESOLVERS`
  is built by scanning `globals()` for `_DJANGO_WAF_*` callables, so removing
  the function is sufficient to drop it from `__getattr__` dispatch.
- `forms/services/replay.py`: docstring now describes session storage only.
- `docs/specs/forms/PRD.md`: both sites (§7.1 and Appendix B). §7.1 gains a
  line positively stating that replay storage is session-only with no
  configurable backend, so the spec asserts the constraint rather than
  falling silent.
- `README.md`: dropped the settings-table row.
- `tests/test_conf.py`: a regression test asserting the name now raises
  `AttributeError`, so it cannot quietly return as dead config.

A grep across `src/`, `tests/`, `docs/`, `README.md` and `CHANGELOG.md`
confirms no other references remain.