### PR TITLE
fix(checks): warn when a DJANGO_WAF_* env var has no effect (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **A system check for `DJANGO_WAF_*` settings set only as environment
+  variables** (#106, `django_waf.W010`). Every `DJANGO_WAF_*` setting is
+  resolved from `django.conf.settings` only: `conf._get_setting` never
+  consults `os.environ`, which is deliberate (Django settings stay the
+  single source of truth), but it means an operator who sets one as an
+  environment variable, the natural reading of a deployment-time flag,
+  gets no error, no log line and no indication anything is wrong. Found on
+  a real deployment where `DJANGO_WAF_FEED_REPORT=True` was set in `.env`
+  and telemetry had never been sent.
+
+  `check_env_only_settings` warns when a name in `conf._RESOLVERS` (every
+  setting the package resolves, not a hand-written list that could drift
+  from it) is present in `os.environ` but absent from `settings`, naming
+  the offending variable(s). Silent when the Django setting is also
+  assigned (the environment variable's presence is then redundant, not a
+  misconfiguration) and silent when neither is set. Not gated on
+  `DJANGO_WAF_ENABLED`, mirroring `django_waf.W008`/`W009`: this is a
+  static fact about configuration plumbing, not a live per-request
+  evaluation path.
+
+  Also corrects the comment above `_DJANGO_WAF_FEED_REPORT` (`conf.py`),
+  which read as a completeness guarantee ("Setting this to True is the
+  only step a site needs to start reporting") without saying *where*
+  (the Django settings module, never the environment), the misreading
+  that produced the original report.
+
 ## [2.5.0] - 2026-09-03
 
 ### Added

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -172,9 +172,43 @@ all (BR-EVAL-002 already makes a present-but-enabled middleware a total
 pass-through), so the absence of a middleware nobody asked to run is not a
 misconfiguration, matching the gating rationale #95 established for every
 other check in this module.
+
+The environment-variable check (``django_waf.W010``) warns when a
+``DJANGO_WAF_*`` name is present in ``os.environ`` but the resolved Django
+setting of the same name is not explicitly configured, so the environment
+variable has no effect (issue #106). Every ``DJANGO_WAF_*`` setting is
+resolved from ``django.conf.settings`` only (``conf._get_setting`` is a
+plain ``getattr(settings, name, default)``; it never consults
+``os.environ``). That is by design: ``django.conf.settings`` is the
+single source of truth this package resolves against, and reading the
+environment as a silent fallback would surprise a consumer who
+deliberately keeps environment and settings separate. The trap is that a
+deployment-time flag such as ``DJANGO_WAF_FEED_REPORT=True`` in a
+``.env`` file reads as a perfectly reasonable way to set it, and nothing
+before this check told the operator otherwise: the URLs it depends on
+resolve to working defaults regardless, and the feature it gates (feed
+telemetry reporting) produces no local artefact whose absence would be
+noticed. Found on a real deployment where telemetry had never been sent.
+Every ``DJANGO_WAF_*`` name is checked, not only ``DJANGO_WAF_FEED_REPORT``:
+the same trap applies to any of them, and a check scoped to one setting
+would leave the rest silent. The setting names checked against come from
+``conf._RESOLVERS`` (the same dict backing ``conf.__getattr__``), so a
+setting added or renamed in ``conf.py`` is covered automatically rather
+than needing a second, hand-maintained list that can drift from the first.
+Silent when both are set (the operator has also set the Django setting, so
+the environment variable's presence is redundant, not a misconfiguration)
+and silent when neither is set. Deliberately NOT gated on
+``DJANGO_WAF_ENABLED``: unlike the checks gated on it (#95), this is not
+about a live evaluation path being switched off. It is a static fact
+about the deployment's configuration plumbing (an environment variable
+that silently does nothing), true or false independent of whether the WAF
+is currently enforcing requests, mirroring the rationale ``django_waf.W008``
+and ``django_waf.W009`` already give for staying ungated.
 """
 
 from __future__ import annotations
+
+import os
 
 from django.core.checks import Error, Warning, register
 
@@ -781,5 +815,60 @@ def check_redis_version(app_configs, **kwargs):
                 "meets the floor."
             ),
             id="django_waf.E005",
+        )
+    ]
+
+
+@register()
+def check_env_only_settings(app_configs, **kwargs):
+    """Warn (``django_waf.W010``) when a ``DJANGO_WAF_*`` name is present in
+    ``os.environ`` but has no matching Django setting, so it has no effect
+    (issue #106).
+
+    Every ``DJANGO_WAF_*`` setting is resolved from ``django.conf.settings``
+    only (``conf._get_setting`` never consults ``os.environ``), which is
+    deliberate: Django settings stay the single source of truth. This check
+    does not change that resolution; it only warns when it looks like the
+    operator believes the environment variable is doing something it is
+    not, as happened on a real deployment where ``DJANGO_WAF_FEED_REPORT``
+    was set in ``.env`` and telemetry was never sent.
+
+    Checked against every name in ``conf._RESOLVERS`` (the same dict that
+    backs ``conf.__getattr__``'s call-time resolution), not a hand-written
+    list, so a setting added or renamed in ``conf.py`` is covered without a
+    second place to update. Silent when the Django setting is also present:
+    the operator has taken the deliberate step of assigning it, so the
+    environment variable's presence alongside it is redundant rather than
+    a misconfiguration. This check does not compare values, only
+    presence.
+
+    Not gated on ``DJANGO_WAF_ENABLED``: this is a static fact about the
+    deployment's configuration plumbing, not a live per-request evaluation
+    path, mirroring the ungated rationale ``django_waf.W008`` and
+    ``django_waf.W009`` already document.
+    """
+    from django.conf import settings
+
+    from django_waf import conf
+
+    _unset = object()
+    ineffective = sorted(
+        name for name in conf._RESOLVERS if name in os.environ and getattr(settings, name, _unset) is _unset
+    )
+    if not ineffective:
+        return []
+
+    names = ", ".join(ineffective)
+    return [
+        Warning(
+            f"Set in the environment but not as a Django setting, so it has "
+            f"no effect: {names}. django-waf reads Django settings only, "
+            "never os.environ.",
+            hint=(
+                "Assign the setting in your settings module instead, e.g. "
+                "DJANGO_WAF_FEED_REPORT = os.environ.get('DJANGO_WAF_FEED_REPORT') "
+                "== 'True', or your project's usual env-parsing helper."
+            ),
+            id="django_waf.W010",
         )
     ]

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -370,8 +370,11 @@ def _DJANGO_WAF_FEED_MIN_CONFIDENCE() -> float:
 # Enable reporting local detections back to the collective feed. Opt-in by
 # design (ADR-021 point 4): telemetry is never sent unless an operator sets
 # this to True, regardless of whether DJANGO_WAF_FEED_REPORT_URL is
-# configured. Setting this to True is the only step a site needs to start
-# reporting.
+# configured. Setting this to True in the Django settings module is the
+# only step a site needs to start reporting: this resolver never consults
+# os.environ (see _get_setting), so an environment variable of the same
+# name has no effect on its own and django_waf.W010 warns when one is set
+# with no matching Django setting (issue #106).
 def _DJANGO_WAF_FEED_REPORT() -> bool:
     return _get_setting("DJANGO_WAF_FEED_REPORT", False)
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -8,11 +8,40 @@ users out. The check refuses settings that would reproduce that lockout.
 
 from __future__ import annotations
 
+import os
+from contextlib import contextmanager
 from unittest.mock import patch
 
 from django.core.management import call_command
 from django.core.management.base import SystemCheckError
 from django.test import override_settings
+
+
+@contextmanager
+def _setting_absent(name):
+    """Temporarily remove a Django setting attribute entirely, restoring it
+    (present or absent, whatever it was) on exit.
+
+    ``override_settings`` can only set/replace a value; it cannot delete an
+    attribute that a project's settings module already assigned, and
+    ``tests/settings.py`` assigns ``DJANGO_WAF_FEED_REPORT`` explicitly. This
+    check's whole distinction is "assigned at all", not "assigned to what
+    value", so the test needs to make the attribute genuinely absent, not
+    merely falsy.
+    """
+    from django.conf import settings
+
+    had_value = hasattr(settings, name)
+    previous = getattr(settings, name, None)
+    if had_value:
+        delattr(settings, name)
+    try:
+        yield
+    finally:
+        if had_value:
+            setattr(settings, name, previous)
+        elif hasattr(settings, name):
+            delattr(settings, name)
 
 
 def _run_checks():
@@ -85,6 +114,12 @@ def _run_middleware_present_check():
     from django_waf.checks import check_middleware_present
 
     return check_middleware_present(app_configs=None)
+
+
+def _run_env_only_settings_check():
+    from django_waf.checks import check_env_only_settings
+
+    return check_env_only_settings(app_configs=None)
 
 
 class TestChallengeDifficultyCheck:
@@ -765,6 +800,65 @@ class TestRedisVersionCheck:
             patch("django_waf.services.redis_client.get_redis_server_version", return_value=None),
         ):
             assert _run_redis_version_check() == []
+
+
+class TestEnvOnlySettingsCheck:
+    """django_waf.W010: warns when a DJANGO_WAF_* name is present in
+    os.environ but has no matching Django setting, so it has no effect
+    (issue #106). A real deployment set DJANGO_WAF_FEED_REPORT=True in
+    .env, believed reporting was on, and no telemetry was ever sent."""
+
+    def test_env_set_and_setting_absent_emits_w010_warning(self):
+        with (
+            _setting_absent("DJANGO_WAF_FEED_REPORT"),
+            patch.dict(os.environ, {"DJANGO_WAF_FEED_REPORT": "True"}),
+        ):
+            messages = _run_env_only_settings_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.W010"
+
+    def test_message_names_the_offending_variable(self):
+        with (
+            _setting_absent("DJANGO_WAF_FEED_REPORT"),
+            patch.dict(os.environ, {"DJANGO_WAF_FEED_REPORT": "True"}),
+        ):
+            messages = _run_env_only_settings_check()
+
+        assert "DJANGO_WAF_FEED_REPORT" in messages[0].msg
+
+    def test_env_set_and_setting_also_set_is_silent(self):
+        """The operator has taken the deliberate step of assigning the
+        Django setting too, so the environment variable's presence
+        alongside it is redundant, not a misconfiguration this check
+        should flag."""
+        with (
+            override_settings(DJANGO_WAF_FEED_REPORT=True),
+            patch.dict(os.environ, {"DJANGO_WAF_FEED_REPORT": "True"}),
+        ):
+            assert _run_env_only_settings_check() == []
+
+    def test_neither_set_is_silent(self):
+        with _setting_absent("DJANGO_WAF_FEED_REPORT"), patch.dict(os.environ):
+            os.environ.pop("DJANGO_WAF_FEED_REPORT", None)
+            assert _run_env_only_settings_check() == []
+
+    def test_env_var_with_no_django_waf_prefix_is_ignored(self):
+        """Only names django-waf actually resolves are in scope: an
+        unrelated FEED_REPORT-shaped variable with no DJANGO_WAF_ prefix
+        is not one of its settings and must not be reported."""
+        with patch.dict(os.environ, {"FEED_REPORT": "True"}):
+            assert _run_env_only_settings_check() == []
+
+    def test_covers_a_setting_other_than_feed_report(self):
+        """Issue #106 asked for every DJANGO_WAF_* name to be covered, not
+        only DJANGO_WAF_FEED_REPORT: the same trap applies to any of them.
+        DJANGO_WAF_SIGNING_KEY is not set in tests/settings.py, so it is
+        already absent without needing _setting_absent."""
+        with patch.dict(os.environ, {"DJANGO_WAF_SIGNING_KEY": "some-key"}):
+            messages = _run_env_only_settings_check()
+
+        assert any(m.id == "django_waf.W010" and "DJANGO_WAF_SIGNING_KEY" in m.msg for m in messages)
 
 
 class TestSitePasswordConfiguredCheck:


### PR DESCRIPTION
Closes #106.

`DJANGO_WAF_FEED_REPORT` set as an environment variable was silently
ignored, so telemetry reporting stayed off with no indication anything was
wrong. Found on a real deployment where `DJANGO_WAF_FEED_REPORT=True` was
in `.env` and telemetry had never been sent. The operator's reasonable
belief was that reporting was on.

## Warn, rather than start reading the environment

`conf._get_setting` is `getattr(settings, name, default)` and never
consults `os.environ`. Making it read the environment would silently change
resolution for all ~100 `DJANGO_WAF_*` settings at once, and would let an
environment variable override an explicit Django setting across the whole
package. That is the wrong blast radius for this defect.

The complaint in #106 is that the misconfiguration is *silent*, so the fix
makes it loud. Django settings remain the single source of truth.

## django_waf.W010

Fires when a `DJANGO_WAF_*` name is present in `os.environ` and the Django
setting of the same name is unset, meaning the environment variable has no
effect. Silent when both are set, and silent when neither is.

Two details worth noting for review:

- **Every `DJANGO_WAF_*` name is covered, not just `FEED_REPORT`.** The same
  trap applies to all of them, and a check scoped to one setting leaves the
  rest silent. The names come from `conf._RESOLVERS`, the dict backing
  `conf.__getattr__`, so a setting added or renamed in `conf.py` is covered
  automatically rather than needing a second hand-maintained list that
  would drift.
- **Presence, not value.** It uses a sentinel with `getattr`, so a setting
  explicitly assigned `None` or `False` counts as configured. The check
  never compares the environment value to the settings value.

Not gated on `DJANGO_WAF_ENABLED`, matching the rationale `W008` and `W009`
already document: this is a static fact about configuration plumbing, true
or false regardless of whether the WAF is currently evaluating requests.
Gating it would hide the problem from exactly the deployments most likely
to have it.

Also corrects the comment above `_DJANGO_WAF_FEED_REPORT`, which said
"Setting this to True is the only step a site needs to start reporting".
Accurate about the Django setting, and the sentence most likely to be read
by an operator turning reporting on via the environment.

## Verified

W010 driven directly against this branch, not reasoned about: env var set
with the setting absent emits exactly one `django_waf.W010`; setting it in
settings as well goes silent; removing both goes silent.