### PR TITLE
fix(middleware,checks): route country blocks through the block hook, add E008 (#76, #121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,13 +44,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   call `self._build_block_response(request, result)` yourself where you
   currently build the 403.
 
-  **Country blocks are deliberately not covered**, and still return the
-  same fixed 403. `_check_country_block` decides before `evaluate_request()`
-  runs, so it has no `EvaluationResult` to hand a `(request, result)`
-  handler, and synthesising a fake one to satisfy the signature would be a
-  worse defect than the gap. That means a country block still fingerprints
-  the WAF on exactly the unbound custom domains this hook is about; until
-  #76 closes that, exempt the path or gate country blocking at the edge.
+  **Country blocks now route through this hook too** (#76).
+  `_check_country_block` decides before `evaluate_request()` runs, so it
+  has no `EvaluationResult` from that call, but the values it needs are
+  exactly what it already writes to `RequestLog` for the same request:
+  `verdict=Verdict.BLOCKED`, `action=RuleAction.BLOCK`,
+  `matched_rule_id=None`, `matched_rule_type=""`, `anomaly_score=None`. The
+  country code itself is not added to `EvaluationResult` (a public
+  NamedTuple consumers unpack; widening it is a bigger change than this
+  fix), and is instead set on the request as `request.waf_blocked_country`
+  before the handler runs, so a handler that wants to branch on it reads
+  `getattr(request, "waf_blocked_country", None)`.
+
+- **`django_waf.E008`**, a boot-time check for an unresolvable
+  `DJANGO_WAF_BLOCK_RESPONSE_HANDLER` (#121).
+
+  Errors when the setting is non-empty and its dotted path cannot be
+  imported, using the same `except Exception` breadth as the runtime guard
+  in `_build_block_response`: importing the handler's module runs that
+  module's own top-level code, which can raise `ImproperlyConfigured`,
+  `AppRegistryNotReady`, a stale-`.pyc` `SyntaxError`, or anything else.
+  Silent when the WAF is disabled, and silent when the setting is empty
+  (its default). This proves only that the path resolves, not that the
+  handler is correct: it cannot verify the signature, that the return
+  value is an `HttpResponse`, or that the handler does not raise, all of
+  which stay caught only at runtime by the existing fallbacks.
 
 - **`django_waf.E007`**, a boot-time check for a challenge flow with
   nowhere to send anyone (#102, BR-EVAL-011).
@@ -135,6 +153,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that produced the original report.
 
 ### Fixed
+
+- **Three source comments cited `BR-TEL-004`, a spec rule that does not
+  exist** (#130). `services/threat_feed.py` attributed
+  `submit_telemetry`'s never-raise-on-failure behaviour to `BR-TEL-004`
+  in its module docstring, its function docstring and an inline comment.
+  The canonical spec defines `BR-TEL-001` through `BR-TEL-003` only, and
+  the rule that actually governs this behaviour is `BR-TEL-003`
+  ("Telemetry failure does not affect WAF operation"). Comments only, no
+  behaviour change: the code already did what `BR-TEL-003` requires.
 
 - **A challenged visitor was served a 500 on a deployment with the WAF
   URLs unrouted** (#102, BR-EVAL-011). The CHALLENGED branch of

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -219,6 +219,30 @@ about the deployment's configuration plumbing (an environment variable
 that silently does nothing), true or false independent of whether the WAF
 is currently enforcing requests, mirroring the rationale ``django_waf.W008``
 and ``django_waf.W009`` already give for staying ungated.
+
+The block-response handler check (``django_waf.E008``) errors when
+``DJANGO_WAF_BLOCK_RESPONSE_HANDLER`` is set to a dotted path that cannot
+be imported (#121). ``WafMiddleware._build_block_response`` already
+guards this at runtime with a broad ``except Exception`` around
+``import_string``, deliberately wider than ``except ImportError``, because
+importing the handler's module runs that module's own top-level code,
+which can raise ``ImproperlyConfigured``, ``AppRegistryNotReady``, a
+``SyntaxError`` under a stale ``.pyc``, or anything else. This check must
+use the same breadth: a narrower except here would pass at boot for a
+handler that fails on every single blocked request afterwards, which is
+worse than not checking at all, since it tells the operator the setting is
+fine when it is not. Silent when the WAF is disabled (#95): a disabled WAF
+issues no BLOCKED verdicts, so an unresolvable handler is never invoked.
+Also silent when the setting is empty, its default, which means "use the
+built-in block response" and is not a misconfiguration.
+
+**Known limitation, stated rather than papered over.** This proves only
+that the dotted path resolves to something importable. It cannot verify
+the handler's signature, that it returns an ``HttpResponse``, or that it
+does not raise when actually called: none of that is observable without
+invoking the handler with a real request, which a boot-time check must
+not do. Those three failure modes are caught only at runtime, by the
+fallbacks ``_build_block_response`` already documents.
 """
 
 from __future__ import annotations
@@ -1015,3 +1039,74 @@ def check_env_only_settings(app_configs, **kwargs):
             id="django_waf.W010",
         )
     ]
+
+
+@register()
+def check_block_response_handler_importable(app_configs, **kwargs):
+    """Error (``django_waf.E008``) when ``DJANGO_WAF_BLOCK_RESPONSE_HANDLER``
+    is set to a dotted path that cannot be imported (#121).
+
+    Layered, cheapest guard first:
+
+    1. **``DJANGO_WAF_ENABLED`` is ``True``.** Otherwise return ``[]``: a
+       disabled WAF issues no BLOCKED verdicts, so
+       ``_build_block_response`` never runs and an unresolvable handler
+       cannot fire. Same gating rationale #95 established for every other
+       check in this module.
+    2. **The setting is non-empty.** The empty string is the default and
+       means "use the built-in block response", not a misconfiguration, so
+       return ``[]``.
+    3. **Only then** attempt ``import_string(dotted_path)``, inside
+       ``try/except Exception``.
+
+    The except is deliberately broader than ``ImportError``. This must
+    agree with the runtime guard in ``WafMiddleware._build_block_response``,
+    which is exactly as broad and documents why: importing the handler's
+    module runs that module's own top-level code, and that code can raise
+    ``ImproperlyConfigured`` from a settings read, ``AppRegistryNotReady``,
+    a ``SyntaxError`` under a stale ``.pyc``, or anything else it likes. A
+    check narrower than the runtime guard would pass at boot for a handler
+    that fails on every blocked request afterwards, which is a worse
+    outcome than no check at all: it tells the operator the setting works
+    when every live block will silently fall back to the built-in 403.
+
+    **Known limitation, stated rather than papered over.** This proves only
+    that the dotted path resolves to an importable object. It cannot verify
+    the handler's signature, that its return value is an ``HttpResponse``,
+    or that it does not raise when actually invoked with a real request and
+    result: none of that is observable without calling the handler, which a
+    boot-time check must not do. Those three failure modes remain caught
+    only at runtime, by the fallbacks ``_build_block_response`` already
+    documents and already falls back from.
+    """
+    from django.utils.module_loading import import_string
+
+    from django_waf import conf
+
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
+
+    dotted_path = conf.DJANGO_WAF_BLOCK_RESPONSE_HANDLER
+    if not dotted_path:
+        return []
+
+    try:
+        import_string(dotted_path)
+    except Exception:
+        return [
+            Error(
+                f"DJANGO_WAF_BLOCK_RESPONSE_HANDLER={dotted_path!r} could not "
+                "be imported. The WAF will fall back to the built-in 403 on "
+                "every blocked request.",
+                hint=(
+                    "Check the dotted path is correct and that importing it "
+                    "does not raise: a typo, a moved module, or the handler "
+                    "module's own top-level code raising on import (a "
+                    "settings read before django.setup(), for instance) all "
+                    "produce this error."
+                ),
+                id="django_waf.E008",
+            )
+        ]
+
+    return []

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -209,8 +209,13 @@ class WafMiddleware:
 
         Fails open: any error resolving the country (missing database,
         geoip2 not installed, lookup exception) falls through to normal
-        evaluation rather than blocking. Logging the block is best-effort —
-        a logging failure never prevents the 403 from being returned.
+        evaluation rather than blocking. Logging the block is best-effort,
+        a logging failure never prevents the block response from being
+        returned. The block response itself goes through
+        ``_build_block_response`` (#76), which guards every failure of its
+        own handler path internally and never raises, so a broken block
+        response handler cannot escape into this method's own
+        fail-open except clause and turn a country block into a pass.
         """
         from django_waf import conf
 
@@ -227,15 +232,35 @@ class WafMiddleware:
                 return None
 
             self._log_country_block(request, ip_address, user_agent, path, country)
-            # NOT routed through DJANGO_WAF_BLOCK_RESPONSE_HANDLER (#74).
-            # That hook's contract is (request, result), and this path has no
-            # EvaluationResult at all: the country decision is taken here,
-            # before evaluate_request() ever runs. Synthesising a fake result
-            # just to satisfy the signature would be a worse defect than the
-            # gap, so the gap is deliberate and recorded. A consumer needing
-            # a custom shape here should exempt the path or gate country
-            # blocking at the edge. Tracked as #76.
-            return HttpResponseForbidden("Access denied.")
+
+            # Routed through DJANGO_WAF_BLOCK_RESPONSE_HANDLER (#76). This
+            # path has no EvaluationResult from evaluate_request(): the
+            # country decision is taken here, before evaluate_request() ever
+            # runs. But the values below are not a fake result invented to
+            # satisfy the signature: they are exactly what _log_country_block,
+            # five lines above, already writes to RequestLog for this same
+            # path. That is the code's own honest description of a country
+            # block, so building the same EvaluationResult and handing it to
+            # the same hook is correct, not a synthesis.
+            #
+            # The country code itself has no field on EvaluationResult (the
+            # NamedTuple is a public type consumers unpack, so widening it
+            # is a bigger API change than this fix). It is carried instead
+            # as request.waf_blocked_country, set just before the handler
+            # runs, so a handler wanting it reads
+            # getattr(request, "waf_blocked_country", None).
+            from django_waf.enums import RuleAction, Verdict
+            from django_waf.services.rule_engine import EvaluationResult
+
+            request.waf_blocked_country = country
+            result = EvaluationResult(
+                verdict=Verdict.BLOCKED,
+                action=RuleAction.BLOCK,
+                matched_rule_id=None,
+                matched_rule_type="",
+                anomaly_score=None,
+            )
+            return self._build_block_response(request, result)
         except Exception:
             logger.exception("django-waf: error during country-block check — failing open")
             return None
@@ -417,6 +442,16 @@ class WafMiddleware:
         must query for it, and should weigh that cost against the traffic
         it is blocking.
 
+        ``request.waf_blocked_country`` is present, holding the ISO 3166-1
+        alpha-2 country code, only when this call came from
+        ``_check_country_block`` (#76). It is absent on every other BLOCKED
+        verdict: ``EvaluationResult`` carries no country field, deliberately
+        (it is a public NamedTuple that consumers unpack, so widening it is
+        a larger API change than this attribute), so a handler that wants
+        to branch on it must read it defensively::
+
+            country = getattr(request, "waf_blocked_country", None)
+
         The return value must be an ``HttpResponse``, of any subclass and
         any status code. The middleware returns it unaltered.
 
@@ -447,9 +482,10 @@ class WafMiddleware:
 
         SCOPE
 
-        BLOCKED verdicts only. THROTTLED and CHALLENGED keep their own
-        responses, and ``_check_country_block``'s direct 403 is out of
-        scope (see the comment at that return).
+        BLOCKED verdicts only, which now includes country blocks (#76):
+        ``_check_country_block`` builds its own ``EvaluationResult`` and
+        calls this method too, rather than returning a hardcoded response
+        directly. THROTTLED and CHALLENGED keep their own responses.
         """
         from django_waf import conf
 

--- a/src/django_waf/services/threat_feed.py
+++ b/src/django_waf/services/threat_feed.py
@@ -2,7 +2,7 @@
 Threat feed service for django-waf.
 
 Manages synchronisation from the central threat feed and opt-in anonymised
-telemetry reporting. Per BR-FEED-001 through BR-TEL-004.
+telemetry reporting. Per BR-FEED-001 through BR-TEL-003.
 """
 
 from __future__ import annotations
@@ -474,7 +474,7 @@ def build_telemetry_payload(period_start, period_end) -> dict:
 def submit_telemetry(payload: dict, report_url: str | None = None) -> bool:
     """POST the telemetry payload to the central reporting endpoint.
 
-    Per BR-TEL-004: never raises on failure. Logs a warning on failure.
+    Per BR-TEL-003: never raises on failure. Logs a warning on failure.
 
     Args:
         payload: Telemetry dict from build_telemetry_payload().
@@ -507,7 +507,7 @@ def submit_telemetry(payload: dict, report_url: str | None = None) -> bool:
         return False
     except Exception as exc:
         logger.warning("django-waf: telemetry submission error: %s", exc)
-        return False  # BR-TEL-004: never raise
+        return False  # BR-TEL-003: never raise
 
 
 def get_or_create_install_id() -> str:

--- a/tests/block_handler_import_boom.py
+++ b/tests/block_handler_import_boom.py
@@ -1,13 +1,12 @@
 """A block-response handler module whose own import fails, and not with an
 ImportError.
 
-Exists solely so ``tests/test_block_response_hook.py`` can prove the
-middleware's import guard is broader than ``except ImportError``. A real
-consumer hits this shape when the handler module reads a setting at import
-time (``ImproperlyConfigured``), touches the app registry too early
-(``AppRegistryNotReady``), or ships a stale ``.pyc``.
-
-Nothing else may import this module.
+Used by ``tests/test_block_response_hook.py`` to prove the middleware's
+runtime import guard is broader than ``except ImportError``, and by
+``tests/test_checks.py`` to prove the ``django_waf.E008`` boot check agrees
+with it. A real consumer hits this shape when the handler module reads a
+setting at import time (``ImproperlyConfigured``), touches the app
+registry too early (``AppRegistryNotReady``), or ships a stale ``.pyc``.
 """
 
 from __future__ import annotations

--- a/tests/test_block_response_hook.py
+++ b/tests/test_block_response_hook.py
@@ -443,3 +443,179 @@ class TestSettingDefault:
         from django_waf import conf
 
         assert conf.DJANGO_WAF_BLOCK_RESPONSE_HANDLER == "some.dotted.path"
+
+
+# ---------------------------------------------------------------------------
+# Country blocks now route through the hook too (#76)
+# ---------------------------------------------------------------------------
+
+
+def _run_country_blocked_request(blocked_countries=("CN",), country="CN"):
+    """Drive a request from a blocked country through the real middleware
+    ``__call__`` path, mirroring ``_run_blocked_request`` above.
+
+    Patches only ``lookup_country``, the single external boundary of
+    ``_check_country_block``. Everything downstream, including the routing
+    into ``_build_block_response``, runs for real, so these tests prove the
+    hook is wired into the country-block path rather than merely that
+    ``_build_block_response`` works in isolation.
+    """
+    from django_waf.middleware import WafMiddleware
+
+    factory = RequestFactory()
+    request = factory.get("/page/")
+    request.user = MagicMock(is_authenticated=False)
+    request.COOKIES = {}
+    get_response = MagicMock(return_value=HttpResponse("view response"))
+
+    with (
+        override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCKED_COUNTRIES=list(blocked_countries)),
+        patch("django_waf.services.geoip.lookup_country", return_value=country),
+    ):
+        middleware = WafMiddleware(get_response)
+        response = middleware(request)
+
+    get_response.assert_not_called()
+    return request, response
+
+
+@pytest.mark.django_db
+class TestCountryBlockRoutesThroughTheHook:
+    """A country block is BLOCKED like any other (#76): it now goes through
+    ``DJANGO_WAF_BLOCK_RESPONSE_HANDLER`` rather than returning a hardcoded
+    403 directly.
+
+    The values ``_check_country_block`` builds the ``EvaluationResult``
+    from are not invented for this path: they are exactly what
+    ``_log_country_block`` already writes to ``RequestLog`` for the same
+    request, a few lines above the call this class exercises.
+    """
+
+    @override_settings(
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_handler_is_called_for_a_country_block(self):
+        _run_country_blocked_request()
+
+        assert len(CALLS) == 1
+
+    @override_settings(
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_handler_response_replaces_the_default_for_a_country_block(self):
+        _request, response = _run_country_blocked_request()
+
+        assert response.status_code == 404
+        assert response.content == b"Not found."
+
+    @override_settings(
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_handler_receives_the_documented_evaluation_result(self):
+        """Pins the exact field values the brief and the docstring both
+        promise, which are the same values ``_log_country_block`` writes to
+        ``RequestLog`` for this request: this is not a synthesised result."""
+        from django_waf.enums import RuleAction, Verdict
+
+        _run_country_blocked_request()
+
+        assert len(CALLS) == 1
+        request, result = CALLS[0]
+        assert result.verdict == Verdict.BLOCKED
+        assert result.action == RuleAction.BLOCK
+        assert result.matched_rule_id is None
+        assert result.matched_rule_type == ""
+        assert result.anomaly_score is None
+        assert request.waf_blocked_country == "CN"
+
+    @override_settings(
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+    )
+    def test_waf_blocked_country_is_absent_on_a_normal_block(self):
+        """The attribute is country-block-only. Checked with ``hasattr``,
+        not ``getattr(..., None)``, because the documented contract is
+        absence, and a handler reading ``None`` back would not be able to
+        tell "not a country block" from "country block with no code"."""
+        from django_waf.middleware import WafMiddleware
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("view response"))
+
+        with (
+            override_settings(DJANGO_WAF_ENABLED=True),
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+            patch("django_waf.middleware._emit_request_blocked"),
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result("blocked")
+
+            middleware = WafMiddleware(get_response)
+            middleware(request)
+
+        assert len(CALLS) == 1
+        seen_request, _result = CALLS[0]
+        assert not hasattr(seen_request, "waf_blocked_country")
+
+    def test_no_handler_configured_returns_the_byte_identical_built_in_403(self):
+        """Unset handler: byte-identical to the pre-#76 hardcoded response,
+        via ``_default_block_response`` rather than a second literal."""
+        _request, response = _run_country_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+        assert CALLS == []
+
+    @override_settings(
+        DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.raising_handler",
+    )
+    def test_raising_handler_on_a_country_block_still_blocks(self):
+        """A broken handler must not turn a country block into a pass. The
+        handler runs and raises, ``_build_block_response`` catches it and
+        falls back to the built-in 403, and none of that reaches
+        ``_check_country_block``'s own outer ``except Exception`` (which
+        would fail the request open)."""
+        _request, response = _run_country_blocked_request()
+
+        assert response.status_code == 403
+        assert response.content == b"Access denied."
+        assert len(CALLS) == 1
+
+
+@pytest.mark.django_db
+class TestGeoipLookupStillFailsOpen:
+    """The geoip lookup failing must still fall through to normal
+    evaluation, not to the block-response hook: fail-open behaviour for
+    ``_check_country_block``'s own errors is unchanged by #76."""
+
+    @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCKED_COUNTRIES=["CN"])
+    def test_lookup_exception_fails_open_to_normal_evaluation(self):
+        from django_waf.middleware import WafMiddleware
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("ok"))
+
+        with (
+            patch("django_waf.services.geoip.lookup_country", side_effect=RuntimeError("geoip boom")),
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result("allowed")
+
+            middleware = WafMiddleware(get_response)
+            response = middleware(request)
+
+        assert response.status_code == 200
+        get_response.assert_called_once_with(request)
+        assert CALLS == []

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -129,6 +129,12 @@ def _run_env_only_settings_check():
     return check_env_only_settings(app_configs=None)
 
 
+def _run_block_response_handler_check():
+    from django_waf.checks import check_block_response_handler_importable
+
+    return check_block_response_handler_importable(app_configs=None)
+
+
 class TestChallengeDifficultyCheck:
     def test_recommended_defaults_produce_no_messages(self):
         import django_waf.conf as conf_mod
@@ -1027,6 +1033,81 @@ class TestEnvOnlySettingsCheck:
             messages = _run_env_only_settings_check()
 
         assert any(m.id == "django_waf.W010" and "DJANGO_WAF_SIGNING_KEY" in m.msg for m in messages)
+
+
+class TestBlockResponseHandlerImportableCheck:
+    """django_waf.E008: errors when DJANGO_WAF_BLOCK_RESPONSE_HANDLER is
+    set to a dotted path that cannot be imported (#121).
+
+    The teeth test below (``test_non_importerror_on_import_is_still_caught``)
+    is the one that matters most: it proves the except clause is broader
+    than ``ImportError``, agreeing with the runtime guard in
+    ``WafMiddleware._build_block_response``. A check narrower than the
+    runtime guard would pass at boot for a handler that fails on every
+    blocked request afterwards.
+    """
+
+    def test_unresolvable_path_emits_e008_error(self):
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.does_not_exist.handler",
+        ):
+            messages = _run_block_response_handler_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.E008"
+
+    def test_message_names_the_setting_and_the_dotted_path(self):
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.does_not_exist.handler",
+        ):
+            messages = _run_block_response_handler_check()
+
+        assert "DJANGO_WAF_BLOCK_RESPONSE_HANDLER" in messages[0].msg
+        assert "tests.does_not_exist.handler" in messages[0].msg
+        assert "403" in messages[0].msg
+
+    def test_resolvable_path_is_silent(self):
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.test_block_response_hook.working_handler",
+        ):
+            assert _run_block_response_handler_check() == []
+
+    def test_empty_setting_is_silent(self):
+        """The default. Not a misconfiguration: it means "use the built-in
+        block response"."""
+        with override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_BLOCK_RESPONSE_HANDLER=""):
+            assert _run_block_response_handler_check() == []
+
+    def test_waf_disabled_is_silent(self):
+        """A disabled WAF issues no BLOCKED verdicts, so
+        _build_block_response never runs and an unresolvable handler can
+        never fire. Same #95 gating rationale as every other check here."""
+        with override_settings(
+            DJANGO_WAF_ENABLED=False,
+            DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.does_not_exist.handler",
+        ):
+            assert _run_block_response_handler_check() == []
+
+    def test_non_importerror_on_import_is_still_caught(self):
+        """The teeth test. ``tests.block_handler_import_boom`` is a real
+        module whose top-level code raises ``ImproperlyConfigured``, not
+        ``ImportError``. ``import_string`` propagates whatever the module
+        itself raises, so a check written as ``except ImportError`` would
+        let this straight through and report ``[]``: a green boot check for
+        a handler that fails on every single blocked request afterwards.
+        This test fails against that narrower except.
+        """
+        with override_settings(
+            DJANGO_WAF_ENABLED=True,
+            DJANGO_WAF_BLOCK_RESPONSE_HANDLER="tests.block_handler_import_boom.handler",
+        ):
+            messages = _run_block_response_handler_check()
+
+        assert len(messages) == 1
+        assert messages[0].id == "django_waf.E008"
 
 
 class TestSitePasswordConfiguredCheck:


### PR DESCRIPTION
Closes #76. Closes #121.

Spec merged first: umbrella `f15d6a1` (BR-EVAL-012 amended, BR-EVAL-013 added) and `8c8c9b9` (check function name).

## #76: country blocks bypassed the block-response hook

`_check_country_block` returned a hardcoded `HttpResponseForbidden`, so a consumer that had configured `DJANGO_WAF_BLOCK_RESPONSE_HANDLER` still leaked the package 403 on that path. For a multi-tenant host serving unbound custom domains, that is the exact fingerprint the hook exists to remove.

Wave 3 scoped this out deliberately, arguing the path has no `EvaluationResult` and that building one would be synthesising a fake. **That reasoning does not hold, and the amended spec withdraws it explicitly rather than quietly rewriting it.** `_log_country_block` already writes `verdict=BLOCKED`, `matched_rule_id=None`, `matched_rule_type=""`, `anomaly_score=None` to the RequestLog row for this same request, five lines above the old comment. Those values are the code's own honest description of a country block, so a result built from them synthesises nothing.

### Why the country is a request attribute, not a new field

Not because widening `EvaluationResult` would break consumers. It would not: `retry_after` was added as a defaulted sixth field in 1.6.0, and that CHANGELOG entry records positional five-argument constructions were unaffected.

The reason is semantic. Every field on `EvaluationResult` describes an outcome `evaluate_request` produced, and a country block is decided before `evaluate_request` runs, so a `blocked_country` field would be permanently `None` for every result the evaluator itself returns. It is carried as `request.waf_blocked_country`, set immediately before the handler runs, **absent rather than None** on every other path, so handlers read `getattr(request, "waf_blocked_country", None)`. The handler signature is unchanged, so no existing handler breaks.

### Fail-open posture, unchanged and load-bearing

`_build_block_response` guards its own import and its own handler call and cannot raise, so a broken handler cannot escape into `_check_country_block`'s outer `except` and turn a country block into a **pass**. A raising handler still returns the built-in 403. The geoip lookup itself still fails open to normal evaluation. Both are covered by tests.

## #121: django_waf.E008, a boot check for the handler path

`check_block_response_handler_importable` errors when the setting names a path that will not import. Layered guards as E005 and E007: WAF enabled, then setting non-empty, then `import_string` inside `try/except`.

The except is deliberately broader than `ImportError` and must stay so to agree with the runtime guard. A narrower check would pass at boot for a handler that fails on every blocked request: a false all-clear worse than no check. It proves only that the path resolves, never that the handler is correct; a bad signature, a non-`HttpResponse` return, or a raising handler are caught only at runtime.

> [!IMPORTANT]
> **Check-id collision, tracked at #131.** An unpushed branch (`feat/throttle-hook-and-method-scoped-paths`) has also claimed `django_waf.E008`, for a rate-limit-paths shape check. Merged spec canon names E008 as the block-response-handler check across four artefacts, so that branch is the side that should move; next free id is **E009**. Flagging here because two checks sharing an id would make `manage.py check` ambiguous and let an operator silencing one silence the other.

## Also: a dangling spec citation

Three comments in `services/threat_feed.py` cited `BR-TEL-004`, which does not exist. The rule governing never-raise-on-failure is `BR-TEL-003`. Comments only, no behaviour change. Found by extracting all 64 BR citations in `src/` and comparing against all 114 rules in the spec; it was the only dangling one. Related to #130, closed earlier today for the same defect class.

## Verification

All in a venv asserted to import from this worktree (a previous session twice got a false green from a venv resolving to a different worktree):

| Gate | Result |
|---|---|
| Full suite | **1416 passed, 6 skipped**. Baseline on `origin/main` in the same venv is 1403, so 13 new tests, zero regressions |
| ruff (CI-pinned 0.15.22) | `check` clean, `format --check` 155 files already formatted |
| mypy 2.3.1 + django-stubs 6.1.0 | clean across **89** source files, above the 80 threshold, so not a no-op run |
| PostgreSQL 16 (real container) | 1414 passed, 8 skipped |
| Redis 6.0 (real container) | 6 passed, redis_integration subset |

**The E008 teeth test was proven by induction, not assumed:** narrowing the except to `ImportError` makes `test_non_importerror_on_import_is_still_caught` FAIL with `ImproperlyConfigured` propagating out; reverting makes it pass. Run twice, once by the tester and once independently.

It reuses the existing `tests/block_handler_import_boom.py` fixture rather than duplicating it, and that module's docstring was updated since it now has two callers and previously claimed "nothing else may import this module".