### PR TITLE
fix(testing): derive factory fields from their production invariants (#91)

### DIFF
--- a/src/django_waf/testing/factories.py
+++ b/src/django_waf/testing/factories.py
@@ -43,7 +43,27 @@ class BlockRuleFactory(factory.django.DjangoModelFactory):
     feed_first_seen = None
     feed_reporters = 0
     notes = ""
-    review_status = ReviewStatus.NOT_APPLICABLE
+    # _get_or_create_auto_rule (anomaly_detector.py) derives review_status
+    # from (source, is_active) at create time: an AUTO rule is
+    # is_active=False/review_status=PENDING when quarantined, or
+    # is_active=True/review_status=NOT_APPLICABLE when created enforcing
+    # (BR-ANOM-007/BR-ANOM-008). Admin and feed rules never get that
+    # derivation: django_waf_block.py, django_waf_import_rules.py and
+    # threat_feed.py all leave review_status untouched (the model default,
+    # NOT_APPLICABLE) regardless of is_active. A flat NOT_APPLICABLE default
+    # here would let a caller build source=AUTO, is_active=False with
+    # review_status=NOT_APPLICABLE, a state the detector never writes. A
+    # caller who passes review_status explicitly, including a value that
+    # contradicts the derivation (e.g. the CONFIRMED/REJECTED states
+    # DashboardAnomalyConfirmView/RejectView write in views.py), still wins:
+    # that is a normal keyword override and takes precedence over this
+    # class-level default, exactly as ChallengeTokenFactory.solved_at does
+    # after #86.
+    review_status = factory.LazyAttribute(
+        lambda o: (
+            ReviewStatus.PENDING if o.source == RuleSource.AUTO and not o.is_active else ReviewStatus.NOT_APPLICABLE
+        )
+    )
     reviewed_at = None
     detectors = ""
 
@@ -92,7 +112,22 @@ class RequestLogFactory(factory.django.DjangoModelFactory):
     method = "GET"
     verdict = Verdict.ALLOWED
     matched_rule_id = None
-    matched_rule_type = ""
+    # rule_engine.evaluate_request writes matched_rule_id and
+    # matched_rule_type as a strict pair throughout (both None/"" when
+    # nothing matched an AllowRule/BlockRule, or both set together: "allow"
+    # with a real UUID, "block" with a real UUID). This holds independently
+    # of verdict: a score-based or malformed-cache-value BLOCKED verdict
+    # still carries matched_rule_id=None, matched_rule_type="" (rule_engine.py,
+    # the score-based and Redis fast-path branches), so verdict itself is
+    # NOT part of this coupling. A caller overriding only matched_rule_id
+    # (leaving matched_rule_type at its flat default of "") would build a
+    # row rule_engine never writes: an id with no type. "block" is the
+    # default derived type (the common case in tests, matching BlockRule's
+    # matched_rule_type value at rule_engine.py) but a caller who wants
+    # "allow" still overrides matched_rule_type explicitly, which wins over
+    # this derivation exactly as ChallengeTokenFactory.solved_at does after
+    # #86.
+    matched_rule_type = factory.LazyAttribute(lambda o: "" if o.matched_rule_id is None else "block")
     anomaly_score = None
     response_code = 200
     country_code = ""

--- a/tests/test_testing_fixtures.py
+++ b/tests/test_testing_fixtures.py
@@ -143,6 +143,135 @@ class TestChallengeTokenFactoryStatusInvariants:
 
 
 # ---------------------------------------------------------------------------
+# BlockRuleFactory source/is_active/review_status derivation
+# ---------------------------------------------------------------------------
+
+
+class TestBlockRuleFactoryReviewStatusInvariants:
+    """BlockRuleFactory must not produce a state production cannot (#91).
+
+    _get_or_create_auto_rule (anomaly_detector.py) pairs is_active=False with
+    review_status=PENDING, and is_active=True with review_status=NOT_APPLICABLE,
+    but only for source=AUTO. Admin and feed rules stay NOT_APPLICABLE
+    regardless of is_active.
+    """
+
+    @pytest.mark.django_db
+    def test_auto_source_inactive_derives_pending_review_status(self):
+        from django_waf.enums import ReviewStatus, RuleSource
+        from django_waf.testing.factories import BlockRuleFactory
+
+        rule = BlockRuleFactory(source=RuleSource.AUTO, is_active=False)
+
+        assert rule.review_status == ReviewStatus.PENDING
+
+    @pytest.mark.django_db
+    def test_auto_source_active_derives_not_applicable_review_status(self):
+        from django_waf.enums import ReviewStatus, RuleSource
+        from django_waf.testing.factories import BlockRuleFactory
+
+        rule = BlockRuleFactory(source=RuleSource.AUTO, is_active=True)
+
+        assert rule.review_status == ReviewStatus.NOT_APPLICABLE
+
+    @pytest.mark.django_db
+    def test_admin_source_inactive_stays_not_applicable(self):
+        from django_waf.enums import ReviewStatus, RuleSource
+        from django_waf.testing.factories import BlockRuleFactory
+
+        rule = BlockRuleFactory(source=RuleSource.ADMIN, is_active=False)
+
+        assert rule.review_status == ReviewStatus.NOT_APPLICABLE
+
+    @pytest.mark.django_db
+    def test_admin_source_active_stays_not_applicable(self):
+        from django_waf.enums import ReviewStatus, RuleSource
+        from django_waf.testing.factories import BlockRuleFactory
+
+        rule = BlockRuleFactory(source=RuleSource.ADMIN, is_active=True)
+
+        assert rule.review_status == ReviewStatus.NOT_APPLICABLE
+
+    @pytest.mark.django_db
+    def test_feed_source_inactive_stays_not_applicable(self):
+        from django_waf.enums import ReviewStatus, RuleSource
+        from django_waf.testing.factories import BlockRuleFactory
+
+        rule = BlockRuleFactory(source=RuleSource.FEED, is_active=False)
+
+        assert rule.review_status == ReviewStatus.NOT_APPLICABLE
+
+    @pytest.mark.django_db
+    def test_feed_source_active_stays_not_applicable(self):
+        from django_waf.enums import ReviewStatus, RuleSource
+        from django_waf.testing.factories import BlockRuleFactory
+
+        rule = BlockRuleFactory(source=RuleSource.FEED, is_active=True)
+
+        assert rule.review_status == ReviewStatus.NOT_APPLICABLE
+
+    @pytest.mark.django_db
+    def test_explicit_review_status_overrides_the_derived_value(self):
+        """A caller may deliberately want an inconsistent object (e.g.
+        reproducing the CONFIRMED/REJECTED states views.py's dashboard
+        actions write); explicit review_status must still win.
+        """
+        from django_waf.enums import ReviewStatus, RuleSource
+        from django_waf.testing.factories import BlockRuleFactory
+
+        rule = BlockRuleFactory(
+            source=RuleSource.AUTO,
+            is_active=False,
+            review_status=ReviewStatus.CONFIRMED,
+        )
+
+        assert rule.review_status == ReviewStatus.CONFIRMED
+
+
+# ---------------------------------------------------------------------------
+# RequestLogFactory matched_rule_id/matched_rule_type derivation
+# ---------------------------------------------------------------------------
+
+
+class TestRequestLogFactoryMatchedRuleInvariants:
+    """RequestLogFactory must not produce a state production cannot (#91).
+
+    rule_engine.evaluate_request always writes matched_rule_id and
+    matched_rule_type as a pair: both unset, or both set together. Neither
+    is ever set alone.
+    """
+
+    @pytest.mark.django_db
+    def test_default_leaves_both_matched_rule_fields_unset(self):
+        from django_waf.testing.factories import RequestLogFactory
+
+        log = RequestLogFactory()
+
+        assert log.matched_rule_id is None
+        assert log.matched_rule_type == ""
+
+    @pytest.mark.django_db
+    def test_matched_rule_id_alone_derives_a_non_empty_matched_rule_type(self):
+        import uuid
+
+        from django_waf.testing.factories import RequestLogFactory
+
+        log = RequestLogFactory(matched_rule_id=uuid.uuid4())
+
+        assert log.matched_rule_type != ""
+
+    @pytest.mark.django_db
+    def test_explicit_matched_rule_type_overrides_the_derived_value(self):
+        import uuid
+
+        from django_waf.testing.factories import RequestLogFactory
+
+        log = RequestLogFactory(matched_rule_id=uuid.uuid4(), matched_rule_type="allow")
+
+        assert log.matched_rule_type == "allow"
+
+
+# ---------------------------------------------------------------------------
 # waf_redis_mock
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #91.

`BlockRuleFactory` defaulted `review_status` to a flat `NOT_APPLICABLE`, so
a caller overriding only `is_active=False` on a `source=AUTO` rule produced
a combination the detector never writes. `django_waf.testing.factories` is
shipped package API, so a consuming project inherits the trap with less
context for spotting it.

## The invariant, read from the code

`anomaly_detector.py:1583-1584`, in `_get_or_create_auto_rule`:

```python
is_active_on_create = not (quarantine or detector_name in observe_only)
review_status_on_create = ReviewStatus.NOT_APPLICABLE if is_active_on_create else ReviewStatus.PENDING
```

Its `lookup` dict fixes `"source": RuleSource.AUTO`, so the derivation is
properly scoped to auto rules. Admin and feed writers
(`django_waf_block.py`, `django_waf_import_rules.py`, `threat_feed.py`)
never touch `review_status` at all, leaving the model default, which is why
the coupling is conditional across three fields and a naive
`LazyAttribute` on `review_status` alone would be wrong.

The docstring and the code agreed. Note the location moved from the
973-978 cited in the issue.

An explicitly passed `review_status` still wins, including values that
contradict the derivation such as the `CONFIRMED` / `REJECTED` states the
dashboard review views write. Same precedent as
`ChallengeTokenFactory.solved_at` after #86.

## The audit found a second instance

`RequestLogFactory` could build a row with `matched_rule_id` set and
`matched_rule_type` empty. `rule_engine` writes the two as a strict pair at
every site, and at `rule_engine.py:390` derives the type from the id
exactly as the factory now does:

```python
matched_rule_type="block" if matched_rule_id else "",
```

The coupling holds independently of `verdict`: a score-based `BLOCKED`
still carries both unset. Fixed the same way.

## The other two are sound, and here is what against

Reported as evidence rather than silence:

- **`AllowRuleFactory`**: `AllowRule` has no `review_status` field. Its
  `verify_rdns` / `rdns_pattern` pair was checked against
  `threat_feed.py` (which skips if either is missing) and the
  `0003_seed_verified_crawlers` migration: every writer sets both together
  or neither, matching the factory's defaults.
- **`IPReputationFactory`**: `threat_score` checked against the formula in
  `update_ip_reputation`. `detector_probe.py:350` deliberately creates rows
  leaving `threat_score` at its default while setting non-zero counters, so
  that is a real, currently-occurring production state rather than a
  forbidden one. The `window_start` / `window_end` / `last_seen_at` fields
  are write-only, never read or branched on, so no test-observable
  invariant exists to violate.

## Compatibility

Behaviour-preserving for the existing suite. Every current
`BlockRuleFactory(source=AUTO, ...)` call site either leaves `is_active` at
its `True` default, passes `is_active=True`, or passes `review_status`
explicitly; none hit the previously-untested combination. The one
`RequestLogFactory(matched_rule_id=...)` call site already sets
`matched_rule_type` explicitly.