### PR TITLE
docs(scripts): record why the citation guard is not a CI check, fix worktree default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a matching heading before trusting any absence, and exits non-zero if
   either side comes back empty, so a missing umbrella checkout fails loudly
   instead of reporting zero dangling citations as a pass. Run it manually
-  or from a pre-push hook: `python3 scripts/check_br_citations.py`. It is
-  not yet wired into CI, because the umbrella spec lives in a separate
-  private repository that the default CI token cannot read; see #142.
+  or from a pre-push hook: `python3 scripts/check_br_citations.py`.
+  Deliberately NOT a CI check: this package is public and the spec it
+  reconciles against is private, so a CI job would need a credential
+  granting a fork-triggerable public workflow read access to a private
+  repository. It is a local and maintainer-side check instead, which is
+  the correct scope for a check whose reference data is not public.
 
 ### Fixed
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -84,3 +84,29 @@ Standard library only, no dependencies. Python 3.
 - `1`: a dangling citation was found, a control failed, or the spec
   directory was missing or empty (and `--allow-missing-spec` was not
   passed).
+
+### Why this is not a CI check
+
+Deliberate, not an omission or a task left undone.
+
+django-waf is a public package. The spec it reconciles against lives in a
+private umbrella repository. `ci.yml` triggers on `pull_request`, and a
+public repo accepts pull requests from forks, so any secret granting read
+access to the umbrella would sit in a workflow surface reachable by
+outside contributors. That is a credential-exfiltration path for private
+spec content, created in order to lint citation strings, and the trade is
+not worth making.
+
+The alternatives fail the same way. Triggering the check from the umbrella
+instead avoids the secret but puts a public package's merge gate inside a
+private repo, so an external contributor gets a check they cannot inspect
+or reproduce. Mirroring the spec into this repo would publish private
+content and create a second source of truth for canon that is supposed to
+live in one place.
+
+So it is a local and maintainer-side check, which is the right scope for a
+check whose reference data is not public. The accepted cost, stated plainly:
+nothing blocks a dangling citation from reaching `main` automatically. If
+that starts happening in practice, the fix is a pre-push hook in the
+maintainer's own workspace, not a CI job reaching across a visibility
+boundary.

--- a/scripts/check_br_citations.py
+++ b/scripts/check_br_citations.py
@@ -39,7 +39,40 @@ CONTROL_RULE_IDS = ("BR-UA-002", "BR-EVAL-001", "BR-ANOM-002b")
 # A citation known to exist on the source side.
 CONTROL_CITATION = "BR-UA-002"
 
-DEFAULT_SPEC_DIR = Path(__file__).resolve().parent.parent.parent.parent / "docs" / "specs" / "django-waf"
+
+def _default_spec_dir() -> Path:
+    """Locate the umbrella spec for the normal workspace layout.
+
+    Resolved from the repo's MAIN worktree rather than from this file's
+    own path. Counting parents from __file__ is correct only in a plain
+    checkout: under the repo's own worktree convention the script lives at
+    .claude/worktrees/<slug>/scripts/, so four parents up lands inside
+    .claude/ and the guard reports the spec as missing. It fails loudly
+    rather than passing when that happens, which is the intended
+    behaviour, but the default should simply work from a worktree, since
+    worktrees are how work is normally split out here.
+
+    git rev-parse --path-format=absolute --git-common-dir returns the
+    shared .git directory for both a checkout and any of its worktrees,
+    whose parent is always the main checkout.
+    """
+    repo_root = Path(__file__).resolve().parent.parent
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            repo_root = Path(result.stdout.strip()).parent
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return repo_root.parent.parent / "docs" / "specs" / "django-waf"
+
+
+DEFAULT_SPEC_DIR = _default_spec_dir()
 
 
 class GuardError(Exception):


### PR DESCRIPTION
Follow-up to #143. Closes nothing; corrects docs that promised something we have now decided against, and fixes a real path bug the correction exposed.

## Why

The #133 guard shipped documented as "not yet wired into CI, see #142", implying CI wiring was pending. It is not pending, it is declined.

django-waf is **public**; the umbrella spec it reconciles against is **private**; and `ci.yml` triggers on `pull_request`. A public repo accepts pull requests from forks, so any secret granting read access to the umbrella would sit in a workflow surface reachable by outside contributors. That is a credential-exfiltration path for private spec content, created in order to lint citation strings.

The alternatives fail the same way: triggering from the umbrella puts a public package's merge gate inside a private repo, giving external contributors a check they cannot inspect or reproduce; mirroring the spec publishes private content and creates a second source of truth for canon. #142 is closed as not planned.

So the guard is a local and maintainer-side check by design. Both `CHANGELOG.md` and `scripts/README.md` now say so, and state the accepted cost plainly: nothing blocks a dangling citation from reaching `main` automatically, and the fix if that recurs is a maintainer pre-push hook, not a CI job reaching across a visibility boundary.

## The path bug this exposed

Writing the correction surfaced a real defect. `DEFAULT_SPEC_DIR` was computed by counting four parents from `__file__`, which is correct in a plain checkout but wrong under this repo's own worktree convention: from `.claude/worktrees/<slug>/scripts/` it resolved to `.claude/docs/specs/django-waf` and reported the spec as missing.

It **failed loudly rather than passing vacuously**, which is the designed behaviour working correctly, but the default should work from a worktree since that is how work is normally split out here.

Now resolved via `git rev-parse --path-format=absolute --git-common-dir`, which returns the shared git directory for both a checkout and any of its worktrees, whose parent is always the main checkout. Falls back to the previous behaviour if git is unavailable.

## Verification

Default path, no arguments, both layouts:

- From the worktree: `citations=66 rules=120 headings=120 reconcile=True`, `dangling: NONE`, exit 0
- From the main checkout: same, resolving `spec dir: ~/Projects/oss/docs/specs/django-waf @ 0c082a6`

All four gating modes re-proven by induction after the change, not assumed to survive it:

| Induced | Exit |
|---|---|
| Dangling citation | 1 |
| Spec dir empty | 1 |
| Src dir empty | 1 |
| Clean tree | 0 |

`ruff check` and `ruff format --check` clean across `scripts/`, `src/`, `tests/`. No source behaviour changed; no version bump.
