### PR TITLE
fix(detection): tier on deception, not on claimed honesty (#82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,84 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`score_user_agent` no longer penalises a client for honestly declaring
+  itself an automated one** (#82). The `_RE_SCRAPER_LIBS` check added 2.5
+  to the anomaly score for any UA matching a known HTTP library string
+  (curl, python-requests, Go-http-client, Scrapy, httpx, and others), on
+  top of every other weighted check in the function. Measured on a live
+  commercial deployment: 12,053 requests penalised this way over one
+  window came from just 22 distinct IPs, all in a single `/24`, all
+  sending `curl/8.7.1`, a scanner that happened to be honest about what it
+  was rather than evidence that honesty itself is suspicious. Worse, the
+  incentive it created was backwards: a client silently pretending to be a
+  browser paid no penalty for the pretence, while one that told the truth
+  paid 2.5 points for it.
+
+  The weight is removed, not reduced. A reduction (scoring honest UAs
+  below zero, or below what an unidentified UA would score) was considered
+  and rejected: it would be trivially exploitable, since any scanner
+  willing to send `curl` as its UA string could buy a discount on every
+  other signal. Absence of penalty is the only defensible position the
+  production evidence supports. Every other check in `score_user_agent` is
+  unchanged at full weight: impossible OS/browser combination (3.0),
+  ancient browser version (2.0), missing version token (1.5), short UA
+  under 15 characters (1.0), empty UA (1.0). Every behavioural signal
+  elsewhere in the composite score (volume gating, path scoring, subnet
+  detection, rate limiting, HTTP fingerprint mismatch) is also unchanged.
+  `classify_ua`, which uses the same `_RE_SCRAPER_LIBS` pattern to label a
+  UA `"library"` for analytics, is untouched: only the scoring
+  contribution inside `score_user_agent` was removed, not the pattern
+  itself.
+
+  Concretely: `curl/7.68.0` (11 characters) drops from 3.5 to 1.0, keeping
+  only the short-UA weight, which is a genuine anomaly signal independent
+  of the library match. `python-requests/2.28.1`, `Go-http-client/1.1`,
+  `Scrapy/2.6.1 (+https://scrapy.org)` and `Wget/1.20.3 (linux-gnu)` all
+  drop from 2.5 to 0.0, being long enough to clear the short-UA threshold.
+
+  **Behaviour change for an existing consumer on upgrade**: fewer honest
+  automated clients will cross `DJANGO_WAF_SCORE_THRESHOLD_LOG` (default
+  3.0) or `_CHALLENGE` (default 5.0) on UA score alone, once their
+  request volume clears the 10-requests-per-5-minutes gate that activates
+  UA scoring at all. A deceptive client, one whose UA claims to be a
+  browser while its headers say otherwise, is not affected by this change;
+  it is caught by `score_fingerprint_mismatch` regardless, which was
+  already scoring purely on the browser claim and is untouched here.
+
+- **`classify_fingerprint` no longer labels an honest non-browser client
+  `"browser"`** (#82). Every check inside `score_fingerprint_mismatch` is
+  gated on the UA claiming to be a browser (matching Chromium's
+  `Sec-CH-UA` requirement or the wider `Sec-Fetch-*` browser set), so a UA
+  that makes no such claim always scored a clean 0.0, by construction, and
+  no known mismatch could ever apply. `classify_fingerprint`'s final
+  fallthrough then labelled that clean score `"browser"`, so `curl`,
+  `python-requests`, and every self-identifying crawler in production were
+  recorded in `RequestLog.fingerprint_verdict` as browsers. That field is
+  what an operator reads to audit exactly this kind of tiering, so the
+  mislabel degraded the diagnostic it exists to provide.
+
+  A UA that makes no browser claim now classifies as `"unknown"` rather
+  than falling through to `"browser"`, which is the honest label: the
+  fingerprint mechanism has no signal to offer either way for a client
+  that never claimed to be a browser. `"unknown"` was already one of the
+  four documented values (browser/bot/suspicious/unknown per BR-FP-001);
+  no fifth value was added, and no consumer-facing admin filter or query
+  needs to change to recognise it.
+
+  **Behaviour change for an existing consumer on upgrade**: `RequestLog`
+  rows for honest libraries and self-identifying crawlers will now record
+  `fingerprint_verdict = "unknown"` instead of `"browser"`. This is a data
+  labelling correction, not an enforcement change: the set of inputs that
+  classify as `"bot"` is unchanged, because that branch requires a mismatch
+  score of 3.0 or higher, which is only reachable when the UA claims to be
+  a browser in the first place, the exact condition this fix's fallthrough
+  never reaches. `BR-CHAL-013`'s escalation gate, which keys on
+  `fingerprint_verdict == "bot"`, is therefore unaffected.
+
 ## [2.5.0] - 2026-09-03
 
 ### Added

--- a/src/django_waf/services/fingerprint.py
+++ b/src/django_waf/services/fingerprint.py
@@ -117,6 +117,18 @@ def score_fingerprint_mismatch(user_agent: str, meta: dict) -> float:
 def classify_fingerprint(user_agent: str, meta: dict) -> str:
     """Classify a request as 'browser', 'bot', or 'suspicious' based on fingerprint.
 
+    Every check in ``score_fingerprint_mismatch`` is gated on the UA
+    claiming to be a browser (matching ``_CHROMIUM_UA_RE`` or
+    ``_SEC_FETCH_BROWSERS_RE``), so a UA that makes no such claim always
+    scores 0.0 here regardless of how consistent or inconsistent its
+    headers actually are. Falling through to 'browser' for that case would
+    label an honest library or crawler UA a browser purely because nothing
+    contradicted a claim it never made (issue #82: this recorded
+    ``curl/7.68.0`` as ``fingerprint_verdict='browser'`` in RequestLog,
+    which is wrong on its face). 'unknown' is the honest label: the
+    fingerprint mechanism has no signal to offer either way for a client
+    that does not claim to be a browser.
+
     Args:
         user_agent: The User-Agent header value.
         meta: Django ``request.META`` dict.
@@ -130,7 +142,11 @@ def classify_fingerprint(user_agent: str, meta: dict) -> str:
         return "bot"
     if mismatch >= 1.5:
         return "suspicious"
-    if mismatch == 0.0 and not user_agent:
+    if not user_agent:
+        return "unknown"
+    if not (_CHROMIUM_UA_RE.search(user_agent) or _SEC_FETCH_BROWSERS_RE.search(user_agent)):
+        # No browser claim made, so no fingerprint signal is possible
+        # (mismatch is always 0.0 here by construction, see above).
         return "unknown"
     return "browser"
 

--- a/src/django_waf/services/ua_analyser.py
+++ b/src/django_waf/services/ua_analyser.py
@@ -13,7 +13,9 @@ import re
 # Pre-compiled regex patterns (module-level for performance — BR-UA-004)
 # ---------------------------------------------------------------------------
 
-# Known scraper / HTTP library strings (weight 2.5)
+# Known scraper / HTTP library strings. Used by classify_ua only (weight
+# 2.5 for this pattern was removed from score_user_agent, see the comment
+# on that function).
 _RE_SCRAPER_LIBS = re.compile(
     r"(python-requests|Go-http-client|libwww-perl|Wget/|curl/|"
     r"urllib|[Ss]crapy|mechanize|aiohttp|httpx/)",
@@ -91,9 +93,21 @@ def score_user_agent(user_agent: str) -> float:
     if _RE_ANCIENT_BROWSER.search(user_agent):
         score += 2.0
 
-    # Weight 2.5 — known scraper library string
-    if _RE_SCRAPER_LIBS.search(user_agent):
-        score += 2.5
+    # No weight for _RE_SCRAPER_LIBS here, deliberately. It used to add
+    # 2.5 for a UA honestly declaring itself an automated client (curl,
+    # python-requests, Go-http-client, and so on). Measured in production
+    # (issue #82): 12,053 requests penalised this way came from 22 distinct
+    # IPs in a single /24, an honest UA attached to a scanner, so honesty
+    # was never a signal of good behaviour there. It also inverted the
+    # incentive the WAF wants: it made silence, not disclosure, the safer
+    # choice. Removing the penalty does not reward honesty either, that
+    # would be a score reduction, exploitable by any scanner willing to
+    # send curl in its UA, it only stops punishing it. Every behavioural
+    # signal (volume gating, path scoring, subnet, rate limiting,
+    # fingerprint mismatch) is unchanged and still applies at full weight;
+    # a short or malformed UA still scores via the checks below regardless
+    # of whether it also matches a library string. Do not reintroduce this
+    # weight without a fresh measurement justifying it, see issue #82.
 
     # Weight 1.5 — missing or anomalous version format
     # Real UAs always contain at least one "Token/version" component.

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -102,63 +102,94 @@ class TestScoreUserAgent:
         )
         assert score_user_agent(ua) == 0.0
 
-    def test_python_requests_scores_high(self):
-        """python-requests UA triggers scraper-library weight."""
-        score = score_user_agent("python-requests/2.28.1")
-        # Scraper lib (2.5) + missing impossible combo, but short (1.0) = at least 2.5
-        assert score >= 2.5
+    def test_python_requests_carries_no_self_identification_penalty(self):
+        """python-requests scores 0.0: no penalty for honest self-identification.
 
-    def test_curl_scores_as_scraper(self):
-        """curl UA triggers scraper-library weight."""
-        score = score_user_agent("curl/7.68.0")
-        assert score >= 2.5
+        Issue #82 teeth check: before the fix this scored 2.5 (the
+        _RE_SCRAPER_LIBS weight). 22 chars, so the short-UA check does not
+        apply either. This test fails against the pre-fix code (asserts
+        2.5, not >= 2.5) and passes after.
+        """
+        assert score_user_agent("python-requests/2.28.1") == 0.0
 
-    def test_wget_scores_as_scraper(self):
-        """Wget UA triggers scraper-library weight."""
-        score = score_user_agent("Wget/1.20.3 (linux-gnu)")
-        assert score >= 2.5
+    def test_curl_carries_no_self_identification_penalty_but_keeps_short_ua_weight(self):
+        """curl scores 1.0: the library penalty is gone, the short-UA weight is not.
+
+        Issue #82 teeth check: before the fix this scored 3.5 (2.5 library
+        + 1.0 short). curl/7.68.0 is 11 characters, under the 15-char
+        threshold, so the short-UA weight is a genuine, independent
+        anomaly signal and correctly still applies. This test fails
+        against the pre-fix code (asserts 3.5) and passes after.
+        """
+        assert score_user_agent("curl/7.68.0") == 1.0
+
+    def test_go_http_client_carries_no_self_identification_penalty(self):
+        """Go-http-client scores 0.0 (18 chars, over the short-UA threshold)."""
+        assert score_user_agent("Go-http-client/1.1") == 0.0
+
+    def test_scrapy_carries_no_self_identification_penalty(self):
+        """Scrapy with a project URL scores 0.0 (34 chars, over the short-UA threshold)."""
+        assert score_user_agent("Scrapy/2.6.1 (+https://scrapy.org)") == 0.0
+
+    def test_httpx_carries_no_self_identification_penalty_but_keeps_short_ua_weight(self):
+        """httpx/0.23.0 scores 1.0: 12 chars is under the short-UA threshold."""
+        assert score_user_agent("httpx/0.23.0") == 1.0
+
+    def test_wget_carries_no_self_identification_penalty(self):
+        """Wget with its platform suffix scores 0.0 (23 chars, over the short-UA threshold)."""
+        assert score_user_agent("Wget/1.20.3 (linux-gnu)") == 0.0
 
     def test_ancient_msie_scores_high(self):
-        """MSIE 6 browser UA triggers ancient-browser weight."""
+        """MSIE 6 browser UA triggers ancient-browser weight.
+
+        Regression guard: this weight (2.0) is untouched by the issue #82
+        change and must remain exactly as before.
+        """
         ua = "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1)"
-        score = score_user_agent(ua)
-        assert score >= 2.0
+        assert score_user_agent(ua) == 2.0
 
     def test_ancient_firefox_scores_high(self):
-        """Firefox/2.x UA triggers ancient-browser weight."""
+        """Firefox/2.x UA triggers ancient-browser weight (unchanged, 2.0)."""
         ua = "Mozilla/5.0 (Windows; U; Windows NT 5.0; en-US; rv:1.9) Gecko/20100101 Firefox/2.0"
-        score = score_user_agent(ua)
-        assert score >= 2.0
+        assert score_user_agent(ua) == 2.0
 
     def test_impossible_ios_windows_combo(self):
-        """iPhone + Windows NT is an impossible combination — scores 3.0+."""
+        """iPhone + Windows NT is an impossible combination (unchanged, 3.0)."""
         ua = "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) Windows NT 10.0"
-        score = score_user_agent(ua)
-        assert score >= 3.0
+        assert score_user_agent(ua) == 3.0
 
     def test_impossible_android_ios_combo(self):
-        """Android + iPhone combination is impossible — scores 3.0+."""
+        """Android + iPhone combination is impossible (unchanged, 3.0)."""
         ua = "Mozilla/5.0 (Android 12; iPhone; U; en-US)"
-        score = score_user_agent(ua)
-        assert score >= 3.0
+        assert score_user_agent(ua) == 3.0
 
     def test_very_short_ua_adds_weight(self):
-        """UAs under 15 characters add 1.0 to score."""
-        ua = "ShortUA/1"  # 9 chars, no version token → 1.5 (no token) + 1.0 (short)
-        score = score_user_agent(ua)
-        assert score >= 1.0
+        """A UA under 15 characters that already has a version token scores 1.0.
+
+        Regression guard: the short-UA weight (1.0) is unaffected by issue
+        #82, and is independent of the missing-version-token weight since
+        "ShortUA/1" itself matches the version-token pattern.
+        """
+        ua = "ShortUA/1"  # 9 chars, has a version token → short weight only
+        assert score_user_agent(ua) == 1.0
 
     def test_ua_without_version_token_adds_weight(self):
-        """UA lacking any 'Word/version' token adds 1.5 to score."""
+        """UA lacking any 'Word/version' token scores 1.5 (unchanged)."""
         ua = "UnknownBrowserWithNoVersionToken"
-        score = score_user_agent(ua)
-        assert score >= 1.5
+        assert score_user_agent(ua) == 1.5
 
     def test_score_capped_at_ten(self):
         """Score is capped at 10.0 regardless of accumulation."""
-        # Impossible combo (3) + scraper (2.5) + ancient (2.0) + no token (1.5) + short (1.0) = 10
-        ua = "MSIE 6.0 python-requests iPhone Windows NT"
+        # Impossible combo (3.0) + ancient browser (2.0) + no version token
+        # (1.5) = 6.5, well under the 10.0 cap. Confirms the cap logic
+        # without depending on the removed scraper-library weight: before
+        # issue #82's fix, a UA matching this pattern plus _RE_SCRAPER_LIBS
+        # could reach the full 10.0 cap; that combination is no longer
+        # reachable because the weight was removed, not because the cap
+        # itself changed.
+        ua = "MSIE 6.0 iPhone Windows NT"
         score = score_user_agent(ua)
+        assert score == 6.5
         assert score <= 10.0
 
     def test_googlebot_scores_zero(self):
@@ -857,8 +888,13 @@ class TestEvaluateRequest:
         # >10 recent requests so UA scoring kicks in
         redis.zcount.return_value = 15
 
-        # 'urllib' scores 5.0 (scraper 2.5 + no version token 1.5 + short 1.0)
-        # which maps to CHALLENGED per _score_to_verdict.
+        # This UA scores 5.0 (ancient-browser 2.0 + impossible OS/browser
+        # combo 3.0), which maps to CHALLENGED per _score_to_verdict. Not
+        # 'urllib', which scored 5.0 before issue #82 removed the
+        # self-identification weight from score_user_agent and now scores
+        # only 2.5 (no version token 1.5 + short 1.0), no longer enough to
+        # clear the threshold this test exercises.
+        ua = "Mozilla/4.0 (compatible; MSIE 6.0; iPhone; Windows NT 5.1)"
         with (
             patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_BURST", 120),
             patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_MINUTE", 1200),
@@ -866,7 +902,7 @@ class TestEvaluateRequest:
         ):
             result = evaluate_request(
                 ip_address="7.7.7.7",
-                user_agent="urllib",
+                user_agent=ua,
                 path="/",
                 method="GET",
                 redis_client=redis,
@@ -4692,12 +4728,114 @@ class TestClassifyFingerprint:
         """An empty UA with no signals classifies as 'unknown'."""
         assert classify_fingerprint("", {}) == "unknown"
 
-    def test_non_browser_ua_classifies_as_browser(self):
-        """A non-browser UA like curl scores 0.0 and falls through to 'browser'.
+    def test_non_browser_ua_classifies_as_unknown(self):
+        """A non-browser UA like curl scores 0.0 and classifies as 'unknown'.
 
-        classify_fingerprint reserves 'unknown' for the empty-UA case.
+        Before the issue #82 fix, this fell through to 'browser' purely
+        because a UA that never claimed to be a browser could not fail any
+        of score_fingerprint_mismatch's browser-claim-gated checks. That
+        recorded honest libraries and crawlers as fingerprint_verdict
+        'browser' in RequestLog. curl never claims to be a browser, so
+        'unknown' (no signal either way) is the honest label, not 'browser'.
         """
-        assert classify_fingerprint("curl/7.88.1", {}) == "browser"
+        assert classify_fingerprint("curl/7.88.1", {}) == "unknown"
+
+    def test_crawler_ua_classifies_as_unknown(self):
+        """A crawler UA that makes no browser claim also classifies as 'unknown'.
+
+        Regression guard distinguishing this from the empty-UA 'unknown'
+        case: Googlebot's UA is non-empty and known to classify_ua as
+        'crawler', but it matches neither _CHROMIUM_UA_RE nor
+        _SEC_FETCH_BROWSERS_RE, so it must land on the same 'unknown'
+        branch as curl, not fall through to 'browser'.
+        """
+        ua = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+        assert classify_fingerprint(ua, {}) == "unknown"
+
+    def test_browser_claiming_ua_still_classifies_as_browser(self):
+        """A genuine browser-claiming UA with consistent headers is still 'browser'.
+
+        Regression guard: the fix must not turn every clean-fingerprint
+        request into 'unknown'. Only a UA that makes no browser claim at
+        all is affected.
+        """
+        assert classify_fingerprint(_CHROME_UA, _CHROME_META) == "browser"
+
+    def test_bot_verdict_set_is_unchanged_for_deceptive_browser_claim(self):
+        """A browser-claiming UA with bot-shaped headers still classifies as 'bot'.
+
+        BR-CHAL-013's escalation gate keys on fingerprint_verdict == 'bot'.
+        This fix only touches the non-browser-claiming fallthrough
+        (mismatch is always 0.0 there), so it cannot change which inputs
+        cross the mismatch >= 3.0 threshold that produces 'bot'.
+        """
+        assert classify_fingerprint(_CHROME_UA, {"HTTP_ACCEPT": "*/*"}) == "bot"
+
+
+class TestIssue82Composite:
+    """Composite checks tying score_user_agent and classify_fingerprint
+    together the way evaluate_request does, confirming issue #82's two
+    changes compose correctly and classify_ua is untouched by either.
+    """
+
+    def test_deceptive_browser_still_scores_five_via_fingerprint(self):
+        """A browser-claiming client with no client hints still scores 5.0.
+
+        Unchanged by issue #82: score_fingerprint_mismatch and
+        classify_fingerprint's 'bot' branch are untouched. Chrome 120
+        claims Chromium 89+ (needs Sec-CH-UA), claims a Sec-Fetch-*
+        browser (needs Sec-Fetch-*, Accept-Language, and a non-wildcard
+        Accept), and the empty meta dict supplies none of them: 2.0 + 1.5
+        + 1.0 + 0.5 = 5.0, the fingerprint scorer's cap.
+        """
+        assert score_fingerprint_mismatch(_CHROME_UA, {}) == 5.0
+        assert classify_fingerprint(_CHROME_UA, {}) == "bot"
+        # score_user_agent is unaffected: Chrome 120's UA string matches
+        # none of the anomaly checks, self-identification weight or not.
+        assert score_user_agent(_CHROME_UA) == 0.0
+
+    def test_honest_curl_scores_low_on_both_axes(self):
+        """Honest curl scores low on score_user_agent and 'unknown' on fingerprint.
+
+        curl/7.68.0 never claims to be a browser, so
+        score_fingerprint_mismatch is 0.0 by construction and
+        classify_fingerprint is 'unknown' (issue #82 change 2), and
+        score_user_agent no longer carries the self-identification penalty
+        (issue #82 change 1), leaving only the short-UA weight (1.0).
+        """
+        ua = "curl/7.68.0"
+        assert score_user_agent(ua) == 1.0
+        assert score_fingerprint_mismatch(ua, {}) == 0.0
+        assert classify_fingerprint(ua, {}) == "unknown"
+
+    def test_googlebot_scores_zero_on_both_axes(self):
+        """Googlebot scores 0.0 on score_user_agent and 'unknown' on fingerprint."""
+        ua = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+        assert score_user_agent(ua) == 0.0
+        assert score_fingerprint_mismatch(ua, {}) == 0.0
+        assert classify_fingerprint(ua, {}) == "unknown"
+
+    def test_classify_ua_categories_are_completely_unchanged(self):
+        """classify_ua's return value for all five categories is untouched by issue #82.
+
+        Neither change in this issue alters classify_ua or the regexes it
+        reads (_RE_CRAWLER, _RE_SCRAPER_LIBS, _RE_BOT, _RE_BROWSER): change
+        1 only removes _RE_SCRAPER_LIBS's contribution inside
+        score_user_agent, and change 2 only touches classify_fingerprint.
+        """
+        cases = {
+            "": "unknown",
+            "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)": "crawler",
+            "curl/7.68.0": "library",
+            "My Custom bot/1.0": "bot",
+            (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/120.0.0.0 Safari/537.36"
+            ): "browser",
+        }
+        for ua, expected in cases.items():
+            assert classify_ua(ua) == expected
 
 
 class TestKnownFingerprintRegistry:


### PR DESCRIPTION
Closes #82. Design recorded at https://github.com/icvoss/django-waf/issues/82#issuecomment-5522868227,
which revises the issue body's direction after reading the code against
the production measurement.

## What reading the code changed

The issue proposed building a tiering scheme over `classify_ua`. Three
findings redirected it:

1. **The deception tier already exists.** Every check in
   `score_fingerprint_mismatch` is gated behind a browser-claiming UA
   (`_CHROMIUM_UA_RE` / `_SEC_FETCH_BROWSERS_RE`), so an honest client
   scores 0.0 by construction and a deceptive one scores up to 5.0.
   Nothing to add.
2. **The penalty on honest clients came from `score_user_agent`**, a
   different function from the one the issue pointed at.
3. **`classify_ua` has no production callers at all**, so wiring it in
   would have put two overlapping UA taxonomies on the scoring path.

## Change 1: stop penalising honest self-identification

`score_user_agent` added 2.5 for a UA declaring itself an automated
client. Against `_score_to_verdict`'s LOG threshold of 3.0, `curl/7.68.0`
crossed it on its UA string alone.

Measured in production: those 12,053 penalised curl requests came from 22
IPs in a single /24, an honest UA attached to a scanner. Honesty was never
evidence of good behaviour, so the weight was not buying detection; it was
inverting the incentive, making silence safer than disclosure.

**Removed, not reduced.** A reduction would be exploitable by any scanner
willing to put curl in its UA. This buys absence of penalty and nothing
more. Every behavioural signal (volume gating, path scoring, subnet, rate
limiting, fingerprint mismatch) is unchanged at full weight, and the regex
stays for `classify_ua`'s `library` branch.

| UA | before | after |
|---|---|---|
| `curl/7.68.0` | 3.5 | 1.0 (short-UA weight, retained) |
| `python-requests/2.28.1` | 2.5 | 0.0 |
| `Go-http-client/1.1` | 2.5 | 0.0 |
| `Scrapy/2.6.1` | 2.5 | 0.0 |
| `httpx/0.23.0` | 2.5 | 1.0 (short-UA weight, retained) |
| Googlebot | 0.0 | 0.0 |

## Change 2: an honest library is not a browser

`classify_fingerprint`'s `unknown` branch required `mismatch == 0.0` **and**
an empty UA, so any non-browser UA with a clean fingerprint fell through to
`browser`. `RequestLog.fingerprint_verdict` has been recording `curl` as a
browser, degrading the exact field an operator would use to audit this
tiering.

A UA making no browser claim now returns `unknown`, an existing documented
value in BR-FP-001, so no data-model or admin change. That is the honest
label: the mechanism can produce no signal either way about a claim that
was never made.

**The `bot` set is unchanged.** That branch needs `mismatch >= 3.0`, only
reachable behind a browser claim, disjoint from the new condition.
BR-CHAL-013's escalation counter gates on exactly this value, so escalation
behaviour is untouched. Verified by driving both functions directly:
deceptive Chrome still 5.0/`bot`, header-less Firefox still 3.0/`bot`, a
well-formed browser still `browser`, and all five `classify_ua` categories
identical.

## Upgrade impact

Both are behaviour changes. Fewer honest automated clients will cross the
LOG and CHALLENGE thresholds on UA score alone, and `fingerprint_verdict`
will read `unknown` rather than `browser` for non-browser clients. A
consumer querying that field for "browser" traffic will see the count drop
and the `unknown` count rise correspondingly.

## Spec follow-up, not in this PR

`ua_analyser.py:69` cites `BR-UA-002` as the authority for these weights,
and **no `BR-UA-` rule exists anywhere in the spec**. The UA scoring
weights, which directly determine what gets blocked, have never been
specified. Raising this separately against the umbrella spec rather than
editing it here (#40 tracks the broader drift).