### PR TITLE
feat(middleware,checks): replaceable throttle response, method-scoped rate-limit paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.6.0] - 2026-09-03
+## [Unreleased]
 ### Added
 
 - **Method-aware `DJANGO_WAF_RATE_LIMIT_PATHS`** (BR-RATE-004).
@@ -81,6 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Scope is THROTTLED verdicts only, exactly as the block-response hook is
   scoped to BLOCKED only: BLOCKED and CHALLENGED keep their own responses.
+
+## [2.6.0] - 2026-09-03
+### Added
 
 - **A replaceable block response** (#74, BR-EVAL-012).
   `DJANGO_WAF_BLOCK_RESPONSE_HANDLER` takes a dotted path to a callable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,80 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.6.0] - 2026-09-03
 ### Added
 
+- **Method-aware `DJANGO_WAF_RATE_LIMIT_PATHS`** (BR-RATE-004).
+  A configured entry can now be `(max_requests, window_seconds, methods)`,
+  where `methods` is an iterable of HTTP method strings such as
+  `("POST",)`, scoping the limit to only those methods. The existing
+  `(max_requests, window_seconds)` shape is completely unchanged and keeps
+  limiting every method, exactly as every prior release did: this is a
+  widely deployed setting, so nothing about it changes silently.
+
+  The need is a URL that serves two very different kinds of traffic: a
+  scan-landing page and its own submit endpoint mounted at the same path
+  (`path("scan/", ScanFormView.as_view())`). A budget meant for submit
+  attempts previously counted ordinary page-view GETs against the same
+  limit, because prefix matching alone cannot say "the POST but not the
+  GET" at one URL. Splitting the route onto two URLs is not always an
+  option, and moving unrelated routes off the shared prefix (the previous
+  workaround) does not fix the shared route itself.
+
+  **Resolution rule, read this before adding a scoped entry.** Prefixes
+  are still tried longest-first, but a prefix that matches the path while
+  its method scope excludes the current request is skipped, and evaluation
+  falls through to the next-longest matching prefix rather than treating
+  the request as having no path limit at all. Concretely: with `"/scan/":
+  (2, 60)` (unscoped) and `"/scan/submit/": (100, 60, ("POST",))`
+  configured together, a GET to `/scan/submit/` is evaluated against the
+  shorter `"/scan/"` entry, not left unlimited. Stopping at the longest
+  match regardless of scope would mean adding one scoped rule for a single
+  route silently turns off rate limiting for every other method at that
+  URL, which is the opposite of what adding a scoped rule is for.
+
+  A malformed entry (wrong tuple length, a non-positive `max_requests` or
+  `window_seconds`, an empty or non-string `methods` collection) is now
+  refused at boot by a new check, `django_waf.E009`, rather than raising
+  deep in the per-request evaluation path the first time a matching
+  request arrived, where it was swallowed by `evaluate_request`'s
+  fail-open wrapper as a generic evaluation error and never reached the
+  operator. Silent when `DJANGO_WAF_ENABLED = False`, matching
+  `django_waf.E001`/`E002`'s gating: rate limiting never runs while the
+  WAF is disabled.
+
+- **A replaceable throttle response** (BR-EVAL-014), mirroring the
+  block-response hook below exactly. `DJANGO_WAF_THROTTLE_RESPONSE_HANDLER`
+  takes a dotted path to a callable `handler(request, result) ->
+  HttpResponse` for a THROTTLED verdict, and the middleware returns
+  whatever it produces, unaltered. Unset (the default), the response is
+  exactly what every prior release returned: a 429 with the body
+  `"Too many requests. Please retry later."` and the existing
+  `Retry-After` logic (the accurate `result.retry_after` value when
+  present, else the fixed `"60"` fallback per #30); the built-in response
+  is now produced by a single named method that both the no-hook path and
+  every fallback path return, so the two cannot drift apart.
+
+  The need is the same fingerprinting problem the block-response hook
+  closes, on the other verdict: an unstyled, hardcoded 429 body rendering
+  on a public page with no supported way to restyle it. Unlike the BLOCKED
+  path, `result.retry_after` **is** populated here, so a handler that
+  wants to set its own `Retry-After` header can read it straight off the
+  result rather than recomputing it.
+
+  Three failure modes fall back to the built-in 429 and log at ERROR,
+  distinguished so you can tell which happened: the path will not import,
+  the handler raises, or it returns something that is not an
+  `HttpResponse`. The path is resolved on each throttled request rather
+  than once at import, so `override_settings` works.
+
+  **If you subclass `WafMiddleware` and override the private
+  `_handle_verdict`, you will not pick this up.** Your override keeps
+  working exactly as before and nothing breaks, but it will not honour the
+  new setting until you either rebase onto the new `_handle_verdict` or
+  call `self._build_throttle_response(request, result)` yourself where you
+  currently build the 429.
+
+  Scope is THROTTLED verdicts only, exactly as the block-response hook is
+  scoped to BLOCKED only: BLOCKED and CHALLENGED keep their own responses.
+
 - **A replaceable block response** (#74, BR-EVAL-012).
   `DJANGO_WAF_BLOCK_RESPONSE_HANDLER` takes a dotted path to a callable
   `handler(request, result) -> HttpResponse`, and the middleware returns

--- a/README.md
+++ b/README.md
@@ -167,9 +167,11 @@ All settings are namespaced under `DJANGO_WAF_*` and have sensible defaults.
 | `DJANGO_WAF_RATE_LIMIT_BURST` | `10` | Max requests per IP per second |
 | `DJANGO_WAF_RATE_LIMIT_PER_MINUTE` | `120` | Max requests per IP per minute |
 | `DJANGO_WAF_RATE_LIMIT_PER_5MIN` | `600` | Max requests per IP per 5 minutes |
-| `DJANGO_WAF_RATE_LIMIT_PATHS` | `{}` | Per-path rate limits: `{path_prefix: (max_requests, window_seconds)}`. Checked before the global windows; the longest matching prefix wins. Cannot cover `/waf/verify/` if it is also in `DJANGO_WAF_EXEMPT_PATHS`, see the dedicated setting below |
+| `DJANGO_WAF_RATE_LIMIT_PATHS` | `{}` | Per-path rate limits: `{path_prefix: (max_requests, window_seconds)}`, or, from BR-RATE-004, `{path_prefix: (max_requests, window_seconds, methods)}` where `methods` is an iterable of HTTP method strings (e.g. `("POST",)`) that scopes the entry to those methods only. The two-item form is unchanged and still limits every method. Checked before the global windows; the longest matching prefix wins, falling through to the next-longest matching prefix if the longest one's method scope excludes the request (see the settings reference spec for the full resolution rule). Malformed entries are refused at boot by `django_waf.E009`. Cannot cover `/waf/verify/` if it is also in `DJANGO_WAF_EXEMPT_PATHS`, see the dedicated setting below |
 | `DJANGO_WAF_VERIFY_RATE_LIMIT_MAX` | `20` | Max `POST /waf/verify/` solve attempts per IP within the window below, independent of the settings above (issue #81) |
 | `DJANGO_WAF_VERIFY_RATE_LIMIT_WINDOW_SECONDS` | `300` | Window (seconds) for `DJANGO_WAF_VERIFY_RATE_LIMIT_MAX`. A breach returns `429` with `Retry-After`, never a block; fails open on Redis errors |
+| `DJANGO_WAF_BLOCK_RESPONSE_HANDLER` | `""` | Dotted path to a callable `handler(request, result) -> HttpResponse` that produces the response for a BLOCKED verdict (BR-EVAL-012). Unset (the default) keeps the built-in `HttpResponseForbidden("Access denied.")`, byte for byte. `result.retry_after` is always `None` on this path |
+| `DJANGO_WAF_THROTTLE_RESPONSE_HANDLER` | `""` | Dotted path to a callable `handler(request, result) -> HttpResponse` that produces the response for a THROTTLED verdict (BR-EVAL-014), mirroring `DJANGO_WAF_BLOCK_RESPONSE_HANDLER` above. Unset (the default) keeps the built-in 429 with its existing `Retry-After` logic, byte for byte. Unlike the BLOCKED path, `result.retry_after` IS populated here |
 
 ### Challenges
 

--- a/src/django_waf/checks.py
+++ b/src/django_waf/checks.py
@@ -243,6 +243,22 @@ does not raise when actually called: none of that is observable without
 invoking the handler with a real request, which a boot-time check must
 not do. Those three failure modes are caught only at runtime, by the
 fallbacks ``_build_block_response`` already documents.
+
+The rate-limit-paths shape check (``django_waf.E009``) errors
+(BR-RATE-004) when a ``DJANGO_WAF_RATE_LIMIT_PATHS`` entry is malformed:
+not a 2- or 3-item tuple/list, a non-positive ``max_requests`` or
+``window_seconds``, or (for the 3-item, method-scoped form) an empty or
+non-string-only ``methods`` collection. Before this check, a malformed
+entry was never validated at all: ``_check_path_rate_limit`` would raise
+``TypeError`` or ``ValueError`` deep in the per-request evaluation path the
+first time a matching request arrived, which ``evaluate_request``'s
+fail-open wrapper then swallows as a generic evaluation error (BR-EVAL-007)
+rather than surfacing the operator's typo. Gated on
+``DJANGO_WAF_ENABLED = True``, matching ``django_waf.E001``/``E002``
+(``check_challenge_difficulty``): with the WAF disabled, rate limiting
+never runs at all, so a malformed entry behind it is not a live
+misconfiguration, only a latent one that will be caught the moment the WAF
+is switched on and this check runs again.
 """
 
 from __future__ import annotations
@@ -1110,3 +1126,99 @@ def check_block_response_handler_importable(app_configs, **kwargs):
         ]
 
     return []
+
+
+@register()
+def check_rate_limit_paths(app_configs, **kwargs):
+    """Error (``django_waf.E009``) when a ``DJANGO_WAF_RATE_LIMIT_PATHS``
+    entry is malformed (BR-RATE-004).
+
+    A valid entry is ``{prefix: (max_requests, window_seconds)}`` (the
+    original, unscoped form) or ``{prefix: (max_requests, window_seconds,
+    methods)}`` (the method-scoped form). This check validates every entry:
+
+    - the value is a tuple or list of length 2 or 3;
+    - ``max_requests`` is a positive int;
+    - ``window_seconds`` is a positive int;
+    - for a 3-item entry, ``methods`` is a non-empty iterable of non-empty
+      strings (an empty ``methods`` collection would make the entry
+      unreachable by any request, silently disabling it rather than
+      raising, since ``_entry_applies_to_method`` treats "nothing listed"
+      as "nothing matches").
+
+    Gated on ``DJANGO_WAF_ENABLED = True``, matching the challenge-difficulty
+    checks (``django_waf.E001``/``E002``): rate limiting never runs while
+    the WAF is disabled, so a malformed entry behind it is latent, not live.
+    """
+    from django_waf import conf
+
+    if not conf.DJANGO_WAF_ENABLED:
+        return []
+
+    rate_limit_paths = conf.DJANGO_WAF_RATE_LIMIT_PATHS
+    if not rate_limit_paths:
+        return []
+
+    messages = []
+
+    for prefix, entry in rate_limit_paths.items():
+        if not isinstance(entry, (tuple, list)) or len(entry) not in (2, 3):
+            messages.append(
+                Error(
+                    f"DJANGO_WAF_RATE_LIMIT_PATHS[{prefix!r}] = {entry!r} is not a valid entry.",
+                    hint=(
+                        "Each value must be (max_requests, window_seconds) or "
+                        "(max_requests, window_seconds, methods), e.g. "
+                        "(5, 300) or (5, 300, ('POST',))."
+                    ),
+                    id="django_waf.E009",
+                )
+            )
+            continue
+
+        max_requests, window_seconds = entry[0], entry[1]
+        if not isinstance(max_requests, int) or isinstance(max_requests, bool) or max_requests <= 0:
+            messages.append(
+                Error(
+                    f"DJANGO_WAF_RATE_LIMIT_PATHS[{prefix!r}]: max_requests must be a "
+                    f"positive integer (got {max_requests!r}).",
+                    hint="The first tuple item is the request budget for the window.",
+                    id="django_waf.E009",
+                )
+            )
+
+        if not isinstance(window_seconds, int) or isinstance(window_seconds, bool) or window_seconds <= 0:
+            messages.append(
+                Error(
+                    f"DJANGO_WAF_RATE_LIMIT_PATHS[{prefix!r}]: window_seconds must be a "
+                    f"positive integer (got {window_seconds!r}).",
+                    hint="The second tuple item is the sliding window length in seconds.",
+                    id="django_waf.E009",
+                )
+            )
+
+        if len(entry) == 3:
+            methods = entry[2]
+            valid_methods = (
+                hasattr(methods, "__iter__")
+                and not isinstance(methods, (str, bytes))
+                and all(isinstance(m, str) and m for m in methods)
+                and len(list(methods)) > 0
+            )
+            if not valid_methods:
+                messages.append(
+                    Error(
+                        f"DJANGO_WAF_RATE_LIMIT_PATHS[{prefix!r}]: the third tuple item "
+                        f"must be a non-empty iterable of non-empty HTTP method strings "
+                        f"(got {methods!r}).",
+                        hint=(
+                            "For example (5, 300, ('POST',)). An empty methods "
+                            "collection matches no request, silently disabling the "
+                            "entry rather than limiting all methods, use the "
+                            "two-item form (5, 300) for that."
+                        ),
+                        id="django_waf.E009",
+                    )
+                )
+
+    return messages

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -611,8 +611,21 @@ def _DJANGO_WAF_CLOUD_SPRAY_UA_RULE() -> bool:
     return _get_setting("DJANGO_WAF_CLOUD_SPRAY_UA_RULE", False)
 
 
-# Per-path rate limits: {path_prefix: (max_requests, window_seconds)}.
-# Longest-prefix match wins; checked before the global IP windows.
+# Per-path rate limits: {path_prefix: (max_requests, window_seconds)} or,
+# from BR-RATE-004, {path_prefix: (max_requests, window_seconds, methods)}
+# where methods is an iterable of HTTP method strings (e.g. ("POST",)) that
+# scopes the entry to only those methods. The two-item form is unchanged and
+# still limits every method, exactly as every prior release did; the
+# three-item form is opt-in per entry.
+#
+# Longest-prefix match wins, checked before the global IP windows, with one
+# refinement for method scoping: if the longest matching prefix carries a
+# method scope that excludes this request's method, evaluation falls through
+# to the next-longest matching prefix rather than stopping. See
+# ``django_waf.services.rate_limiter._check_path_rate_limit`` for the
+# resolution algorithm and why fall-through, not stop, is the chosen
+# behaviour. Validated at boot by ``django_waf.checks.check_rate_limit_paths``
+# (``django_waf.E009``).
 def _DJANGO_WAF_RATE_LIMIT_PATHS() -> dict:
     return _get_setting("DJANGO_WAF_RATE_LIMIT_PATHS", {})
 
@@ -639,10 +652,31 @@ def _DJANGO_WAF_BLOCKED_COUNTRIES() -> list:
 # built-in response and log at ERROR. The WAF never 500s on its own
 # misconfiguration.
 #
-# This is the only dotted-path setting in the package; every other setting
-# resolves to a scalar, list or dict.
+# This and DJANGO_WAF_THROTTLE_RESPONSE_HANDLER below are the only two
+# dotted-path settings in the package; every other setting resolves to a
+# scalar, list or dict.
 def _DJANGO_WAF_BLOCK_RESPONSE_HANDLER() -> str:
     return _get_setting("DJANGO_WAF_BLOCK_RESPONSE_HANDLER", "")
+
+
+# Dotted path to a callable returning the response for a THROTTLED verdict
+# (BR-EVAL-014). Empty (the default) keeps the built-in 429 response with its
+# existing Retry-After logic, byte for byte.
+#
+# Mirrors DJANGO_WAF_BLOCK_RESPONSE_HANDLER exactly: resolved with
+# import_string at call time on each throttled request, not at import time,
+# so override_settings and the pytest settings fixture work; the same three
+# failure classes (unimportable path, handler raises, handler returns a
+# non-HttpResponse) fall back to the built-in response and log at ERROR
+# distinctly. See
+# ``django_waf.middleware.WafMiddleware._build_throttle_response`` for the
+# full contract.
+#
+# Unlike the BLOCKED path, ``result.retry_after`` IS populated here (it is
+# always None on the BLOCKED path); a handler that wants to set its own
+# Retry-After header reads it from ``result.retry_after``.
+def _DJANGO_WAF_THROTTLE_RESPONSE_HANDLER() -> str:
+    return _get_setting("DJANGO_WAF_THROTTLE_RESPONSE_HANDLER", "")
 
 
 # Enable the optional DRF API under waf/api/ (requires the [api] extra).

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -529,6 +529,136 @@ class WafMiddleware:
 
         return response
 
+    def _default_throttle_response(self, result) -> HttpResponse:
+        """Return the package's built-in THROTTLED response (BR-RATE-002).
+
+        Kept as a single named source so the hook's fallback path and the
+        no-hook path cannot drift apart: both return this, byte for byte.
+
+        Preserves the existing Retry-After logic unchanged: the accurate
+        ``result.retry_after`` when present, else the fixed ``"60"``
+        fallback (see the comment inline about #30).
+        """
+        response = HttpResponse("Too many requests. Please retry later.", status=429)
+        # hasattr() was always True for the real EvaluationResult NamedTuple
+        # even before it carried a real retry_after value, so this always
+        # sent the fixed fallback (#30). Use the accurate sliding-window
+        # value when present; only fall back to a fixed 60 seconds when the
+        # result genuinely carries none (e.g. a test double or a pre-#30
+        # caller).
+        retry_after = getattr(result, "retry_after", None)
+        response["Retry-After"] = str(retry_after) if retry_after is not None else "60"
+        return response
+
+    def _build_throttle_response(self, request, result) -> HttpResponse:
+        """Return the response for a THROTTLED verdict (BR-EVAL-014).
+
+        With ``DJANGO_WAF_THROTTLE_RESPONSE_HANDLER`` unset (the default)
+        this is exactly what every release before the hook returned: a 429
+        with the body ``"Too many requests. Please retry later."`` and the
+        existing ``Retry-After`` logic, unchanged.
+
+        HANDLER CONTRACT
+
+        ``DJANGO_WAF_THROTTLE_RESPONSE_HANDLER`` is a dotted path to a
+        callable with this signature::
+
+            def handler(request: HttpRequest, result: EvaluationResult) -> HttpResponse
+
+        ``request`` is the live ``HttpRequest``. The handler runs before the
+        view, so nothing downstream has touched it.
+
+        ``result`` is the ``EvaluationResult`` NamedTuple from
+        ``django_waf.services.rule_engine``, carrying ``verdict``,
+        ``action``, ``matched_rule_id``, ``matched_rule_type``,
+        ``anomaly_score`` and ``retry_after``. ``verdict`` is always
+        ``Verdict.THROTTLED`` here, and **unlike the BLOCKED path,
+        ``retry_after`` IS populated** (it is always ``None`` on the BLOCKED
+        path -- see ``_build_block_response``). A handler that wants to set
+        its own ``Retry-After`` header reads it from ``result.retry_after``.
+
+        The return value must be an ``HttpResponse``, of any subclass and
+        any status code. The middleware returns it unaltered.
+
+        The dotted path is resolved with ``import_string`` on each throttled
+        request rather than once at import time, following the package's
+        call-time settings resolution (see ``django_waf.conf``), so
+        ``override_settings`` and the pytest ``settings`` fixture work.
+
+        FAILURE BEHAVIOUR
+
+        A misconfigured WAF must never break a request. That is the same
+        fail-open posture BR-EVAL-007 sets for evaluation. All three
+        failure modes fall back to ``_default_throttle_response(result)`` and
+        log at ERROR, classified distinctly so an operator can tell which
+        one happened:
+
+        1. the dotted path will not import, for any reason: a typo, a moved
+           module, or the handler module's own top-level code raising
+           something that is not an ``ImportError``;
+        2. the handler raises;
+        3. the handler returns something that is not an ``HttpResponse``.
+
+        The request is still throttled in all three cases. Falling back to
+        the built-in 429 is the safe direction: a broken hook must not turn
+        a throttle into a pass.
+
+        SCOPE
+
+        THROTTLED verdicts only. BLOCKED and CHALLENGED keep their own
+        responses (see ``_build_block_response`` and the CHALLENGED branch
+        of ``_handle_verdict``).
+
+        SUBCLASSING WARNING
+
+        If you subclass ``WafMiddleware`` and override the private
+        ``_handle_verdict``, you will not pick this up: your override keeps
+        working exactly as before, but it will not honour this setting until
+        you either rebase onto the new ``_handle_verdict`` or call
+        ``self._build_throttle_response(request, result)`` yourself where you
+        currently build the 429.
+        """
+        from django_waf import conf
+
+        dotted_path = conf.DJANGO_WAF_THROTTLE_RESPONSE_HANDLER
+        if not dotted_path:
+            return self._default_throttle_response(result)
+
+        try:
+            handler = import_string(dotted_path)
+        except Exception:
+            # Deliberately broader than ImportError, mirroring
+            # _build_block_response: importing the handler's module runs
+            # that module's own top-level code, which can raise anything.
+            # None of those may reach the client as a 500 on a request the
+            # WAF is already throttling.
+            logger.exception(
+                "django-waf: DJANGO_WAF_THROTTLE_RESPONSE_HANDLER %r could not be imported. "
+                "Falling back to the built-in throttle response.",
+                dotted_path,
+            )
+            return self._default_throttle_response(result)
+
+        try:
+            response = handler(request, result)
+        except Exception:
+            logger.exception(
+                "django-waf: throttle response handler %r raised. Falling back to the built-in throttle response.",
+                dotted_path,
+            )
+            return self._default_throttle_response(result)
+
+        if not isinstance(response, HttpResponse):
+            logger.error(
+                "django-waf: throttle response handler %r returned %s, not an HttpResponse. "
+                "Falling back to the built-in throttle response.",
+                dotted_path,
+                type(response).__name__,
+            )
+            return self._default_throttle_response(result)
+
+        return response
+
     def _handle_verdict(self, request, result, ip_address, user_agent, path, redis_client):
         from django_waf.enums import Verdict
 
@@ -553,16 +683,7 @@ class WafMiddleware:
 
         if verdict == Verdict.THROTTLED:
             _emit_request_throttled(result, ip_address)
-            response = HttpResponse("Too many requests. Please retry later.", status=429)
-            # hasattr() was always True for the real EvaluationResult
-            # NamedTuple even before it carried a real retry_after value, so
-            # this always sent the fixed fallback (#30). Use the accurate
-            # sliding-window value when present; only fall back to a fixed
-            # 60 seconds when the result genuinely carries none (e.g. a
-            # test double or a pre-#30 caller).
-            retry_after = getattr(result, "retry_after", None)
-            response["Retry-After"] = str(retry_after) if retry_after is not None else "60"
-            return response
+            return self._build_throttle_response(request, result)
 
         if verdict == Verdict.CHALLENGED:
             try:

--- a/src/django_waf/middleware.py
+++ b/src/django_waf/middleware.py
@@ -574,7 +574,7 @@ class WafMiddleware:
         ``anomaly_score`` and ``retry_after``. ``verdict`` is always
         ``Verdict.THROTTLED`` here, and **unlike the BLOCKED path,
         ``retry_after`` IS populated** (it is always ``None`` on the BLOCKED
-        path -- see ``_build_block_response``). A handler that wants to set
+        path, see ``_build_block_response``). A handler that wants to set
         its own ``Retry-After`` header reads it from ``result.retry_after``.
 
         The return value must be an ``HttpResponse``, of any subclass and

--- a/src/django_waf/services/rate_limiter.py
+++ b/src/django_waf/services/rate_limiter.py
@@ -56,18 +56,60 @@ def _retry_after_from_oldest(oldest_in_window: list, window_seconds: int, now: f
     return max(1, retry_after)
 
 
+def _entry_applies_to_method(entry: tuple, method: str) -> bool:
+    """Return whether a ``DJANGO_WAF_RATE_LIMIT_PATHS`` entry covers ``method``.
+
+    ``entry`` is the configured tuple for a matched prefix: either
+    ``(max_requests, window_seconds)`` (BR-RATE-001, unscoped, applies to
+    every method, unchanged since the setting's introduction) or
+    ``(max_requests, window_seconds, methods)`` (BR-RATE-004, opt-in
+    method scoping). A two-item entry always applies. A three-item entry
+    applies only when ``method`` (already upper-cased by the caller) is a
+    member of its ``methods`` collection, compared case-insensitively
+    against each configured value.
+
+    ``method`` may be the empty string when the caller has no method to
+    offer (a pre-existing call site not yet passing one through); an
+    unscoped two-item entry still applies in that case, but a three-item
+    scoped entry never matches an unknown method, since matching would mean
+    guessing which method the caller meant.
+    """
+    if len(entry) == 2:
+        return True
+    _max_requests, _window_seconds, methods = entry
+    if not method:
+        return False
+    return method in {m.upper() for m in methods}
+
+
 def _check_path_rate_limit(
     ip_address: str,
     path: str,
     redis_client,
     now: float,
+    method: str = "",
 ) -> RateLimitResult | None:
-    """Check the per-path rate limit for the longest matching configured prefix.
+    """Check the per-path rate limit for the longest matching configured
+    prefix whose method scope covers ``method`` (BR-RATE-001, BR-RATE-004).
 
     Mirrors the sliding-window sorted-set algorithm used by the global
     windows in ``check_rate_limit`` (ZADD, ZREMRANGEBYSCORE, ZCARD, EXPIRE),
     but keyed per-prefix so a hot path can be throttled independently of
     the IP's overall traffic.
+
+    RESOLUTION RULE (BR-RATE-004): candidate prefixes are tried
+    longest-first. A prefix that matches the path but whose entry is
+    method-scoped (the three-item tuple form) to methods excluding this
+    request's method is skipped, and evaluation FALLS THROUGH to the next
+    longest matching prefix, rather than stopping there with "no path
+    limit". This is the less surprising of the two readings: a scoped
+    submit-only rule (for example ``POST`` on ``"scan/"``) is not meant to
+    also silently exempt every other method at that same prefix from a
+    shorter, unscoped rule that legitimately wants to cover the whole tree
+    (for example ``"/"``). Stopping at the longest match regardless of scope
+    would make adding a method-scoped rule for one route quietly turn off
+    rate limiting for every other method at that URL, which is the opposite
+    of what an operator adding a scoped rule is trying to do.
 
     Args:
         ip_address: Client IP address string.
@@ -75,11 +117,15 @@ def _check_path_rate_limit(
         redis_client: Configured Redis client instance.
         now: Current time (``time.time()``), passed in so callers share a
             single timestamp across the path and global checks.
+        method: HTTP method string (any case; normalised to upper case
+            here). Empty string (the default) means the caller has no
+            method to offer, in which case only unscoped (two-item) entries
+            can match.
 
     Returns:
         A ``RateLimitResult`` with ``window="path"`` if the matching prefix's
-        limit was breached, or ``None`` if no prefix matched or the matching
-        prefix's limit was not breached.
+        limit was breached, or ``None`` if no prefix's scope matched, or the
+        matching prefix's limit was not breached.
     """
     from django_waf import conf  # lazy, avoids circular import at module load
 
@@ -87,18 +133,31 @@ def _check_path_rate_limit(
     if not path or not rate_limit_paths:
         return None
 
-    # Longest-prefix match wins.
+    method = method.upper()
+
+    # Longest-prefix match wins, falling through past a matching prefix
+    # whose method scope excludes this request (see the resolution rule in
+    # the docstring above).
+    candidate_prefixes = sorted(
+        (prefix for prefix in rate_limit_paths if path.startswith(prefix)),
+        key=len,
+        reverse=True,
+    )
     matched_prefix = None
-    for prefix in rate_limit_paths:
-        if path.startswith(prefix) and (matched_prefix is None or len(prefix) > len(matched_prefix)):
+    for prefix in candidate_prefixes:
+        if _entry_applies_to_method(rate_limit_paths[prefix], method):
             matched_prefix = prefix
+            break
 
     if matched_prefix is None:
         return None
 
-    max_requests, window_seconds = rate_limit_paths[matched_prefix]
+    entry = rate_limit_paths[matched_prefix]
+    max_requests, window_seconds = entry[0], entry[1]
     # Not a security use, just a stable, short cache-key fragment derived
-    # from the configured prefix string.
+    # from the configured prefix string. Method-scoped entries at the same
+    # prefix share this key: BR-RATE-004 scopes which requests count
+    # against a budget, not a separate budget per method.
     prefix_hash = hashlib.sha1(matched_prefix.encode(), usedforsecurity=False).hexdigest()[:12]
     key = f"waf:rate:{ip_address}:path:{prefix_hash}"
     cutoff = now - window_seconds
@@ -183,6 +242,7 @@ def check_rate_limit(
     ip_address: str,
     redis_client,
     path: str = "",
+    method: str = "",
 ) -> RateLimitResult:
     """Check whether the IP has exceeded any rate limit window.
 
@@ -195,16 +255,21 @@ def check_rate_limit(
     When ``path`` is supplied and ``DJANGO_WAF_RATE_LIMIT_PATHS`` configures a
     matching prefix, that per-path limit is checked first using the same
     sliding-window algorithm, keyed independently of the global IP windows.
-    The longest matching prefix wins. A breach there returns immediately
-    with ``window="path"`` without touching the global windows.
+    The longest matching prefix whose method scope covers ``method`` wins
+    (BR-RATE-004; see ``_check_path_rate_limit`` for the fall-through
+    resolution rule). A breach there returns immediately with
+    ``window="path"`` without touching the global windows.
 
-    Per BR-RATE-001 and BR-RATE-002.
+    Per BR-RATE-001, BR-RATE-002 and BR-RATE-004.
 
     Args:
         ip_address: Client IP address string.
         redis_client: Configured Redis client instance.
         path: Request path, used to match per-path rate limits. Empty string
             (default) skips per-path checking entirely.
+        method: HTTP method string, used to resolve method-scoped entries in
+            ``DJANGO_WAF_RATE_LIMIT_PATHS`` (BR-RATE-004). Empty string
+            (default) matches only unscoped entries.
 
     Returns:
         RateLimitResult namedtuple. If any window is exceeded, ``exceeded``
@@ -226,7 +291,7 @@ def check_rate_limit(
 
     now = time.time()
 
-    path_result = _check_path_rate_limit(ip_address, path, redis_client, now)
+    path_result = _check_path_rate_limit(ip_address, path, redis_client, now, method=method)
     if path_result is not None:
         return path_result
 

--- a/src/django_waf/services/rule_engine.py
+++ b/src/django_waf/services/rule_engine.py
@@ -408,8 +408,9 @@ def evaluate_request(
             return _gate_challenge_or_escalate(ip_address, redis_client, block_eval_result, fingerprint_verdict)
         return block_eval_result
 
-    # Step 7: Rate limits
-    rate_result = check_rate_limit(ip_address, redis_client, path=path)
+    # Step 7: Rate limits. method threads BR-RATE-004's method scoping
+    # through to DJANGO_WAF_RATE_LIMIT_PATHS entries.
+    rate_result = check_rate_limit(ip_address, redis_client, path=path, method=method)
     if rate_result.exceeded:
         return EvaluationResult(
             verdict=Verdict.THROTTLED,

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -135,6 +135,12 @@ def _run_block_response_handler_check():
     return check_block_response_handler_importable(app_configs=None)
 
 
+def _run_rate_limit_paths_check():
+    from django_waf.checks import check_rate_limit_paths
+
+    return check_rate_limit_paths(app_configs=None)
+
+
 class TestChallengeDifficultyCheck:
     def test_recommended_defaults_produce_no_messages(self):
         import django_waf.conf as conf_mod
@@ -1301,3 +1307,113 @@ class TestManagePyCheckWithUnroutedChallengeUrls:
                 assert "django_waf.E007" in str(exc)
             else:
                 raise AssertionError("expected SystemCheckError from django_waf.E007")
+
+
+class TestRateLimitPathsCheck:
+    """django_waf.E009 (BR-RATE-004): errors when a
+    DJANGO_WAF_RATE_LIMIT_PATHS entry is malformed. Before this check
+    existed, a malformed entry raised deep in the per-request evaluation
+    path the first time a matching request arrived, swallowed by
+    evaluate_request's fail-open wrapper as a generic evaluation error
+    rather than surfaced to the operator.
+    """
+
+    def test_empty_dict_is_silent(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {}):
+            assert _run_rate_limit_paths_check() == []
+
+    def test_valid_two_item_entries_are_silent(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (10, 60), "/scan/": (5, 300)}):
+            assert _run_rate_limit_paths_check() == []
+
+    def test_valid_three_item_method_scoped_entry_is_silent(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/scan/": (5, 300, ("POST",))}):
+            assert _run_rate_limit_paths_check() == []
+
+    def test_wrong_length_tuple_errors(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (10,)}):
+            messages = _run_rate_limit_paths_check()
+
+        assert any(m.id == "django_waf.E009" for m in messages)
+
+    def test_non_tuple_value_errors(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": 10}):
+            messages = _run_rate_limit_paths_check()
+
+        assert any(m.id == "django_waf.E009" for m in messages)
+
+    def test_non_positive_max_requests_errors(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (0, 60)}):
+            messages = _run_rate_limit_paths_check()
+
+        assert any(m.id == "django_waf.E009" for m in messages)
+
+    def test_negative_window_seconds_errors(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (10, -60)}):
+            messages = _run_rate_limit_paths_check()
+
+        assert any(m.id == "django_waf.E009" for m in messages)
+
+    def test_non_int_max_requests_errors(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": ("ten", 60)}):
+            messages = _run_rate_limit_paths_check()
+
+        assert any(m.id == "django_waf.E009" for m in messages)
+
+    def test_empty_methods_collection_errors(self):
+        """An empty methods collection would silently disable the entry
+        rather than limiting all methods (the two-item form does that);
+        this is a shape error, not a permitted "match nothing"."""
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/scan/": (5, 300, ())}):
+            messages = _run_rate_limit_paths_check()
+
+        assert any(m.id == "django_waf.E009" for m in messages)
+
+    def test_methods_as_a_bare_string_errors(self):
+        """A common mistake: ``"POST"`` iterates as four single-character
+        strings ("P", "O", "S", "T"), not the intended method. Must be
+        rejected rather than silently misinterpreted."""
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/scan/": (5, 300, "POST")}):
+            messages = _run_rate_limit_paths_check()
+
+        assert any(m.id == "django_waf.E009" for m in messages)
+
+    def test_message_names_the_offending_prefix(self):
+        import django_waf.conf as conf_mod
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/broken/": (0, 60)}):
+            messages = _run_rate_limit_paths_check()
+
+        assert any("/broken/" in m.msg for m in messages)
+
+    def test_silent_when_waf_disabled(self):
+        """Rate limiting never runs while the WAF is disabled, so a
+        malformed entry behind it is latent, not a live misconfiguration
+        (mirrors django_waf.E001/E002's own gating)."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", False),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (0, -60)}),
+        ):
+            assert _run_rate_limit_paths_check() == []

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -486,6 +486,163 @@ class TestCheckRateLimitPerPath:
 
 
 # ---------------------------------------------------------------------------
+# check_rate_limit, method-scoped per-path limits (BR-RATE-004)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRateLimitMethodScoping:
+    """Tests for the three-item, method-scoped form of
+    DJANGO_WAF_RATE_LIMIT_PATHS: {prefix: (max_requests, window_seconds,
+    methods)}.
+    """
+
+    def test_two_item_entry_still_limits_every_method_unchanged(self):
+        """The pre-existing two-item form must keep limiting every method,
+        exactly as every prior release did: no silent behaviour change for
+        a widely deployed setting."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(11)  # over the limit of 10
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", {"/api/": (10, 60)}):
+            get_result = check_rate_limit("1.2.3.4", redis, path="/api/widgets/", method="GET")
+            post_result = check_rate_limit("1.2.3.4", redis, path="/api/widgets/", method="POST")
+            no_method_result = check_rate_limit("1.2.3.4", redis, path="/api/widgets/")
+
+        assert get_result.exceeded is True
+        assert post_result.exceeded is True
+        assert no_method_result.exceeded is True
+
+    def test_scoped_entry_limits_only_the_named_method(self):
+        """A three-item entry scoped to POST must not throttle a GET at the
+        same prefix."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(11)  # would breach if checked
+
+        rate_limit_paths = {"/scan/": (5, 300, ("POST",))}
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", rate_limit_paths),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_BURST", 1000),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_MINUTE", 1000),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_5MIN", 1000),
+        ):
+            get_result = check_rate_limit("1.2.3.4", redis, path="/scan/", method="GET")
+
+        # The GET never matched the scoped entry, so no path-level breach;
+        # falls through to the (deliberately generous) global windows.
+        assert get_result.exceeded is False
+
+    def test_scoped_entry_limits_the_named_method(self):
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(6)  # over the limit of 5
+
+        rate_limit_paths = {"/scan/": (5, 300, ("POST",))}
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", rate_limit_paths):
+            post_result = check_rate_limit("1.2.3.4", redis, path="/scan/", method="POST")
+
+        assert post_result.exceeded is True
+        assert post_result.window == "path"
+
+    def test_method_matching_is_case_insensitive(self):
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(6)
+
+        rate_limit_paths = {"/scan/": (5, 300, ("post",))}
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", rate_limit_paths):
+            result = check_rate_limit("1.2.3.4", redis, path="/scan/", method="POST")
+
+        assert result.exceeded is True
+
+    def test_no_method_supplied_does_not_match_a_scoped_entry(self):
+        """A caller with no method to offer (empty string, the default)
+        cannot match a method-scoped entry: matching would mean guessing
+        which method was meant."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(11)
+
+        rate_limit_paths = {"/scan/": (5, 300, ("POST",))}
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", rate_limit_paths),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_BURST", 1000),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_MINUTE", 1000),
+            patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PER_5MIN", 1000),
+        ):
+            result = check_rate_limit("1.2.3.4", redis, path="/scan/")
+
+        assert result.exceeded is False
+
+    def test_longer_scoped_prefix_falls_through_to_shorter_unscoped_prefix(self):
+        """Pins the resolution rule: a longer prefix that matches the path
+        but is method-scoped away for this request falls through to a
+        shorter, unscoped prefix rather than the request seeing no path
+        limit at all.
+        """
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(3)  # over the shorter limit of 2
+
+        rate_limit_paths = {
+            "/scan/": (2, 60),  # shorter, unscoped: covers every method
+            "/scan/submit/": (100, 60, ("POST",)),  # longer, scoped to POST only
+        }
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", rate_limit_paths):
+            get_result = check_rate_limit("1.2.3.4", redis, path="/scan/submit/", method="GET")
+
+        # The longer prefix matched the path but not the method, so
+        # evaluation fell through to the shorter, unscoped prefix, whose
+        # limit of 2 is breached by the mocked count of 3.
+        assert get_result.exceeded is True
+        assert get_result.window == "path"
+
+        import hashlib
+
+        expected_hash = hashlib.sha1(b"/scan/").hexdigest()[:12]
+        zadd_calls = redis.pipeline.return_value.zadd.call_args_list
+        used_keys = {c.args[0] for c in zadd_calls}
+        assert f"waf:rate:1.2.3.4:path:{expected_hash}" in used_keys
+
+    def test_longer_scoped_prefix_wins_when_method_matches(self):
+        """The same configuration as above, but with the method the longer
+        prefix scopes to: the longer, more specific prefix wins as usual."""
+        import django_waf.conf as conf_mod
+
+        redis = _make_redis()
+        redis.pipeline.return_value = _make_pipeline_mock(101)  # over the longer limit of 100
+
+        rate_limit_paths = {
+            "/scan/": (2, 60),
+            "/scan/submit/": (100, 60, ("POST",)),
+        }
+
+        with patch.object(conf_mod, "DJANGO_WAF_RATE_LIMIT_PATHS", rate_limit_paths):
+            post_result = check_rate_limit("1.2.3.4", redis, path="/scan/submit/", method="POST")
+
+        assert post_result.exceeded is True
+
+        import hashlib
+
+        expected_hash = hashlib.sha1(b"/scan/submit/").hexdigest()[:12]
+        zadd_calls = redis.pipeline.return_value.zadd.call_args_list
+        used_keys = {c.args[0] for c in zadd_calls}
+        assert f"waf:rate:1.2.3.4:path:{expected_hash}" in used_keys
+
+
+# ---------------------------------------------------------------------------
 # load_rule_cache
 # ---------------------------------------------------------------------------
 

--- a/tests/test_throttle_response_hook.py
+++ b/tests/test_throttle_response_hook.py
@@ -1,0 +1,429 @@
+"""Tests for DJANGO_WAF_THROTTLE_RESPONSE_HANDLER, the throttle-response hook.
+
+BR-EVAL-014. Mirrors ``test_block_response_hook.py`` (#74, BR-EVAL-012)
+exactly: a consumer needing a different throttle-response shape sets a
+dotted path here instead of subclassing ``WafMiddleware`` and overriding
+the private ``_handle_verdict``.
+
+Scope under test:
+
+- unset setting is byte-identical to the pre-hook behaviour, including the
+  existing Retry-After logic (accurate value when present, "60" fallback
+  otherwise);
+- a handler set by dotted path replaces the throttle response, and can read
+  ``result.retry_after`` (populated here, unlike the BLOCKED path);
+- all three failure modes (path will not import, handler raises, handler
+  returns a non-response) fall back to the built-in response and log at
+  ERROR rather than 500ing;
+- scope is THROTTLED only: BLOCKED and CHALLENGED verdicts ignore the
+  setting.
+
+The handlers live at module level in this file precisely so the tests can
+address them by a real dotted path (``tests.test_throttle_response_hook.X``)
+and exercise ``import_string`` for real, rather than patching it out.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.http import HttpResponse, HttpResponseNotFound
+from django.test import RequestFactory, override_settings
+
+# ---------------------------------------------------------------------------
+# Handlers addressed by dotted path from the tests below
+# ---------------------------------------------------------------------------
+
+CALLS: list[tuple] = []
+
+
+def working_handler(request, result):
+    """The documented happy path: return a consumer-shaped response that
+    reads the accurate retry_after off the result."""
+    CALLS.append((request, result))
+    response = HttpResponseNotFound(f"Slow down, retry in {result.retry_after}s.")
+    return response
+
+
+def raising_handler(request, result):
+    """A handler with a bug in it."""
+    CALLS.append((request, result))
+    raise RuntimeError("handler exploded")
+
+
+def non_response_handler(request, result):
+    """A handler returning the wrong type."""
+    CALLS.append((request, result))
+    return "<html>throttled</html>"
+
+
+@pytest.fixture(autouse=True)
+def _reset_calls():
+    CALLS.clear()
+    yield
+    CALLS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers (mirroring tests/test_block_response_hook.py's conventions)
+# ---------------------------------------------------------------------------
+
+
+def _make_result(verdict: str, **kwargs) -> MagicMock:
+    result = MagicMock()
+    result.verdict = verdict
+    result.matched_rule_id = None
+    result.matched_rule_type = ""
+    result.anomaly_score = None
+    result.action = None
+    result.retry_after = None
+    for key, value in kwargs.items():
+        setattr(result, key, value)
+    return result
+
+
+def _mock_redis():
+    redis = MagicMock()
+    redis.get.return_value = None
+    return redis
+
+
+def _run_throttled_request(retry_after=None):
+    """Drive a full THROTTLED request through the middleware and return the
+    response.
+
+    Goes through ``__call__`` rather than calling ``_build_throttle_response``
+    directly, so the test proves the hook is wired into the real request
+    path and not merely that a helper method works in isolation.
+    """
+    from django_waf.middleware import WafMiddleware
+
+    factory = RequestFactory()
+    request = factory.get("/page/")
+    request.user = MagicMock(is_authenticated=False)
+    request.COOKIES = {}
+    get_response = MagicMock(return_value=HttpResponse("view response"))
+
+    with (
+        patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+        patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+        patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+        patch("django_waf.middleware._emit_request_throttled"),
+    ):
+        mock_redis_fn.return_value = _mock_redis()
+        mock_validate.return_value = False
+        mock_eval.return_value = _make_result("throttled", retry_after=retry_after)
+
+        middleware = WafMiddleware(get_response)
+        response = middleware(request)
+
+    # The throttle must still be a throttle: the view is never reached,
+    # whichever branch of the hook ran. Without this every test below would
+    # pass if the hook accidentally failed the request open.
+    get_response.assert_not_called()
+    return response
+
+
+# ---------------------------------------------------------------------------
+# The default: unset setting is byte-identical to the pre-hook behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestUnsetHandlerIsUnchanged:
+    """With the setting unset the response is exactly what every release
+    before the hook returned: a 429 with the fixed body text and the
+    existing Retry-After logic.
+    """
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_default_is_429_with_fixed_body(self):
+        response = _run_throttled_request(retry_after=None)
+
+        assert response.status_code == 429
+        assert response.content == b"Too many requests. Please retry later."
+
+    @override_settings(DJANGO_WAF_ENABLED=True, DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="")
+    def test_empty_string_handler_is_the_same_as_unset(self):
+        response = _run_throttled_request(retry_after=None)
+
+        assert response.status_code == 429
+        assert response.content == b"Too many requests. Please retry later."
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_no_handler_is_ever_called_when_unset(self):
+        _run_throttled_request(retry_after=None)
+
+        assert CALLS == []
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_default_retry_after_uses_accurate_value_when_present(self):
+        """Retry-After logic must survive the refactor untouched: an
+        accurate result.retry_after value is sent, not the 60s fallback."""
+        response = _run_throttled_request(retry_after=23)
+
+        assert response["Retry-After"] == "23"
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_default_retry_after_falls_back_to_60_when_absent(self):
+        response = _run_throttled_request(retry_after=None)
+
+        assert response["Retry-After"] == "60"
+
+
+# ---------------------------------------------------------------------------
+# A configured handler replaces the throttle response
+# ---------------------------------------------------------------------------
+
+
+class TestConfiguredHandler:
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.working_handler",
+    )
+    def test_handler_response_replaces_the_default(self):
+        response = _run_throttled_request(retry_after=42)
+
+        assert response.status_code == 404
+        assert response.content == b"Slow down, retry in 42s."
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.working_handler",
+    )
+    def test_handler_receives_the_request_and_the_evaluation_result(self):
+        """The documented signature is ``(request, result)``, and
+        result.retry_after is populated here (unlike the BLOCKED path)."""
+        _run_throttled_request(retry_after=15)
+
+        assert len(CALLS) == 1
+        request, result = CALLS[0]
+        assert request.path == "/page/"
+        assert result.verdict == "throttled"
+        assert result.retry_after == 15
+
+    @override_settings(DJANGO_WAF_ENABLED=True)
+    def test_setting_is_read_at_call_time_not_import_time(self):
+        """Two requests in one process, differing only by an
+        ``override_settings`` block, must get different responses."""
+        default_response = _run_throttled_request(retry_after=None)
+        assert default_response.status_code == 429
+
+        with override_settings(
+            DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.working_handler",
+        ):
+            hooked_response = _run_throttled_request(retry_after=5)
+
+        assert hooked_response.status_code == 404
+
+        after_response = _run_throttled_request(retry_after=None)
+        assert after_response.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# Failure modes: never 500, always fall back, always log distinctly
+# ---------------------------------------------------------------------------
+
+
+class TestHandlerFailureFallsBack:
+    """A misconfigured hook must not break a request, and must not turn a
+    throttle into a pass either.
+
+    Every case asserts three things: the built-in response comes back
+    byte-identical, an ERROR is logged naming the dotted path so the
+    operator can find it, and no exception escapes the middleware.
+    """
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.does_not_exist",
+    )
+    def test_unimportable_path_falls_back_and_logs(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_throttled_request(retry_after=None)
+
+        assert response.status_code == 429
+        assert response.content == b"Too many requests. Please retry later."
+        assert any("could not be imported" in message for message in caplog.messages)
+        assert any("does_not_exist" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.no_such_module_at_all.handler",
+    )
+    def test_unimportable_module_falls_back_and_logs(self, caplog):
+        """A missing module, not just a missing attribute."""
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_throttled_request(retry_after=None)
+
+        assert response.status_code == 429
+        assert response.content == b"Too many requests. Please retry later."
+        assert any("could not be imported" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.throttle_handler_import_boom.handler",
+    )
+    def test_module_raising_a_non_importerror_on_import_falls_back(self, caplog):
+        """The import guard is deliberately broader than ``ImportError``,
+        mirroring the block-response hook. This test fails against a narrow
+        ``except ImportError``.
+        """
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_throttled_request(retry_after=None)
+
+        assert response.status_code == 429
+        assert response.content == b"Too many requests. Please retry later."
+        assert any("could not be imported" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.raising_handler",
+    )
+    def test_raising_handler_falls_back_and_logs(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_throttled_request(retry_after=None)
+
+        assert response.status_code == 429
+        assert response.content == b"Too many requests. Please retry later."
+        assert len(CALLS) == 1
+        assert any("raised" in message for message in caplog.messages)
+        assert any("raising_handler" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.raising_handler",
+    )
+    def test_raising_handler_does_not_propagate(self):
+        response = _run_throttled_request(retry_after=None)
+
+        assert response.status_code == 429
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.non_response_handler",
+    )
+    def test_non_response_return_falls_back_and_logs(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            response = _run_throttled_request(retry_after=None)
+
+        assert response.status_code == 429
+        assert response.content == b"Too many requests. Please retry later."
+        assert len(CALLS) == 1
+        assert any("not an HttpResponse" in message for message in caplog.messages)
+        assert any("str" in message for message in caplog.messages)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.raising_handler",
+    )
+    def test_failure_classifications_are_distinct(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="django_waf.middleware"):
+            _run_throttled_request(retry_after=None)
+        raised_messages = list(caplog.messages)
+
+        caplog.clear()
+        CALLS.clear()
+
+        with (
+            override_settings(
+                DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.does_not_exist",
+            ),
+            caplog.at_level(logging.ERROR, logger="django_waf.middleware"),
+        ):
+            _run_throttled_request(retry_after=None)
+        import_messages = list(caplog.messages)
+
+        assert not any("could not be imported" in message for message in raised_messages)
+        assert not any("raised" in message for message in import_messages)
+
+
+# ---------------------------------------------------------------------------
+# Scope: THROTTLED only
+# ---------------------------------------------------------------------------
+
+
+class TestHookScope:
+    """The hook covers THROTTLED verdicts only.
+
+    Without these, a later change that routed BLOCKED or CHALLENGED through
+    the hook would go unnoticed, and a consumer's throttle-shaped handler
+    would start answering blocks.
+    """
+
+    def _run_with_verdict(self, verdict: str, **result_kwargs):
+        from django_waf.middleware import WafMiddleware
+
+        factory = RequestFactory()
+        request = factory.get("/page/")
+        request.user = MagicMock(is_authenticated=False)
+        request.COOKIES = {}
+        get_response = MagicMock(return_value=HttpResponse("view response"))
+
+        with (
+            patch("django_waf.middleware._get_redis_client") as mock_redis_fn,
+            patch("django_waf.services.challenge_service.validate_pass_cookie") as mock_validate,
+            patch("django_waf.services.rule_engine.evaluate_request") as mock_eval,
+            patch("django_waf.middleware._emit_request_blocked"),
+            patch("django_waf.middleware._emit_request_throttled"),
+        ):
+            mock_redis_fn.return_value = _mock_redis()
+            mock_validate.return_value = False
+            mock_eval.return_value = _make_result(verdict, **result_kwargs)
+
+            middleware = WafMiddleware(get_response)
+            return middleware(request)
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.working_handler",
+    )
+    def test_blocked_verdict_ignores_the_handler(self):
+        response = self._run_with_verdict("blocked", retry_after=None)
+
+        assert response.status_code == 403
+        assert CALLS == []
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.working_handler",
+    )
+    def test_challenged_verdict_ignores_the_handler(self):
+        response = self._run_with_verdict("challenged")
+
+        assert response.status_code == 302
+        assert CALLS == []
+
+    @override_settings(
+        DJANGO_WAF_ENABLED=True,
+        DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="tests.test_throttle_response_hook.working_handler",
+    )
+    def test_throttled_verdict_is_the_positive_control(self):
+        """Pins the two absence assertions above.
+
+        Without this the handler could be dead entirely (a broken setting
+        name, an unwired branch) and both would still pass.
+        """
+        response = self._run_with_verdict("throttled", retry_after=9)
+
+        assert response.status_code == 404
+        assert len(CALLS) == 1
+
+
+# ---------------------------------------------------------------------------
+# The setting itself
+# ---------------------------------------------------------------------------
+
+
+class TestSettingDefault:
+    def test_default_is_empty_string(self):
+        from django_waf import conf
+
+        assert conf.DJANGO_WAF_THROTTLE_RESPONSE_HANDLER == ""
+
+    @override_settings(DJANGO_WAF_THROTTLE_RESPONSE_HANDLER="some.dotted.path")
+    def test_override_settings_is_visible_to_conf(self):
+        from django_waf import conf
+
+        assert conf.DJANGO_WAF_THROTTLE_RESPONSE_HANDLER == "some.dotted.path"


### PR DESCRIPTION
Two related additions, both driven by a live defect on a consuming site: an
unstyled plain-text 429 served on a public acquisition page, and that page
consuming a rate-limit budget meant for form submissions.

## A replaceable throttle response (BR-EVAL-014)

`DJANGO_WAF_THROTTLE_RESPONSE_HANDLER` takes a dotted path to
`handler(request, result) -> HttpResponse`, mirroring
`DJANGO_WAF_BLOCK_RESPONSE_HANDLER` (#74) method for method: the same
named-default-response pattern, the same three-stage fallback ladder (the path
will not import, the handler raises, the handler returns a non-`HttpResponse`),
each logged distinctly at ERROR, and call-time resolution so `override_settings`
works.

Unset, the response is byte for byte what every prior release returned,
including the existing `Retry-After` logic (the accurate `result.retry_after`
when present, the fixed `"60"` otherwise, per #30).

Unlike the BLOCKED path, `result.retry_after` IS populated here, so a handler
can tell the visitor how long to wait. Scope is THROTTLED only; BLOCKED and
CHALLENGED keep their own responses.

If you subclass `WafMiddleware` and override the private `_handle_verdict`, you
will not pick this up. Nothing breaks, but the setting is not honoured until you
rebase onto the new `_handle_verdict` or call `self._build_throttle_response(request, result)`
where you currently build the 429.

## Method-aware rate-limit paths (BR-RATE-004)

`DJANGO_WAF_RATE_LIMIT_PATHS` entries accept an opt-in third element:
`(max_requests, window_seconds, methods)`, where `methods` is an iterable of
HTTP method strings matched case-insensitively. The two-item form is unchanged
and still limits every method.

The need: prefix matching alone cannot express "the submit POST but not the
landing GET" when a Django view serves both at one URL, which is the common
shape for a form page. Without this, ordinary page views spend a budget sized
for submissions and lock real visitors out.

`services/rule_engine.py`'s `evaluate_request` already took a `method`
argument and never used it. It now forwards it to `check_rate_limit`, which
was the actual plumbing gap behind the defect.

Resolution rule: longest-prefix-first, but a prefix whose method scope excludes
the request falls through to the next-longest matching prefix rather than
stopping. Stopping would let one scoped rule silently disable rate limiting for
every other method at that URL. A three-item entry never matches an unknown
method rather than guessing which the caller meant.

`django_waf.E009` refuses a malformed entry at boot, gated on
`DJANGO_WAF_ENABLED` like E001/E002.

## Verification

Full CI leg set, run through a venv on this repo's exact pins (Django 6.1.1,
mypy 2.3.1, django-stubs 6.1.0, ruff 0.15.22):

- pytest (Django 6.1): 1455 passed, 6 skipped, 93.72% coverage
- test-postgres: 1453 passed, 8 skipped, real PostgreSQL 16
- test-redis-integration: 6 passed, against the CI-pinned `redis:6.0-alpine`
- ruff check and ruff format --check: clean, 157 files
- mypy: success, 90 source files

Pinned by tests: the default 429 byte-identical on both `Retry-After` branches;
all three handler fallback modes; the handler never called for BLOCKED or
CHALLENGED; two-item entries still limiting every method; method scoping and
case-insensitive matching; the fall-through resolution rule; E009 firing and
staying silent when the WAF is disabled.

Spec updated in the umbrella (BR-EVAL-014, BR-RATE-004, AC-EVAL-022/023,
AC-RATE-004, the E009 and W010 check rows). No version bump here; a release
step owns that.