### PR TITLE
docs(changelog): move wave 3 out of the published 2.5.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.0] - 2026-09-03
+## [Unreleased]
 
 ### Added
 
@@ -89,6 +89,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   check time, which under django-hosts or per-request urlconfs may not be
   the one serving traffic. Setting both URL overrides is the escape for
   that case, and is what the package already recommends there.
+
+### Fixed
+
+- **A challenged visitor was served a 500 on a deployment with the WAF
+  URLs unrouted** (#102, BR-EVAL-011). The CHALLENGED branch of
+  `_handle_verdict` called `_get_challenge_paths()` unguarded, and no
+  `NoReverseMatch` handler existed anywhere in `middleware.py`, so with
+  `django_waf.urls` routed nowhere and no explicit URL override set, the
+  exception escaped the middleware entirely. The visitor affected is a
+  legitimate one who merely tripped a detector: the WAF's own
+  misconfiguration turned a challenge into an error page.
+
+  The branch now catches `NoReverseMatch` narrowly, passes the request
+  through to the view, and logs at ERROR naming the client IP, the path,
+  and both fixes. Failing open is the right direction here, not a
+  compromise: there is no route to send the visitor to, so half-blocking
+  them behind a redirect to a page that does not exist is strictly worse
+  than letting them through. It is the same fail-open posture BR-EVAL-007
+  already sets for Redis outages and evaluation errors. Caught narrowly
+  rather than as a bare `Exception`, so any other failure in that branch
+  still surfaces. `django_waf.E007` above reports the same
+  misconfiguration at boot, and both are needed: an operator who ignores
+  the check must still not serve 500s.
+
+## [2.5.0] - 2026-09-03
+
+### Added
 
 - **A liveness probe for the Redis hit-count flush path** (#100, BR-LIFE-005).
   The companion to the detector probe shipped in 2.2.0, covering the
@@ -203,27 +230,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with enforcement off.
 
 ### Fixed
-
-- **A challenged visitor was served a 500 on a deployment with the WAF
-  URLs unrouted** (#102, BR-EVAL-011). The CHALLENGED branch of
-  `_handle_verdict` called `_get_challenge_paths()` unguarded, and no
-  `NoReverseMatch` handler existed anywhere in `middleware.py`, so with
-  `django_waf.urls` routed nowhere and no explicit URL override set, the
-  exception escaped the middleware entirely. The visitor affected is a
-  legitimate one who merely tripped a detector: the WAF's own
-  misconfiguration turned a challenge into an error page.
-
-  The branch now catches `NoReverseMatch` narrowly, passes the request
-  through to the view, and logs at ERROR naming the client IP, the path,
-  and both fixes. Failing open is the right direction here, not a
-  compromise: there is no route to send the visitor to, so half-blocking
-  them behind a redirect to a page that does not exist is strictly worse
-  than letting them through. It is the same fail-open posture BR-EVAL-007
-  already sets for Redis outages and evaluation errors. Caught narrowly
-  rather than as a bare `Exception`, so any other failure in that branch
-  still surfaces. `django_waf.E007` above reports the same
-  misconfiguration at boot, and both are needed: an operator who ignores
-  the check must still not serve 500s.
 
 - **The detector liveness probe reported a healthy detector as SILENT**
   once a deployment had accumulated any `BlockRule` history. The dry-run


### PR DESCRIPTION
The changelog on `main` currently claims the published 2.5.0 release shipped
`django_waf.E007` and `DJANGO_WAF_BLOCK_RESPONSE_HANDLER`. It did not.

## What happened

Wave 3 (#123) branched at `93bc9a2`, when its CHANGELOG entries correctly sat
under `## [Unreleased]`. Release 2.5.0 (#122) merged while wave 3 was in
flight and renamed that exact heading to `## [2.5.0] - 2026-09-03`. The squash
merge applied cleanly, with no conflict, and dropped wave 3's entries
underneath a heading for an already-published release.

## Proof it is wrong

```
$ git show v2.5.0:src/django_waf/checks.py | grep -c 'E007'
0
```

The published tag contains none of the code its changelog section now
describes. A consumer reading the 2.5.0 notes would look for a check and a
setting that are not in the version they installed.

## The fix

Restores `## [Unreleased]` above 2.5.0 carrying wave 3's three entries: the
E007 check, the block-response hook (`### Added`), and the challenge-500 fix
(`### Fixed`).

The 2.5.0 section is left byte-identical to what was published, verified
rather than assumed:

```
$ git show v2.5.0:CHANGELOG.md | awk '/^## \[2\.5\.0\]/{f=1} /^## \[2\.4/{f=0} f' > tag.txt
$ awk '/^## \[2\.5\.0\]/{f=1} /^## \[2\.4/{f=0} f' CHANGELOG.md > now.txt
$ diff tag.txt now.txt && echo IDENTICAL
IDENTICAL
```

173 lines each, no difference. No 2.5.0 content was moved, reworded or lost;
only wave 3's entries were lifted out.

Documentation only. No code changes.

## Worth noting for next time

This is a merge-order hazard rather than anybody's mistake: both PRs were
green, the merge was conflict-free, and the corruption was invisible to CI.
Any long-running branch that writes to `[Unreleased]` will land inside a
release section if a release merges first. Worth a check that fails when a
dated release section gains entries the matching tag does not contain.