### PR TITLE
chore(release): 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.7.0] - 2026-09-03
 ### Added
 
 - **Method-aware `DJANGO_WAF_RATE_LIMIT_PATHS`** (BR-RATE-004).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.6.0"
+version = "2.7.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

Releases 2.7.0: two additive, backwards-compatible features already merged to main.

- Method-aware `DJANGO_WAF_RATE_LIMIT_PATHS` (BR-RATE-004): an optional third tuple element scopes a rate-limit entry to specific HTTP methods. The existing two-item form is unchanged.
- A replaceable throttle response (BR-EVAL-014): `DJANGO_WAF_THROTTLE_RESPONSE_HANDLER`, mirroring the existing block-response hook. Unset behaviour is byte-identical to every prior release.

No removals, no breaking changes to any public surface. Minor version bump per RELEASING.md.

## Changes in this PR

- `pyproject.toml`: version 2.6.0 -> 2.7.0
- `CHANGELOG.md`: rename `[Unreleased]` to `[2.7.0] - 2026-09-03`

`src/django_waf/__init__.py` resolves `__version__` from installed package metadata at runtime, so there is no second literal to bump.

## Test plan

- [x] CI green on `8e1168c` (the commit this branch is based on): full Python 3.11-3.13 x Django 5.2/6.0/6.1 matrix, real PostgreSQL 16, real Redis 6.0 integration, lint, mypy
- [ ] CI green again on this PR's own commit
- [ ] Publish-gate simulation (clean venv, `publish.yml`'s install list) before tagging
- [ ] Artefact verification (wheel contents, twine check, clean-venv import) before and after publish