### PR TITLE
fix(tasks): a malformed IP no longer aborts the whole parse_access_log batch (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **A malformed IP in the nginx access log no longer aborts the whole
+  `parse_access_log` batch** (#72). The parse loop took `ip_address` straight
+  from the regex match with no validation; the first `ValueError` Django's
+  own `GenericIPAddressField` validation raised, from deep inside
+  `bulk_create`, escaped the surrounding `except OSError` and discarded the
+  entire batch, including every well-formed row. Observed in production at
+  a consuming application: 54 Bugsnag events. Access logs are
+  attacker-influenced input, so a malformed value in the IP position is an
+  expected condition, not an exceptional one.
+
+  The loop now validates each IP with `django.core.validators.validate_ipv46_address`,
+  the exact validator `RequestLog.ip_address` (`GenericIPAddressField`,
+  `protocol="both"`) runs at write time, and skips the row (counted in the
+  existing `skipped_lines`) rather than including it in the batch. The
+  status code is checked the same way against the `response_code` column's
+  smallint range, since the regex only guarantees digits, not that the
+  value fits the column, and an out-of-range value is the same
+  batch-abort failure mode. A single summarising `WARNING` log line reports
+  how many lines were skipped for a malformed IP, rather than one line per
+  bad row.
+
 ## [2.5.0] - 2026-09-03
 
 ### Added

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -172,11 +172,20 @@ def parse_access_log(log_path: str | None = None) -> dict:
         r'(?:\s+"[^"]*"\s+"([^"]*)")?'
     )
 
-    # response_code is a PositiveSmallIntegerField (SQL smallint), max 32767
-    # across every backend Django supports. The regex only guarantees the
-    # matched group is digits, not that it fits the column, so a corrupted
-    # or crafted line with an oversized status code is validated the same
-    # way as the IP address below rather than reaching bulk_create.
+    # response_code is a PositiveSmallIntegerField. The regex only
+    # guarantees the matched group is digits, not that it fits the column,
+    # so a corrupted or crafted line with an oversized status code is
+    # validated the same way as the IP address below rather than reaching
+    # bulk_create.
+    #
+    # 32767 is PostgreSQL's signed-smallint ceiling, which is what
+    # connection.ops.integer_field_range reports for this field on
+    # PostgreSQL (verified) and the tightest bound among the backends this
+    # package supports. It is deliberately a fixed literal rather than a
+    # per-backend lookup: the bound is only used to reject a value no real
+    # access log carries, so the tightest one is correct everywhere, and
+    # introducing a backend-dependent limit inside the parse loop would
+    # make ingestion silently accept different rows on different databases.
     _MAX_SMALLINT = 32767
 
     records_to_create = []

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -101,6 +101,16 @@ def parse_access_log(log_path: str | None = None) -> dict:
     the stored offset is treated as invalid and reset to 0 rather than
     silently skipping the file's live tail forever.
 
+    A line whose IP address does not pass the same validation
+    ``RequestLog.ip_address`` (``GenericIPAddressField``) would apply at
+    write time, or whose status code exceeds the ``response_code`` column's
+    smallint range, is skipped (counted in ``skipped_lines``) rather than
+    included in the batch (#72). Access logs are attacker-influenced input,
+    so a malformed value in either position is an expected condition: before
+    this validation, one bad IP raised ``ValueError`` from Django's own
+    field validation inside ``bulk_create``, escaped the ``except OSError``
+    below, and discarded the whole batch, including every well-formed row.
+
     Args:
         log_path: Override path. Defaults to DJANGO_WAF_ACCESS_LOG_PATH.
 
@@ -112,6 +122,8 @@ def parse_access_log(log_path: str | None = None) -> dict:
     import os
 
     from django.core.cache import cache
+    from django.core.exceptions import ValidationError as DjangoValidationError
+    from django.core.validators import validate_ipv46_address
 
     from django_waf import conf
     from django_waf.enums import RequestLogSource
@@ -151,6 +163,7 @@ def parse_access_log(log_path: str | None = None) -> dict:
         stored_offset = 0
 
     parsed_lines = created_records = skipped_lines = 0
+    skipped_ip_lines = 0
 
     # Combined log format pattern:
     # IP - - [timestamp] "METHOD /path HTTP/x.x" status size "referer" "ua"
@@ -158,6 +171,13 @@ def parse_access_log(log_path: str | None = None) -> dict:
         r'^(\S+)\s+-\s+-\s+\[([^\]]+)\]\s+"(\S+)\s+(\S+)\s+\S+"\s+(\d+)\s+\S+'
         r'(?:\s+"[^"]*"\s+"([^"]*)")?'
     )
+
+    # response_code is a PositiveSmallIntegerField (SQL smallint), max 32767
+    # across every backend Django supports. The regex only guarantees the
+    # matched group is digits, not that it fits the column, so a corrupted
+    # or crafted line with an oversized status code is validated the same
+    # way as the IP address below rather than reaching bulk_create.
+    _MAX_SMALLINT = 32767
 
     records_to_create = []
 
@@ -192,6 +212,27 @@ def parse_access_log(log_path: str | None = None) -> dict:
                 status_code = int(match.group(5))
                 user_agent = (match.group(6) or "")[:1024]
 
+                # Access logs are attacker-influenced input, so a malformed
+                # value in the IP position is an expected condition, not an
+                # exceptional one (#72). validate_ipv46_address is the exact
+                # validator RequestLog.ip_address (GenericIPAddressField,
+                # protocol="both") runs at full_clean() time, so "valid"
+                # here means precisely what the field will accept at write
+                # time; previously nothing validated this before
+                # bulk_create, so one malformed IP raised ValueError from
+                # Django's own field validation deep inside bulk_create and
+                # discarded the whole batch, including every well-formed row.
+                try:
+                    validate_ipv46_address(ip_address)
+                except DjangoValidationError:
+                    skipped_lines += 1
+                    skipped_ip_lines += 1
+                    continue
+
+                if status_code > _MAX_SMALLINT:
+                    skipped_lines += 1
+                    continue
+
                 log_timestamp = _parse_nginx_timestamp(timestamp_str)
                 event_id = _build_source_event_id(ip_address, timestamp_str, method, path_str, status_code)
 
@@ -216,6 +257,17 @@ def parse_access_log(log_path: str | None = None) -> dict:
             created_records = len(records_to_create)
 
         cache.set(offset_key, new_offset, timeout=None)
+
+        if skipped_ip_lines:
+            # One summarising line rather than one per bad line: a burst of
+            # malformed IPs (a proxy misconfiguration, a crafted header) is
+            # exactly the condition this validation exists to survive, so
+            # logging per-line at WARNING would itself flood production.
+            logger.warning(
+                "django-waf: skipped %d access log line(s) with a malformed IP address (path=%s)",
+                skipped_ip_lines,
+                path,
+            )
 
     except OSError as exc:
         logger.error("django-waf: error reading access log %s: %s", path, exc)

--- a/tests/test_log_ingestion.py
+++ b/tests/test_log_ingestion.py
@@ -244,3 +244,125 @@ class TestDetectorSourceAwareness:
         rules = detect_unsolved_challenges(window_minutes=10, min_challenged=3)
 
         assert rules == []
+
+
+# ---------------------------------------------------------------------------
+# malformed IP does not abort the batch (#72)
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedIPDoesNotAbortBatch:
+    @pytest.mark.django_db
+    def test_one_malformed_ip_is_skipped_and_good_rows_still_persist(self):
+        """A malformed IP is skipped; every well-formed row in the same batch still persists.
+
+        This is the key regression test for #72. Against the unfixed code,
+        the malformed IP on the middle line reaches
+        RequestLog.objects.bulk_create unvalidated. Django's own
+        GenericIPAddressField validation raises ValueError from inside
+        bulk_create; nothing in this task catches ValueError (only OSError
+        is caught), so it propagates out of parse_access_log entirely, and
+        the whole batch, including the two well-formed rows either side of
+        the bad one, is lost. Fixed, the malformed line is validated and
+        skipped before being appended to records_to_create, so the task
+        does not raise and the two good rows are created.
+        """
+        log_content = (
+            '1.2.3.4 - - [07/Apr/2026:10:00:00 +0000] "GET /a/ HTTP/1.1" 200 10 "-" "ua"\n'
+            '999.999.999.999 - - [07/Apr/2026:10:00:01 +0000] "GET /bad/ HTTP/1.1" 200 10 "-" "ua"\n'
+            '5.6.7.8 - - [07/Apr/2026:10:00:02 +0000] "GET /b/ HTTP/1.1" 200 10 "-" "ua"\n'
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as fh:
+            fh.write(log_content)
+            log_path = fh.name
+
+        from django_waf.models import RequestLog
+        from django_waf.tasks import parse_access_log
+
+        # Must not raise. This is the actual defect (#72): a ValueError from
+        # Django's field validation escaping the task entirely.
+        result = parse_access_log(log_path=log_path)
+
+        assert result["parsed_lines"] == 3
+        assert result["created_records"] == 2
+        assert result["skipped_lines"] == 1
+
+        assert RequestLog.objects.count() == 2
+        assert RequestLog.objects.filter(path="/a/").exists()
+        assert RequestLog.objects.filter(path="/b/").exists()
+        assert not RequestLog.objects.filter(path="/bad/").exists()
+
+    @pytest.mark.django_db
+    def test_malformed_ip_summary_logged_once_not_per_line(self, caplog):
+        """Skipped malformed IPs are reported as one summarising WARNING, not one per line."""
+        import logging
+
+        log_content = (
+            '999.999.999.999 - - [07/Apr/2026:10:00:00 +0000] "GET /x/ HTTP/1.1" 200 10 "-" "ua"\n'
+            'also-not-an-ip - - [07/Apr/2026:10:00:01 +0000] "GET /y/ HTTP/1.1" 200 10 "-" "ua"\n'
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as fh:
+            fh.write(log_content)
+            log_path = fh.name
+
+        from django_waf.tasks import parse_access_log
+
+        with caplog.at_level(logging.WARNING, logger="django_waf.tasks"):
+            result = parse_access_log(log_path=log_path)
+
+        assert result["skipped_lines"] == 2
+        malformed_ip_lines = [r for r in caplog.records if "malformed ip" in r.message.lower()]
+        assert len(malformed_ip_lines) == 1
+        assert "2" in malformed_ip_lines[0].message
+
+    @pytest.mark.django_db
+    def test_all_good_rows_batch_is_unaffected(self):
+        """A batch of entirely well-formed rows behaves exactly as before, no regression."""
+        log_content = (
+            '1.2.3.4 - - [07/Apr/2026:10:00:00 +0000] "GET /a/ HTTP/1.1" 200 10 "-" "ua"\n'
+            '5.6.7.8 - - [07/Apr/2026:10:00:01 +0000] "GET /b/ HTTP/1.1" 200 10 "-" "ua"\n'
+            '::1 - - [07/Apr/2026:10:00:02 +0000] "GET /c/ HTTP/1.1" 200 10 "-" "ua"\n'
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as fh:
+            fh.write(log_content)
+            log_path = fh.name
+
+        from django_waf.models import RequestLog
+        from django_waf.tasks import parse_access_log
+
+        result = parse_access_log(log_path=log_path)
+
+        assert result["parsed_lines"] == 3
+        assert result["created_records"] == 3
+        assert result["skipped_lines"] == 0
+        assert RequestLog.objects.count() == 3
+
+    @pytest.mark.django_db
+    def test_out_of_range_status_code_is_skipped_not_abort_the_batch(self):
+        """A status code outside the response_code column's smallint range is skipped, not fatal.
+
+        response_code is a PositiveSmallIntegerField (SQL smallint, max
+        32767). The regex only guarantees the matched group is digits, not
+        that it fits the column, so a corrupted or crafted line with an
+        oversized status code is the same batch-abort failure mode as the
+        malformed-IP case, and is validated the same way.
+        """
+        log_content = (
+            '1.2.3.4 - - [07/Apr/2026:10:00:00 +0000] "GET /a/ HTTP/1.1" 999999 10 "-" "ua"\n'
+            '5.6.7.8 - - [07/Apr/2026:10:00:01 +0000] "GET /b/ HTTP/1.1" 200 10 "-" "ua"\n'
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as fh:
+            fh.write(log_content)
+            log_path = fh.name
+
+        from django_waf.models import RequestLog
+        from django_waf.tasks import parse_access_log
+
+        result = parse_access_log(log_path=log_path)
+
+        assert result["parsed_lines"] == 2
+        assert result["created_records"] == 1
+        assert result["skipped_lines"] == 1
+        assert RequestLog.objects.count() == 1
+        assert RequestLog.objects.filter(path="/b/").exists()
+        assert not RequestLog.objects.filter(path="/a/").exists()


### PR DESCRIPTION
Closes #72.

A malformed IP in the nginx access log aborted the entire
`parse_access_log` bulk insert rather than skipping the one bad row, so one
unparseable value discarded every well-formed record in the batch. Observed
in production at a consuming application, 54 Bugsnag events, surviving a
1.3.0 to 1.5.2 upgrade.

## The mechanism is not where the issue title suggests

Nothing in the parse loop raises. `ip_address` is taken straight from the
regex with no validation and passed through unchecked. The `ValueError`
comes from Django validating `GenericIPAddressField` inside
`bulk_create`, and the surrounding `try` catches `OSError` only, so it
escapes the task entirely and the whole batch is lost.

The fix therefore belongs at validation time in the loop, not in a wider
`except`.

## Validation matches the field exactly

`validate_ipv46_address` is not merely an equivalent validator, it is the
identical object `RequestLog.ip_address` runs. Verified:
`GenericIPAddressField().default_validators == [validate_ipv46_address]`,
and the field is declared with no `protocol` kwarg, so `protocol="both"`.
A validator that disagreed with the field would just be the same bug again.

Bad rows are counted in the existing `skipped_lines` return key and
reported in a single summarising WARNING after the loop, not once per line:
a burst of malformed IPs is precisely the condition this exists to survive,
so per-line logging would itself flood production.

## A second instance of the same defect class

The issue asked whether other fields parsed in the same path share the
fragility. Checked all of them:

- `_parse_nginx_timestamp`: already safe, catches its own `ValueError` and
  falls back to `timezone.now()`.
- `method`, `path`, `user_agent`: safe by construction, each sliced to
  exactly the model field's `max_length`.
- **`status_code`: genuinely vulnerable.** `int()` cannot raise given the
  `(\d+)` regex guard, but `response_code` is a
  `PositiveSmallIntegerField` and nothing bounded the digit run to the
  column's range. An oversized value passes the regex, builds a
  `RequestLog`, and fails at `bulk_create` with a database error, uncaught,
  aborting the batch exactly as the IP defect did. Fixed the same way.

On the bound: 32767 is PostgreSQL's `smallint` ceiling, which
`connection.ops.integer_field_range` confirms for this field on PostgreSQL.
It is not universal, and the comment has been corrected to say so: on
SQLite the column is `smallint unsigned` and the reported range is
`(0, 9223372036854775807)`. The literal stays, being the tightest bound and
the production backend's, with the reasoning recorded so a future reader
does not "fix" it into a backend-dependent limit that would make ingestion
accept different rows on different databases.