### PR TITLE
fix(anomaly): resolve AllowRules at the counting stage for scraper 404 ratio (#140, #135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,73 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+
+- `scripts/check_br_citations.py`: a guard that extracts every `BR-XXX-NNN`
+  business-rule citation from `src/` and fails if any names a rule id not
+  defined in the umbrella spec (`docs/specs/django-waf/`). Guards against a
+  citation reading as a guarantee that behaviour is specified when it is
+  not, the defect class behind `BR-UA-002`, `BR-UA-004` and `BR-TEL-004`
+  (#133). It asserts a known-present rule id, a known-present citation and
+  a matching heading before trusting any absence, and exits non-zero if
+  either side comes back empty, so a missing umbrella checkout fails loudly
+  instead of reporting zero dangling citations as a pass. Run it manually
+  or from a pre-push hook: `python3 scripts/check_br_citations.py`. It is
+  not yet wired into CI, because the umbrella spec lives in a separate
+  private repository that the default CI token cannot read; see #142.
+
+### Fixed
+
+- **`detect_scraper_404_ratio` auto-challenged a verified Bingbot crawler
+  in production** (#140, #135, BR-ANOM-014).
+
+  The detector's base filter counts rows with `verdict` in `(allowed,
+  logged)` and deliberately excludes `verdict=passed` (an AllowRule match,
+  e.g. a verified crawler), but applies no `source` filter. A nginx-sourced
+  `RequestLog` row (written by `tasks.parse_access_log` for every request
+  the access log records, including exempt-path requests the middleware
+  itself never sees) has its verdict INFERRED from the HTTP status code,
+  never observed by `rule_engine.evaluate_request`, so it can never be
+  `verdict=passed` no matter how the client is actually vetted. For a
+  published Bingbot `/24`, 52,165 middleware rows were correctly excluded
+  as `passed`, while 2,828 nginx rows at 78.9% 404 were inferred as
+  `verdict=allowed` and counted. In 24 hours the detector auto-created 70
+  rules, 34 of them covering Bingbot ranges, staged at `CHALLENGE`
+  (`BLOCK` with `DJANGO_WAF_SCRAPER_404_ACTION_BLOCK=True`).
+
+  **Fix**: AllowRules are now resolved a second time, at the counting
+  stage, for any IP that has already cleared both the `min_requests` floor
+  and the `ratio_floor` gate, regardless of which `source` its rows carry.
+  A qualifying IP whose observed User-Agent(s) match an active AllowRule
+  (including one requiring forward-confirmed reverse DNS) is excluded
+  entirely: no rule is created, no signal is emitted. The rule cache is
+  loaded once per detector run, not once per IP, and the User-Agents an IP
+  presented in the window are fetched in a single query for every
+  qualifying IP, not one query per IP.
+
+  **Fails closed.** If the AllowRule check cannot be evaluated for any
+  reason (no Redis client available, the rule cache fails to load, or the
+  matcher itself raises), every qualifying IP in that run is treated as
+  excluded rather than flagged, and a warning is logged naming why. A
+  detector whose one exoneration path is unavailable must never flag on
+  the strength of a check it could not actually run.
+
+  **`source=middleware` filtering was considered and rejected.** Restricting
+  this detector's base query the way `detect_unsolved_challenges` restricts
+  its own (source=middleware, #32) was the obvious first fix, and is wrong
+  for this detector specifically: `middleware.py`'s exempt-path
+  short-circuit (BR-EVAL-001) returns before any `RequestLog` row is
+  written, so a request to an exempt path exists ONLY as a nginx row, and
+  that is exactly where a scanner probes. Filtering to `source=middleware`
+  would have cut this detector's input to roughly 2% of what it receives
+  today and made it blind to exempt-path traffic entirely. Evaluating
+  AllowRules inside `parse_access_log` itself was also considered and
+  rejected: the wrong layer (a log-ingestion task should not carry
+  WAF rule-evaluation cost) against the wrong volume (every ingested row,
+  roughly 194,000 per run, rather than only the handful of detector
+  candidates).
+
 ## [2.7.0] - 2026-09-03
 ### Added
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,86 @@
+# scripts/
+
+## check_br_citations.py
+
+Guards against a specific defect class: source code cites a `BR-XXX-NNN`
+business-rule id as the authority for its behaviour, and the rule does not
+actually exist in the spec. See issue #133 for the full history: two
+confirmed occurrences (`BR-UA-002`, `BR-UA-004`) went unnoticed until
+someone happened to change the code they governed and found there was no
+spec text to amend, and a third (`BR-TEL-004`, should have been
+`BR-TEL-003`) was found independently by a different session. Neither was
+caught by a check.
+
+### What it checks
+
+Extracts every `BR-[A-Z]+-\d+[a-z]?` citation from every file under `src/`
+(the lowercase suffix, e.g. `BR-ANOM-002b`, is a real pattern in this
+spec, not test noise) and asserts each one is defined by a matching
+`### BR-...` heading in the umbrella spec at `docs/specs/django-waf/*.md`.
+Any citation with no matching rule (a "dangling" citation) fails the
+guard.
+
+### Why the controls exist
+
+The citations live in this repo; the rules live in a separate umbrella
+repo. That split makes the check falsifiable in two symmetric,
+opposite-looking ways, and a run that hits either one silently is worse
+than no check at all:
+
+- If the **spec side** returns nothing (wrong path, umbrella checkout
+  absent, empty directory), every citation looks dangling and the guard
+  fails, but for the wrong reason: not because the code is wrong, but
+  because the check could not see the spec. This happened for real: a
+  session ran an ad hoc check from inside this repo, the spec-side lookup
+  silently returned zero rules, and it reported "63 dangling rules",
+  which was completely wrong.
+- If the **citation side** returns nothing (wrong path, empty src,
+  extraction pattern stopped matching), zero dangling citations are
+  reported and the guard passes, having checked nothing at all.
+
+Both failure modes are unfalsifiable without a control: a check that
+cannot tell "there is genuinely nothing wrong" from "I could not see
+anything" is not evidence either way. So before this script trusts any
+absence, it asserts:
+
+- at least one rule id known to exist in the spec (three are checked,
+  including a suffixed one, since a regex that silently dropped the
+  suffix would otherwise under-match without anything noticing),
+- at least one citation known to exist in `src/`,
+- that the heading regex matched at least one `### BR-...` heading.
+
+If any control fails, the script exits non-zero with a message naming
+which control failed and why the result below it cannot be trusted. A
+control failure is never allowed to read as a pass, and the default CLI
+behaviour requires a real, non-empty spec directory: `--allow-missing-spec`
+exists for local convenience only and is never the default.
+
+### Running it locally
+
+From a checkout where the umbrella repo is cloned as a sibling of
+`public/` (the normal layout, `~/Projects/oss/public/django-waf` next to
+`~/Projects/oss/docs/specs/django-waf`), no arguments are needed:
+
+```sh
+python3 scripts/check_br_citations.py
+```
+
+To point at a different umbrella checkout, pass `--spec-dir` or set
+`DJANGO_WAF_SPEC_DIR`:
+
+```sh
+python3 scripts/check_br_citations.py --spec-dir /path/to/icv-oss-umbrella/docs/specs/django-waf
+DJANGO_WAF_SPEC_DIR=/path/to/icv-oss-umbrella/docs/specs/django-waf python3 scripts/check_br_citations.py
+```
+
+`--src` overrides which directory is scanned for citations (default
+`src`). Both flags accept relative or absolute paths.
+
+Standard library only, no dependencies. Python 3.
+
+### Exit codes
+
+- `0`: every citation resolved to a spec rule, and all controls passed.
+- `1`: a dangling citation was found, a control failed, or the spec
+  directory was missing or empty (and `--allow-missing-spec` was not
+  passed).

--- a/scripts/check_br_citations.py
+++ b/scripts/check_br_citations.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Guard: every BR- rule id cited in src/ must be defined in the spec.
+
+See scripts/README.md for the incident this guards against, the control
+design, and how to run it locally.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+CITATION_PATTERN = re.compile(r"BR-[A-Z]+-\d+[a-z]?")
+HEADING_PATTERN = re.compile(r"(?m)^### (BR-[A-Z]+-\d+[a-z]?)\b")
+
+# Directory names to skip when walking src/. Not expected to exist on a
+# fresh checkout, but a dirty runner or local working tree can carry them.
+# Build artefacts are excluded by suffix rather than by exact name because
+# the generated directory is named after the distribution: this repo
+# produces src/django_waf.egg-info/, which is gitignored (.gitignore line
+# 3) and untracked. Reading it is not merely redundant, it makes the
+# guard's own result depend on whether anyone has run an editable install
+# locally: PKG-INFO embeds the README, so the settings table's
+# BR-EVAL-012 reference appeared as a 67th citation on a built tree and
+# not at all on a clean one. A guard whose counts move with local build
+# state cannot be used to tell a real citation from a stale one.
+EXCLUDED_DIR_NAMES = {"__pycache__", ".git"}
+EXCLUDED_DIR_SUFFIXES = (".egg-info", ".dist-info")
+
+# Known-present items asserted before any absence is trusted (issue #133).
+# A rule id known to exist on the spec side, including one with the
+# lowercase suffix, since a regex that drops the suffix would silently
+# under-match without this control catching it.
+CONTROL_RULE_IDS = ("BR-UA-002", "BR-EVAL-001", "BR-ANOM-002b")
+# A citation known to exist on the source side.
+CONTROL_CITATION = "BR-UA-002"
+
+DEFAULT_SPEC_DIR = Path(__file__).resolve().parent.parent.parent.parent / "docs" / "specs" / "django-waf"
+
+
+class GuardError(Exception):
+    """Raised for any condition that must fail the guard, control or real."""
+
+
+def iter_src_files(src_dir: Path):
+    for root, dirnames, filenames in os.walk(src_dir):
+        dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIR_NAMES and not d.endswith(EXCLUDED_DIR_SUFFIXES)]
+        for filename in filenames:
+            yield Path(root) / filename
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="strict")
+
+
+def collect_citations(src_dir: Path) -> set[str]:
+    if not src_dir.is_dir():
+        raise GuardError(f"src directory does not exist: {src_dir}")
+    citations: set[str] = set()
+    for path in iter_src_files(src_dir):
+        try:
+            text = read_text(path)
+        except UnicodeDecodeError as exc:
+            # Every file under src/ is text at the time of writing; a binary
+            # file appearing later is not silently skipped.
+            raise GuardError(f"could not read {path} as UTF-8 text") from exc
+        citations |= set(CITATION_PATTERN.findall(text))
+    return citations
+
+
+def collect_rules_and_headings(spec_dir: Path) -> tuple[set[str], set[str]]:
+    rules: set[str] = set()
+    headings: set[str] = set()
+    for path in sorted(spec_dir.glob("*.md")):
+        text = read_text(path)
+        rules |= set(CITATION_PATTERN.findall(text))
+        headings |= set(HEADING_PATTERN.findall(text))
+    return rules, headings
+
+
+def resolve_spec_commit(spec_dir: Path) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(spec_dir), "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def run_controls(citations: set[str], rules: set[str], headings: set[str]) -> None:
+    """Assert known-present items on both sides before trusting any absence.
+
+    Both failure directions matter equally (issue #133): if the spec side
+    silently returns nothing, every citation reports as dangling; if the
+    citation side silently returns nothing, the guard passes having checked
+    nothing. Either must error, never pass quietly.
+    """
+    for rule_id in CONTROL_RULE_IDS:
+        if rule_id not in rules:
+            raise GuardError(
+                f"control failed: {rule_id} not found on the spec side. "
+                "The spec directory is missing, empty, or unreadable: "
+                "treat every 'dangling' result below as untrustworthy."
+            )
+    if CONTROL_CITATION not in citations:
+        raise GuardError(
+            "control failed: citation side empty (expected "
+            f"{CONTROL_CITATION} in src/). The src directory is missing, "
+            "empty, or the extraction pattern stopped matching: a zero "
+            "dangling result below would be a vacuous pass, not a real one."
+        )
+    if not headings:
+        raise GuardError(
+            "control failed: the heading regex matched no '### BR-...' "
+            "headings in the spec. Either the spec files are missing "
+            "their expected heading format, or the spec directory is wrong."
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--src",
+        type=Path,
+        default=Path("src"),
+        help="Path to the src/ directory to scan for BR- citations (default: src)",
+    )
+    parser.add_argument(
+        "--spec-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Path to the umbrella spec directory (docs/specs/django-waf). "
+            "Falls back to $DJANGO_WAF_SPEC_DIR, then the local default "
+            "'../../docs/specs/django-waf' relative to this repo."
+        ),
+    )
+    require_group = parser.add_mutually_exclusive_group()
+    require_group.add_argument(
+        "--require-spec",
+        dest="require_spec",
+        action="store_true",
+        default=True,
+        help="Fail if the spec directory is missing or empty (default).",
+    )
+    require_group.add_argument(
+        "--allow-missing-spec",
+        dest="require_spec",
+        action="store_false",
+        help=(
+            "Exit 0 without checking if the spec directory is missing. "
+            "NOT for CI use: this is exactly the vacuous-pass failure "
+            "issue #133 was filed about. For local use only, when the "
+            "umbrella checkout is deliberately absent."
+        ),
+    )
+    args = parser.parse_args()
+
+    spec_dir = args.spec_dir or (
+        Path(os.environ["DJANGO_WAF_SPEC_DIR"]) if "DJANGO_WAF_SPEC_DIR" in os.environ else DEFAULT_SPEC_DIR
+    )
+    spec_dir = spec_dir.resolve()
+    src_dir = args.src.resolve()
+
+    spec_files = sorted(spec_dir.glob("*.md")) if spec_dir.is_dir() else []
+
+    if not spec_files:
+        message = (
+            f"spec directory has no spec files: {spec_dir}\n"
+            "The umbrella checkout (docs/specs/django-waf) is absent, "
+            "empty, or the path is wrong. This is precisely the "
+            "vacuous-pass failure issue #133 was filed about: a check "
+            "that cannot see the spec must not report zero dangling "
+            "citations as if it had verified anything."
+        )
+        if args.require_spec:
+            print(f"FAIL: {message}", file=sys.stderr)
+            return 1
+        print(f"SKIP (--allow-missing-spec): {message}")
+        return 0
+
+    try:
+        citations = collect_citations(src_dir)
+        rules, headings = collect_rules_and_headings(spec_dir)
+        run_controls(citations, rules, headings)
+    except GuardError as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    commit = resolve_spec_commit(spec_dir)
+    print(f"spec dir: {spec_dir}" + (f" @ {commit}" if commit else ""))
+    print(f"src dir:  {src_dir}")
+    print("controls OK (known-present rule ids incl. suffixed id, known-present citation, heading pattern)")
+    print(
+        f"citations={len(citations)} rules={len(rules)} headings={len(headings)} "
+        f"reconcile={len(rules) == len(headings)}"
+    )
+
+    dangling = sorted(citations - rules)
+    print("dangling:", dangling or "NONE")
+
+    mentioned_no_heading = sorted(rules - headings)
+    print("mentioned but no heading:", mentioned_no_heading or "none")
+
+    if dangling:
+        print(
+            f"FAIL: {len(dangling)} citation(s) reference rule ids not defined in the spec (see 'dangling' above).",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("PASS: every BR- citation in src/ is defined in the spec.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -463,6 +463,17 @@ def detect_unsolved_challenges(
     # request middleware already logged, so counting both would double the
     # apparent challenged_count for every IP and distort this detector's
     # threshold checks.
+    #
+    # This is the opposite answer to detect_scraper_404_ratio's deliberate
+    # decision NOT to filter by source (#140, #135; see that detector's
+    # docstring): same field, different reason. CHALLENGED is a verdict
+    # rule_engine.evaluate_request actually produces, so a nginx row and a
+    # middleware row can both describe the identical request, and counting
+    # both here would double-count it. detect_scraper_404_ratio counts
+    # application 404s, which a nginx row observes independently (and, for
+    # an exempt path, exclusively, since the middleware never runs there),
+    # so there is no double-counting risk to filter away, and filtering it
+    # anyway would blind that detector to exempt-path scanner traffic.
     challenged_by_ip = list(
         RequestLog.objects.filter(
             timestamp__gte=cutoff,
@@ -1060,6 +1071,52 @@ def detect_scraper_404_ratio(
     step 4, ahead of every BlockRule and every scoring path, applied here
     at the counting stage rather than left to downstream staging alone.
 
+    Nginx-sourced rows (``RequestLog.source=RequestLogSource.NGINX_LOG``,
+    written by ``tasks.parse_access_log``) ARE deliberately counted
+    alongside middleware-sourced rows, with no ``source`` filter anywhere in
+    this detector, and this is load-bearing, not an oversight (#140, #135).
+    ``middleware.py``'s exempt-path short-circuit (BR-EVAL-001) returns
+    before a ``RequestLog`` row is ever written, so a request to an exempt
+    path exists ONLY as a nginx row; scanner probes frequently target
+    exactly those paths, and dropping nginx rows here would make this
+    detector blind to them. Restricting to ``source=middleware`` was
+    considered and rejected: traced against the production incident below,
+    it would have cut this detector's input to roughly 2% of what it
+    receives today.
+
+    The cost of counting nginx rows is that a nginx row's verdict is
+    INFERRED from the access-log status code
+    (``tasks._infer_verdict_from_status``), not observed by
+    ``rule_engine.evaluate_request``, so it can never be ``Verdict.PASSED``:
+    an inferred verdict has no way to carry an AllowRule match. A verified
+    crawler whose traffic is logged only via nginx (or whose nginx rows
+    simply outnumber its middleware rows) therefore cannot be excluded by
+    the ``reached_app`` filter above, no matter how it is worded, because
+    the exclusion that filter relies on (``Verdict.PASSED``) never appears
+    on those rows in the first place.
+
+    This is exactly what happened in production (#140): a published Bingbot
+    /24 produced 52,165 middleware rows, correctly excluded as
+    ``verdict=passed``, and 2,828 nginx rows at 78.9% 404, inferred as
+    ``verdict=allowed`` (the default inferred verdict for a non-403/429/
+    challenge-redirect status) and therefore counted. This detector created
+    70 rules in 24 hours, 34 of them covering Bingbot ranges, auto-
+    challenging a verified search crawler in a real deployment.
+
+    The fix (#140, #135) is to resolve AllowRules a second time, at the
+    counting stage, for any candidate IP that has already cleared both the
+    ``min_requests`` floor and the ``ratio_floor`` gate below, regardless of
+    which ``source`` its rows carry: see the AllowRule-exclusion block
+    inside the candidate loop. This keeps nginx rows counted (preserving
+    exempt-path visibility) while restoring the same "a verified crawler is
+    never flagged" guarantee the ``Verdict.PASSED`` exclusion already gives
+    middleware-sourced rows, without evaluating AllowRules for all ~194,000
+    rows in a typical window (only for the handful of IPs that already
+    look like scrapers). Rejected as an alternative: evaluating AllowRules
+    inside ``tasks.parse_access_log`` itself, which is the wrong layer (a
+    log-ingestion task should not carry WAF rule-evaluation cost) and the
+    wrong cost shape (every ingested row, not just detector candidates).
+
     Excluding ``passed`` does more than protect a legitimate crawler from
     this detector's own count: it is what lets the detector *distinguish*
     a real verified crawler from an impostor presenting the identical UA
@@ -1159,17 +1216,108 @@ def detect_scraper_404_ratio(
         .filter(total__gte=min_requests)
     )
 
-    created_rules = []
-    expiry = timezone.now() + timedelta(hours=conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS)
-
+    # The ratio gate itself stays exactly as it was (see the comment above):
+    # applied here, in Python, on the already-fetched integer counts. Only
+    # rows that clear BOTH gates are candidates for rule creation, so
+    # everything from here on (the AllowRule exclusion check below, in
+    # particular) is sized to "how many IPs actually look like scrapers",
+    # never to the full candidate set above.
+    qualifying_rows = []
     for row in candidates:
         total = row["total"]
         count_404 = row["count_404"]
         ratio = count_404 / total
         if ratio < ratio_floor:
             continue
+        qualifying_rows.append((row["ip_address"], total, count_404, ratio))
 
-        ip = row["ip_address"]
+    # AllowRule exclusion (#140, #135), resolved here at the counting stage
+    # rather than relied upon from RequestLog.verdict. Built once, outside
+    # the loop below, for two reasons: _check_allow_rules needs a RuleCache
+    # (loaded from Redis, or rebuilt from the DB on a cache miss) and this
+    # detector only ever needs ONE snapshot of the active rule set for a
+    # single run, and a per-IP cache load would turn what is normally a
+    # single Redis GET into one GET per qualifying IP for no benefit.
+    #
+    # Fails CLOSED, not open: if the AllowRule check cannot be evaluated at
+    # all (no Redis client available, or the cache fails to load), every
+    # qualifying IP in this run is treated as excluded rather than flagged.
+    # A 404-ratio anomaly is a coarse behavioural signal, not proof of
+    # malice (see the Action staging note below); flagging it anyway when
+    # the one check that could exonerate a verified crawler is unavailable
+    # would silently reopen the exact production incident (#140) this fix
+    # exists to close, on every Redis hiccup. allow_check_available is
+    # threaded through explicitly, rather than leaving cache=None to mean
+    # "no rules matched", because an empty RuleCache and an unavailable one
+    # must NOT be handled the same way: an empty cache correctly excludes
+    # nobody, an unavailable one must exclude everybody in this run.
+    allow_check_available = True
+    cache = None
+    redis_client_for_run = None
+    if qualifying_rows:
+        from django_waf.services.redis_client import get_redis_client
+        from django_waf.services.rule_engine import load_rule_cache
+
+        redis_client_for_run = get_redis_client()
+        if redis_client_for_run is None:
+            allow_check_available = False
+            logger.warning(
+                "django-waf: detect_scraper_404_ratio could not obtain a Redis "
+                "client; skipping AllowRule verification and treating every "
+                "qualifying IP this run as excluded (fail-closed, #140)."
+            )
+        else:
+            try:
+                cache = load_rule_cache(redis_client_for_run)
+            except Exception:
+                allow_check_available = False
+                logger.warning(
+                    "django-waf: detect_scraper_404_ratio failed to load the "
+                    "rule cache; skipping AllowRule verification and treating "
+                    "every qualifying IP this run as excluded (fail-closed, #140).",
+                    exc_info=True,
+                )
+
+    # Distinct User-Agents observed per qualifying IP within the same
+    # window, fetched in ONE query for every qualifying IP rather than one
+    # query per IP. _check_allow_rules needs a user_agent argument (a
+    # UA-typed AllowRule, e.g. the seeded Googlebot rule, matches on it),
+    # and a candidate IP can carry more than one distinct UA across its
+    # rows. The rule applied below is fail-safe toward NOT flagging: if ANY
+    # user agent observed for an IP in this window matches an AllowRule,
+    # the whole IP is excluded, on the reasoning that a genuine crawler's
+    # rows all carry its own UA, so a single non-matching row (a redirect
+    # target logged without the client's own header, a truncated log line,
+    # or similar) must not be enough to strip the exclusion and reintroduce
+    # the #140 incident.
+    user_agents_by_ip: dict[str, set] = {}
+    if qualifying_rows:
+        qualifying_ips = [ip for ip, _, _, _ in qualifying_rows]
+        ua_rows = (
+            RequestLog.objects.filter(ip_address__in=qualifying_ips, timestamp__gte=cutoff)
+            .values_list("ip_address", "user_agent")
+            .distinct()
+        )
+        for ip, user_agent in ua_rows:
+            user_agents_by_ip.setdefault(ip, set()).add(user_agent)
+
+    created_rules = []
+    expiry = timezone.now() + timedelta(hours=conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS)
+
+    for ip, total, count_404, ratio in qualifying_rows:
+        if not allow_check_available:
+            continue
+
+        if _scraper_candidate_matches_allow_rule(ip, user_agents_by_ip.get(ip, {""}), cache, redis_client_for_run):
+            logger.info(
+                "django-waf: detect_scraper_404_ratio excluded %s (ratio=%.0f%%, "
+                "total=%d), it matches an active AllowRule (#140, #135).",
+                ip,
+                ratio * 100,
+                total,
+            )
+            continue
+
         details = {
             "total_requests": total,
             "count_404": count_404,
@@ -1216,6 +1364,53 @@ def detect_scraper_404_ratio(
                 )
 
     return created_rules
+
+
+def _scraper_candidate_matches_allow_rule(
+    ip_address: str,
+    user_agents,
+    cache,
+    redis_client,
+) -> bool:
+    """Return True if any UA observed for ``ip_address`` matches an active AllowRule.
+
+    Reuses ``rule_engine._check_allow_rules`` (the same matcher
+    ``evaluate_request`` calls at its own step 4), never a reimplementation:
+    the FCrDNS verification an AllowRule can require
+    (``rule_engine._verify_rdns``) is security-critical and must stay a
+    single source of truth (#140, #135; see ``detect_scraper_404_ratio``'s
+    docstring for the full incident).
+
+    ``user_agents`` is every distinct User-Agent this IP presented in the
+    detection window. Checked with an OR: the IP is excluded (returns True)
+    the moment ANY of its UAs matches, the fail-safe-toward-not-flagging
+    choice documented on the caller. A genuine crawler is not expected to
+    present more than one UA in practice, but a multi-UA IP is treated the
+    same as a single-UA one rather than as suspicious in its own right;
+    this detector's job is the 404 ratio, not UA consistency (that is
+    ``detect_ua_rotation``'s signal).
+
+    Any exception from the matcher itself (as opposed to the caller's own
+    "could not get a Redis client / could not load the cache" fail-closed
+    path) is also treated as fail-closed: caught here, logged, and treated
+    as a match (excluded), never allowed to propagate and abort the whole
+    detector run over one IP's lookup.
+    """
+    from django_waf.services.rule_engine import _check_allow_rules
+
+    for user_agent in user_agents:
+        try:
+            if _check_allow_rules(ip_address, user_agent, cache, redis_client) is not None:
+                return True
+        except Exception:
+            logger.warning(
+                "django-waf: detect_scraper_404_ratio AllowRule check raised for "
+                "%s; treating as excluded (fail-closed, #140).",
+                ip_address,
+                exc_info=True,
+            )
+            return True
+    return False
 
 
 def run_all_detectors(

--- a/tests/test_detector_probe.py
+++ b/tests/test_detector_probe.py
@@ -28,9 +28,10 @@ real query path, for every detector it names, is worth nothing.
 
 from __future__ import annotations
 
+import time
 from datetime import timedelta
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core.management import call_command
@@ -40,6 +41,48 @@ from django.utils import timezone
 from django_waf.enums import MatchType, ReviewStatus, RuleAction, RuleSource, RuleType
 from django_waf.services.anomaly_detector import DETECTOR_NAMES
 from django_waf.services.detector_probe import run_detector_probe
+
+
+def _make_redis() -> MagicMock:
+    """A working Redis double with the rule-cache and rate-limiter pipeline
+    shapes configured, mirroring tests/test_scraper_404_ratio.py's helper of
+    the same name. detect_scraper_404_ratio's AllowRule re-resolution
+    (#140, #135) needs a reachable Redis client to load the rule cache; a
+    real (non-mocked) probe run that omitted this would report
+    detect_scraper_404_ratio SILENT under the fix's fail-closed design,
+    not because the detector is broken but because no qualifying IP could
+    ever clear the AllowRule check with no cache available. This module
+    exercises every detector against the real code path, so every test in
+    it needs Redis reachable exactly like a real deployment provides it.
+    """
+    redis = MagicMock()
+    redis.get.return_value = None
+    redis.set.return_value = True
+    redis.setex.return_value = True
+    redis.delete.return_value = 1
+    redis.incr.return_value = 1
+    redis.zcount.return_value = 0
+    now = time.time()
+    pipeline = MagicMock()
+    pipeline.execute.return_value = [1, 0, 1, [(str(now), now)], True]
+    redis.pipeline.return_value = pipeline
+    return redis
+
+
+@pytest.fixture(autouse=True)
+def _redis_client_available():
+    """Autouse: every test in this module runs detect_scraper_404_ratio for
+    real (directly or via run_all_detectors/run_detector_probe), so its
+    AllowRule re-resolution needs get_redis_client() to return a working
+    client, exactly as a real deployment does. Without this, the detector
+    fails closed on every test here for a reason unrelated to what each
+    test is actually checking."""
+    with patch(
+        "django_waf.services.redis_client.get_redis_client",
+        return_value=_make_redis(),
+    ):
+        yield
+
 
 # ---------------------------------------------------------------------------
 # run_detector_probe: falsifiability against the REAL detection path

--- a/tests/test_scraper_404_ratio.py
+++ b/tests/test_scraper_404_ratio.py
@@ -16,14 +16,15 @@ falsify the fixture rather than the fixture silently tracking the raise.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 from django.utils import timezone
 
-from django_waf.enums import RuleAction, RuleSource, RuleType, Verdict
+from django_waf.enums import MatchType, RequestLogSource, RuleAction, RuleSource, RuleType, Verdict
 from django_waf.services.anomaly_detector import detect_scraper_404_ratio
-from django_waf.testing.factories import RequestLogFactory
+from django_waf.testing.factories import AllowRuleFactory, RequestLogFactory
 
 pytestmark = pytest.mark.django_db
 
@@ -36,9 +37,14 @@ def _make_requests(
     verdict: str = Verdict.ALLOWED,
     response_code_non_404: int = 200,
     timestamp=None,
+    source: str = RequestLogSource.MIDDLEWARE,
+    user_agent: str | None = None,
 ) -> None:
     """Create ``total`` RequestLog rows for ``ip``, ``count_404`` of them 404."""
     now = timestamp or timezone.now()
+    kwargs = {}
+    if user_agent is not None:
+        kwargs["user_agent"] = user_agent
     for i in range(total):
         RequestLogFactory(
             ip_address=ip,
@@ -46,7 +52,50 @@ def _make_requests(
             verdict=verdict,
             response_code=404 if i < count_404 else response_code_non_404,
             timestamp=now,
+            source=source,
+            **kwargs,
         )
+
+
+def _make_redis() -> MagicMock:
+    """Mirrors tests/test_rdns_fcrdns.py's _make_redis: a working Redis
+    double with the rule-cache and rate-limiter pipeline shapes configured
+    so a call into rule_engine machinery doesn't hit an unconfigured
+    MagicMock partway through."""
+    redis = MagicMock()
+    redis.get.return_value = None
+    redis.set.return_value = True
+    redis.setex.return_value = True
+    redis.delete.return_value = 1
+    redis.incr.return_value = 1
+    redis.zcount.return_value = 0
+    now = time.time()
+    pipeline = MagicMock()
+    pipeline.execute.return_value = [1, 0, 1, [(str(now), now)], True]
+    redis.pipeline.return_value = pipeline
+    return redis
+
+
+@pytest.fixture(autouse=True)
+def _redis_client_available():
+    """Autouse: every test in this module runs detect_scraper_404_ratio for
+    real, and the AllowRule re-resolution step (#140, #135) needs
+    get_redis_client() to return a working client to load the rule cache.
+    Without this, every pre-existing test in this module that expects a
+    rule to be created would instead fail closed for a reason unrelated to
+    what it is actually checking.
+
+    Tests in TestDetectScraper404RatioNginxAllowRuleExclusion that need a
+    different Redis behaviour (in particular, the unavailable-client case)
+    nest their own ``patch(...get_redis_client...)`` inside this one, which
+    overrides it for their duration and is restored on exit, so this
+    fixture does not interfere with them.
+    """
+    with patch(
+        "django_waf.services.redis_client.get_redis_client",
+        return_value=_make_redis(),
+    ):
+        yield
 
 
 class TestDetectScraper404RatioCreatesRule:
@@ -403,6 +452,165 @@ class TestDetectScraper404RatioWindow:
         with (
             patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
             patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []
+
+
+class TestDetectScraper404RatioNginxAllowRuleExclusion:
+    """Regression coverage for #140/#135: the production incident this
+    detector's verdict-scoping filter could not catch on its own, because a
+    nginx-sourced row's verdict is inferred from the status code and can
+    never be Verdict.PASSED. These tests would fail if the AllowRule
+    exclusion at the counting stage were removed, proving it is load-bearing
+    rather than redundant with the existing reached_app filter."""
+
+    def test_verified_crawler_nginx_sourced_allowed_verdict_with_allow_rule_is_excluded(self):
+        """The exact #140 shape: source=nginx_log, verdict=allowed (never
+        passed, since nginx verdicts are inferred, not observed), 100% 404,
+        WITH a matching active AllowRule. Must NOT be flagged.
+
+        Without the fix this creates a rule, because reached_app's
+        Verdict.PASSED exclusion never applies to a nginx-sourced row in
+        the first place: the row is verdict=allowed, one of the two
+        verdicts the base filter counts.
+        """
+        ip = "40.77.167.132"  # a real Bingbot address from the traced incident
+        AllowRuleFactory(
+            rule_type=RuleType.IP,
+            match_type=MatchType.EXACT,
+            pattern=ip,
+            verify_rdns=False,
+            is_active=True,
+        )
+        _make_requests(
+            ip,
+            total=34,
+            count_404=34,
+            verdict=Verdict.ALLOWED,
+            source=RequestLogSource.NGINX_LOG,
+        )
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch(
+                "django_waf.services.redis_client.get_redis_client",
+                return_value=_make_redis(),
+            ),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert created == []
+
+    def test_impostor_same_user_agent_but_no_allow_rule_match_is_still_flagged(self):
+        """An impostor IP presents the identical User-Agent a seeded
+        UA+rDNS AllowRule requires, but its PTR record does not
+        forward-confirm (FCrDNS fails), so it never matches the AllowRule.
+        Must still be flagged.
+
+        Proves the fix preserves BR-ANOM-014's discrimination property
+        (a real crawler is excluded, an impostor presenting the same UA is
+        not) rather than switching the detector off for anyone claiming to
+        be a crawler.
+        """
+        import socket
+
+        crawler_ua = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+        AllowRuleFactory(
+            rule_type=RuleType.UA,
+            match_type=MatchType.CONTAINS,
+            pattern="Googlebot",
+            verify_rdns=True,
+            rdns_pattern=r"\.googlebot\.com$|\.google\.com$",
+            is_active=True,
+        )
+
+        impostor_ip = "45.45.237.69"
+        _make_requests(
+            impostor_ip,
+            total=27,
+            count_404=24,
+            verdict=Verdict.ALLOWED,
+            source=RequestLogSource.NGINX_LOG,
+            user_agent=crawler_ua,
+        )
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch(
+                "django_waf.services.redis_client.get_redis_client",
+                return_value=_make_redis(),
+            ),
+            patch(
+                "django_waf.services.rule_engine.socket.gethostbyaddr",
+                side_effect=socket.herror("no PTR record"),
+            ),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert len(created) == 1
+        assert created[0].pattern == impostor_ip
+
+    def test_malicious_nginx_sourced_ip_with_no_allow_rule_at_all_is_still_flagged(self):
+        """A malicious scraper, nginx-sourced, no AllowRule anywhere in the
+        system. Must still be flagged: proves nginx rows remain counted and
+        the detector was not quietly disabled by adding the AllowRule
+        check."""
+        ip = "4.205.62.107"
+        _make_requests(
+            ip,
+            total=25,
+            count_404=25,
+            verdict=Verdict.ALLOWED,
+            source=RequestLogSource.NGINX_LOG,
+        )
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch(
+                "django_waf.services.redis_client.get_redis_client",
+                return_value=_make_redis(),
+            ),
+        ):
+            created = detect_scraper_404_ratio(window_minutes=180)
+
+        assert len(created) == 1
+        assert created[0].pattern == ip
+
+    def test_allow_rule_check_unavailable_fails_closed_and_does_not_flag(self):
+        """When the AllowRule check cannot be evaluated at all (no Redis
+        client obtainable), a qualifying IP is NOT flagged, even with no
+        AllowRule in the system and a 100% 404 ratio that would otherwise
+        create a rule.
+
+        This is the fail-closed guarantee: an unverifiable check must never
+        let a flag through, exactly as an unverifiable check must never let
+        a request through elsewhere in this package (BR-EVAL-007).
+        """
+        ip = "10.10.10.200"
+        _make_requests(
+            ip,
+            total=25,
+            count_404=25,
+            verdict=Verdict.ALLOWED,
+            source=RequestLogSource.NGINX_LOG,
+        )
+
+        with (
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS", 20),
+            patch("django_waf.conf.DJANGO_WAF_SCRAPER_404_RATIO", 0.85),
+            patch("django_waf.conf.DJANGO_WAF_AUTO_RULE_EXPIRY_HOURS", 24),
+            patch(
+                "django_waf.services.redis_client.get_redis_client",
+                return_value=None,
+            ),
         ):
             created = detect_scraper_404_ratio(window_minutes=180)
 


### PR DESCRIPTION
Closes #140. Closes #135. Adds the guard from #133 (CI wiring deferred to #142).

Spec half: **icvoss/icv-oss-umbrella#601**, which amends BR-ANOM-014 and adds AC-ANOM-039..042. The two should land together.

## The defect

`detect_scraper_404_ratio` auto-challenged verified Bingbot on a production deployment.

Its crawler safeguard excludes `Verdict.PASSED` (an AllowRule match) from the count, and that exclusion was measured, not assumed: excluding `passed` flagged zero IPs, including it flagged 10 verified Bingbot addresses. But the exclusion is **verdict-based**, and a `RequestLog` row written by `tasks.parse_access_log` has its verdict inferred from the HTTP status (`_infer_verdict_from_status`, `tasks.py:958-966`, returns `allowed` for anything that is not 403, 429, or a 302 to the challenge path). Such a row can never be `passed`, however well the client is actually vetted, because no AllowRule evaluation happens during log ingest.

So the safeguard silently stopped applying to nginx-sourced rows, and the protection came to depend on which ingest path wrote the row, which is invisible from the detector's logic and from the settings.

| source | verdict | rows | counted? |
|---|---|---|---|
| `middleware` | `passed` | 52,165 | No, correctly excluded |
| `nginx_log` | `allowed` | 2,828 (78.9% 404) | **Yes** |

70 rules created in 24 hours, 34 covering Bingbot ranges, all at `CHALLENGE`. Bingbot cannot solve a proof-of-work challenge, so it was turned away for about a day. It had never surfaced because `parse_access_log` had failed silently on file permissions for its whole life on that deployment; fixing the permissions exposed the latent defect with no code change.

## The fix, and why not the obvious one

AllowRules are resolved a **second time, at the counting stage**, for any IP that has already cleared both the `min_requests` floor and the ratio gate, regardless of `source`. It reuses `rule_engine._check_allow_rules` and its FCrDNS Redis cache; the rule cache is loaded once per run, and the user agents an IP presented in the window are fetched in one query for all qualifying IPs. A match excludes the IP entirely: no rule, no signal.

**It fails closed.** No Redis client, a cache that fails to load, or a matcher that raises all mean the IP is treated as excluded, with the reason logged at WARNING. A detector that starts challenging Bingbot during a Redis or resolver outage is the same incident with a different trigger.

**Filtering to `source=MIDDLEWARE` was considered and rejected**, which is the fix #140 and #135 both suggested first:

1. It would cut the detector to under 2% of its input (#135 measured 36,479 of 37,112 rows as nginx-sourced), and this detector exists for a botnet whose defining property is a mean of 1.42 requests per IP.
2. It is structurally blind to exempt-path traffic. `middleware.py:78-86` (BR-EVAL-001) returns before any `RequestLog` row is written, so exempt-path requests exist only as nginx rows, and that is where scanners probe. #135 measured that middleware-only rows flag one completely different IP, and that all three confirmed-malicious IPs in its window were nginx-sourced.
3. It does not implement the property BR-ANOM-014 claims: that an impostor sending a byte-identical crawler UA fails FCrDNS and is still caught while the genuine crawler is excluded.

Full reasoning: #140 (comment https://github.com/icvoss/django-waf/issues/140#issuecomment-5528916646).

The deliberate asymmetry with `detect_unsolved_challenges`, which does filter `source=MIDDLEWARE`, is now documented from both ends: a CHALLENGED verdict is only ever produced by the middleware, so counting nginx rows would double-count the same request, whereas a 404 is legitimately and sometimes exclusively observed by nginx.

## Verification

Four new tests in `TestDetectScraper404RatioNginxAllowRuleExclusion`, matching AC-ANOM-039..042. **Teeth proven by inducing the failure, not by watching them pass:**

- With the exclusion short-circuited, `test_verified_crawler_nginx_sourced_allowed_verdict_with_allow_rule_is_excluded` **fails** with `assert [<BlockRule: Auto: scraper 404 ratio from 40.77.167.132>] == []`; the other three still pass.
- With fail-closed inverted, `test_allow_rule_check_unavailable_fails_closed_and_does_not_flag` **fails**.

Gates: all 7 matrix legs (3.11/3.12/3.13 x Django 5.2/6.0/6.1), 1459 passed, 6 skipped, 93.64% coverage; ruff check and format; mypy on 90 source files; Redis integration against a real `redis:6.0-alpine` container; and a real PostgreSQL run (locally 17.10 rather than CI's 16, noted as a version gap).

**Pre-existing fixture gap fixed:** 8 tests in `test_scraper_404_ratio.py` and 9 in `test_detector_probe.py` never mocked `get_redis_client`, so under the new fail-closed path they silently took the excluded branch. Each file gains an autouse fixture supplying a working Redis double, so they exercise the intended "Redis reachable, no matching AllowRule" path. None of them seed an AllowRule, so they correctly still create rules.

## Also in this PR: the BR- citation guard (#133)

`scripts/check_br_citations.py` asserts every `BR-` citation in `src/` is defined in the umbrella spec. Controls on both sides, so a missing umbrella checkout fails loudly instead of reporting zero dangling citations as a pass, which is the exact failure #133 was filed about.

Proven by induction: dangling citation exits 1, empty spec dir exits 1, empty src dir exits 1, clean tree exits 0 at `citations=66 rules=120 headings=120 reconcile=True dangling=NONE`.

Two defects were found and fixed while verifying it. The reference implementation **exited 0 while printing the dangling citation**, so it would have reported failures into a log and let CI pass. And scanning all of `src/` picked up `src/django_waf.egg-info/PKG-INFO`, a gitignored build artefact, so the citation count moved between 66 and 67 depending on whether anyone had run an editable install locally; build artefact directories are now excluded by suffix.

Not wired into CI: the spec lives in a private repo the default CI token cannot read. Tracked as #142 with the options written up.
