### PR TITLE
fix(forms): ship waf_record_credential_failure so the per-account credential counter can increment (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   roughly 194,000 per run, rather than only the handful of detector
   candidates).
 
+- **The credential-throttle per-account counter could never increment**
+  (#141, BR-FORM-009). `CredentialThrottleDefence` only reads the per-IP
+  counter at submit time; the per-account counter and the
+  `credential_attack_observed` signal both depended on a documented
+  caller, `record_credential_failure`, that had zero callers anywhere in
+  `src/`. Neither the `ProtectedForm` mixin nor the `waf_protect_post`
+  decorator could call it on the consumer's behalf: both run before the
+  authentication check, so neither can know whether it subsequently
+  failed, and the mixin has no way to know which field carries the
+  identifier.
+
+  **Fix**: a new public entry point, `waf_record_credential_failure(request,
+  identifier)`, exported from `django_waf.forms`. Consumers call it from
+  their login view after their own credential check fails, unconditionally,
+  whether or not the account exists (enumeration safety, PRD §3.6.1). It
+  increments both counters and emits `credential_attack_observed` on the
+  single request whose increment makes the per-account count exactly equal
+  `DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT`, once per window rather than
+  on every attempt at or above it. Fails open like the rest of the
+  subsystem: a Redis outage, an empty identifier, or a request with no
+  resolvable client IP all no-op without raising.
+
+  The `CredentialThrottleDefence` docstring and the PRD's "Hooking into
+  login flow" section previously described a caller (an "orchestrator"
+  call, or the mixin "handling it") that did not exist; both are corrected
+  to name the new explicit call.
+
 ## [2.7.0] - 2026-09-03
 ### Added
 

--- a/docs/specs/forms/PRD.md
+++ b/docs/specs/forms/PRD.md
@@ -372,19 +372,29 @@ values; the `1.5` weight ensures this can't single-handedly block.
 Both have window TTL `DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW` (default
 `900` seconds, 15 min).
 
-**Hooking into login flow:** This defence runs in `evaluate()` *after*
-the form's `is_valid()` returns `False` (i.e. authentication failed).
-The mixin handles this; for the decorator, the consumer calls
-`waf_record_credential_failure(request, identifier)` explicitly when
-auth fails.
+**Hooking into login flow:** `CredentialThrottleDefence.evaluate()`
+only *reads* the per-IP counter; it runs before the auth check and
+cannot know whether that check subsequently fails. Neither the mixin
+nor the decorator increments the counter on the consumer's behalf:
+the mixin cannot distinguish an authentication failure from any other
+form-validation failure, and it cannot know which field carries the
+identifier. In both integration paths, the consumer calls
+`waf_record_credential_failure(request, identifier)` explicitly from
+their login view after the credential check fails, unconditionally
+(whether or not the account exists, see §3.6.1). Without that call
+the per-account counter never increments and
+`credential_attack_observed` never fires.
 
 **Verdict on submit:**
 - Per-IP count ≥ `DJANGO_WAF_FORM_CREDENTIAL_IP_LIMIT` (default `20`)
   → `flag`, score `5.0`, reason `"credential_throttle:ip"`. Triggers
   challenge redirect.
 - Per-account count ≥ `DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT`
-  (default `5`) → does **not** affect form verdict; emits
-  `credential_attack_observed` signal only (see §3.6.1).
+  (default `5`) is the observation state; it does **not** affect the
+  form verdict. `credential_attack_observed` fires once per window,
+  on the single request whose increment makes the count exactly equal
+  `DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT` (the crossing), not on
+  every attempt at or above it (see §3.6.1).
 - Otherwise → `pass`.
 
 #### 3.6.1 Account enumeration safety

--- a/src/django_waf/forms/__init__.py
+++ b/src/django_waf/forms/__init__.py
@@ -7,11 +7,16 @@ three entry points:
 * ``waf_protect_post``, view decorator (block 6).
 * ``{% waf_protect %}``, template tag (block 6).
 
-Plus the orchestrator and signals for advanced use.
+Plus ``waf_record_credential_failure`` for the login flow to call
+after an authentication failure (required by both the mixin and
+decorator paths, neither runs the check for you, see
+``forms/credentials.py``), and the orchestrator and signals for
+advanced use.
 """
 
 from __future__ import annotations
 
+from django_waf.forms.credentials import waf_record_credential_failure
 from django_waf.forms.mixin import ProtectedForm
 from django_waf.forms.protection import (
     FormEvaluationResult,
@@ -34,4 +39,5 @@ __all__ = [
     "form_submission_blocked",
     "form_submission_flagged",
     "form_submission_passed",
+    "waf_record_credential_failure",
 ]

--- a/src/django_waf/forms/credentials.py
+++ b/src/django_waf/forms/credentials.py
@@ -1,0 +1,92 @@
+"""Public entry point for recording a credential-login failure.
+
+``CredentialThrottleDefence`` (``defences/credential_throttle.py``) only
+*reads* the per-IP counter at submit time, it never increments anything.
+The increment happens here, called explicitly by the consuming project's
+login flow after its own authentication check fails. Neither the
+``ProtectedForm`` mixin nor the ``waf_protect_post`` decorator can do this
+on the consumer's behalf: both run *before* the password check, and the
+mixin in particular has no way to know which field holds the identifier
+or whether the credential check even failed, that is application logic
+this package does not own.
+
+Per PRD §3.6 + §3.6.1 and BR-FORM-009.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from django_waf.forms.services.counters import hash_identifier, record_credential_failure
+from django_waf.forms.signals import credential_attack_observed
+
+logger = logging.getLogger("django_waf.forms")
+
+
+def waf_record_credential_failure(request, identifier: str) -> tuple[int, int]:
+    """Record a failed login attempt, call this from the login view.
+
+    Must be called **unconditionally** whenever the credential check
+    fails, whether or not ``identifier`` corresponds to a real account
+    (PRD §3.6.1's enumeration-safety constraint: an attacker must not be
+    able to distinguish "wrong password" from "no such account" by
+    observing side effects). Both the mixin and decorator integration
+    paths require this explicit call; see
+    ``defences/credential_throttle.py`` for why the chain itself cannot
+    make it.
+
+    Increments both the per-account and per-IP failure counters in
+    Redis and returns ``(account_count, ip_count)`` after incrementing.
+    Emits ``credential_attack_observed`` when ``account_count`` exactly
+    equals ``DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT``, i.e. on the
+    request that crosses the threshold, not on every attempt at or
+    above it. Redis's ``INCR`` is atomic, so exactly one request per
+    window observes that exact value; emitting on ``>=`` would fire the
+    signal on every subsequent attempt during an ongoing attack, which
+    is wrong for the documented consumer (an email-to-owner handler
+    that should fire once, not spam the account holder).
+
+    Fails open like the rest of the form-protection subsystem: a Redis
+    outage, an empty ``identifier``, or a request with no resolvable
+    client IP all return ``(0, 0)`` without raising, and a receiver
+    that raises on the signal is caught and logged rather than
+    propagated into the caller's login flow.
+    """
+    from django_waf import conf
+    from django_waf.services.client_ip import resolve_client_ip
+    from django_waf.services.redis_client import get_redis_client
+
+    if not identifier:
+        return (0, 0)
+
+    ip = resolve_client_ip(request) if request else ""
+    if not ip:
+        return (0, 0)
+
+    redis_client = get_redis_client()
+    if redis_client is None:
+        return (0, 0)
+
+    window_seconds = conf.DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW
+    account_count, ip_count = record_credential_failure(
+        redis_client,
+        identifier=identifier,
+        ip=ip,
+        window_seconds=window_seconds,
+    )
+
+    # account_count 0 is the fail-open sentinel (Redis outage), never a
+    # crossing, even under a misconfigured limit of 0.
+    if account_count > 0 and account_count == conf.DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT:
+        try:
+            credential_attack_observed.send(
+                sender=None,
+                identifier_hash=hash_identifier(identifier),
+                attempt_count=account_count,
+                window_seconds=window_seconds,
+                ip=ip,
+            )
+        except Exception:
+            logger.exception("django-waf: credential_attack_observed receiver raised")
+
+    return account_count, ip_count

--- a/src/django_waf/forms/defences/credential_throttle.py
+++ b/src/django_waf/forms/defences/credential_throttle.py
@@ -14,10 +14,15 @@ whether an account exists**. This implementation enforces that by:
 
 The defence runs at submit time, *before* the auth check. It reads
 the current per-IP count; if it's at-or-above threshold the
-submission is flagged (challenge redirect). The actual increment
-happens via the orchestrator's ``record_credential_failure`` call
-after auth fails, which the consuming project hooks into its
-login view.
+submission is flagged (challenge redirect). There is no orchestrator
+call that increments the counter: neither the ``ProtectedForm`` mixin
+nor the ``waf_protect_post`` decorator can tell whether the
+authentication check that runs after them succeeded, so the consumer
+must call ``django_waf.forms.waf_record_credential_failure(request,
+identifier)`` from their own login flow, unconditionally, whenever
+the credential check fails, whether or not the account exists (PRD
+§3.6.1). Without that call the per-account counter never increments
+and ``credential_attack_observed`` never fires.
 
 Per PRD §3.6 + §3.6.1.
 """

--- a/src/django_waf/forms/services/counters.py
+++ b/src/django_waf/forms/services/counters.py
@@ -27,11 +27,16 @@ _CRED_IP_KEY = "waf:form:cred_fail:ip:{ip}"
 _SIGNUP_IP_KEY = "waf:form:signup:{ip}"
 
 
-def _hash_identifier(identifier: str) -> str:
+def hash_identifier(identifier: str) -> str:
     """Return a stable hash of the typed identifier (username/email).
 
     Hashed not for security per se (the identifier is on a wire we
     control) but so a Redis dump doesn't expose typed credentials.
+
+    Public (not module-private) because ``forms/credentials.py`` needs
+    the same hash to populate ``credential_attack_observed``'s
+    ``identifier_hash`` kwarg, and re-hashing ad hoc there would risk
+    the two hashes silently diverging.
     """
     return hashlib.sha256(identifier.encode("utf-8", errors="replace")).hexdigest()
 
@@ -56,7 +61,7 @@ def record_credential_failure(redis_client, *, identifier: str, ip: str, window_
     if not identifier or not ip:
         return (0, 0)
 
-    account_key = _CRED_ACCOUNT_KEY.format(identifier_hash=_hash_identifier(identifier))
+    account_key = _CRED_ACCOUNT_KEY.format(identifier_hash=hash_identifier(identifier))
     ip_key = _CRED_IP_KEY.format(ip=ip)
 
     try:
@@ -102,7 +107,7 @@ def credential_account_count(redis_client, *, identifier: str) -> int:
     if not identifier:
         return 0
     try:
-        raw = redis_client.get(_CRED_ACCOUNT_KEY.format(identifier_hash=_hash_identifier(identifier)))
+        raw = redis_client.get(_CRED_ACCOUNT_KEY.format(identifier_hash=hash_identifier(identifier)))
         if raw is None:
             return 0
         return int(raw)

--- a/tests/forms/test_credentials.py
+++ b/tests/forms/test_credentials.py
@@ -1,0 +1,196 @@
+"""Tests for waf_record_credential_failure, the public login-flow hook.
+
+Before this fix (#141) the per-account credential counter could never
+increment: no caller existed anywhere in ``src/``. These tests pin the
+new public entry point that closes that gap, exercised through the
+package's public import path (``from django_waf.forms import ...``)
+per the PRD's documented usage.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _redis():
+    r = MagicMock(name="redis")
+    pipe = MagicMock()
+    pipe.execute.return_value = [1, True, 1, True]
+    r.pipeline.return_value = pipe
+    r.get.return_value = None
+    return r
+
+
+def _request(ip="1.2.3.4"):
+    req = MagicMock()
+    req.META = {"REMOTE_ADDR": ip}
+    return req
+
+
+class TestWafRecordCredentialFailure:
+    def test_increments_both_counters_via_public_import(self):
+        from django_waf.forms import waf_record_credential_failure
+
+        redis = _redis()
+        redis.pipeline.return_value.execute.return_value = [3, True, 7, True]
+
+        with patch("django_waf.services.redis_client.get_redis_client", return_value=redis):
+            acct, ip = waf_record_credential_failure(_request(), "user@example.com")
+
+        assert (acct, ip) == (3, 7)
+        calls = redis.pipeline.return_value.method_calls
+        method_names = [c[0] for c in calls]
+        assert method_names.count("incr") == 2
+        assert method_names.count("expire") == 2
+
+    def test_signal_fires_exactly_on_the_crossing(self):
+        """credential_attack_observed fires only when account_count == limit.
+
+        Not before (count < limit) and not after (count > limit, an
+        attempt beyond the crossing during an ongoing attack).
+        """
+        import django_waf.conf as conf_mod
+        from django_waf.forms import waf_record_credential_failure
+        from django_waf.forms.signals import credential_attack_observed
+
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        credential_attack_observed.connect(handler, dispatch_uid="test_crossing")
+        try:
+            with patch.object(conf_mod, "DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT", 5):
+                for attempt_count in (3, 4, 5, 6):
+                    redis = _redis()
+                    redis.pipeline.return_value.execute.return_value = [attempt_count, True, 1, True]
+                    with patch("django_waf.services.redis_client.get_redis_client", return_value=redis):
+                        waf_record_credential_failure(_request(), "user@example.com")
+        finally:
+            credential_attack_observed.disconnect(dispatch_uid="test_crossing")
+
+        assert len(received) == 1
+        kwargs = received[0]
+        assert kwargs["attempt_count"] == 5
+        assert kwargs["window_seconds"] == conf_mod.DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW
+        assert kwargs["ip"] == "1.2.3.4"
+        assert "identifier_hash" in kwargs
+        assert kwargs["identifier_hash"] != "user@example.com"
+
+    def test_signal_kwargs_match_hash_identifier(self):
+        from django_waf.forms import waf_record_credential_failure
+        from django_waf.forms.services.counters import hash_identifier
+        from django_waf.forms.signals import credential_attack_observed
+
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        credential_attack_observed.connect(handler, dispatch_uid="test_hash_match")
+        try:
+            redis = _redis()
+            redis.pipeline.return_value.execute.return_value = [5, True, 1, True]
+            with patch("django_waf.services.redis_client.get_redis_client", return_value=redis):
+                waf_record_credential_failure(_request(), "admin@example.com")
+        finally:
+            credential_attack_observed.disconnect(dispatch_uid="test_hash_match")
+
+        assert len(received) == 1
+        assert received[0]["identifier_hash"] == hash_identifier("admin@example.com")
+
+    def test_redis_pipeline_failure_fails_open(self):
+        """Redis outage: (0, 0), no signal, no exception."""
+        from django_waf.forms import waf_record_credential_failure
+        from django_waf.forms.signals import credential_attack_observed
+
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        credential_attack_observed.connect(handler, dispatch_uid="test_fail_open")
+        try:
+            redis = _redis()
+            redis.pipeline.return_value.execute.side_effect = RuntimeError("redis down")
+            with patch("django_waf.services.redis_client.get_redis_client", return_value=redis):
+                result = waf_record_credential_failure(_request(), "user@example.com")
+        finally:
+            credential_attack_observed.disconnect(dispatch_uid="test_fail_open")
+
+        assert result == (0, 0)
+        assert received == []
+
+    def test_no_redis_client_available_fails_open(self):
+        """get_redis_client() returning None (misconfigured backend) is a no-op."""
+        from django_waf.forms import waf_record_credential_failure
+
+        with patch("django_waf.services.redis_client.get_redis_client", return_value=None):
+            result = waf_record_credential_failure(_request(), "user@example.com")
+
+        assert result == (0, 0)
+
+    def test_empty_identifier_no_ops(self):
+        from django_waf.forms import waf_record_credential_failure
+
+        redis = _redis()
+        with patch("django_waf.services.redis_client.get_redis_client", return_value=redis):
+            result = waf_record_credential_failure(_request(), "")
+
+        assert result == (0, 0)
+        redis.pipeline.assert_not_called()
+
+    def test_missing_ip_no_ops(self):
+        from django_waf.forms import waf_record_credential_failure
+
+        redis = _redis()
+        request = _request(ip="")
+        with patch("django_waf.services.redis_client.get_redis_client", return_value=redis):
+            result = waf_record_credential_failure(request, "user@example.com")
+
+        assert result == (0, 0)
+        redis.pipeline.assert_not_called()
+
+    def test_signal_receiver_exception_does_not_propagate(self):
+        """A misbehaving receiver must NOT break the caller's login flow."""
+        from django_waf.forms import waf_record_credential_failure
+        from django_waf.forms.signals import credential_attack_observed
+
+        def broken_handler(sender, **kwargs):
+            raise RuntimeError("receiver bug")
+
+        credential_attack_observed.connect(broken_handler, dispatch_uid="test_broken_cred")
+        try:
+            redis = _redis()
+            redis.pipeline.return_value.execute.return_value = [5, True, 1, True]
+            with patch("django_waf.services.redis_client.get_redis_client", return_value=redis):
+                # Must NOT raise.
+                result = waf_record_credential_failure(_request(), "user@example.com")
+        finally:
+            credential_attack_observed.disconnect(dispatch_uid="test_broken_cred")
+
+        assert result == (5, 1)
+
+    def test_account_count_zero_does_not_emit(self):
+        """A (0, 0) fail-open result must never emit, even if LIMIT were 0."""
+        import django_waf.conf as conf_mod
+        from django_waf.forms import waf_record_credential_failure
+        from django_waf.forms.signals import credential_attack_observed
+
+        received = []
+
+        def handler(sender, **kwargs):
+            received.append(kwargs)
+
+        credential_attack_observed.connect(handler, dispatch_uid="test_zero_no_emit")
+        try:
+            with patch.object(conf_mod, "DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT", 0):
+                redis = _redis()
+                redis.pipeline.return_value.execute.side_effect = RuntimeError("redis down")
+                with patch("django_waf.services.redis_client.get_redis_client", return_value=redis):
+                    result = waf_record_credential_failure(_request(), "user@example.com")
+        finally:
+            credential_attack_observed.disconnect(dispatch_uid="test_zero_no_emit")
+
+        assert result == (0, 0)
+        assert received == []


### PR DESCRIPTION
Closes icvoss/django-waf#141.

## What changed and why

`record_credential_failure` (forms/services/counters.py) had zero callers in `src/`: the credential-throttle per-account counter could never increment and `credential_attack_observed` (BR-FORM-009) could never fire, while the defence shipped in the canonical chain and two pieces of prose described a caller that did not exist.

- New public entry point `waf_record_credential_failure(request, identifier)` (`forms/credentials.py`), exported from `django_waf.forms`: resolves IP, window and Redis client, delegates to `record_credential_failure`, and emits `credential_attack_observed` on the request whose increment makes the per-account count exactly equal `DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT` (once per window; `>=` would emit per attempt during an attack, wrong for the documented email-to-owner consumer). Fails open: Redis outage, empty identifier, unresolvable IP and raising receivers all no-op without raising; `account_count == 0` (the fail-open sentinel) never emits.
- Corrected `defences/credential_throttle.py` docstring: there is no orchestrator call; the consumer must call the helper from their login flow after auth fails, unconditionally (enumeration safety, PRD 3.6.1).
- Corrected `docs/specs/forms/PRD.md`: removed the false "the mixin handles this" claim (the mixin cannot distinguish an auth failure from any other validation failure, nor know the identifier field) and disambiguated the verdict table (observation state is `>=` limit; the signal fires on the crossing).
- `hash_identifier` made public in `counters.py` so the helper populates `identifier_hash` without re-hashing ad hoc.
- Regression tests (`tests/forms/test_credentials.py`, 9 tests) pin the increment through the public import path, the exactly-once crossing emission, fail-open, and receiver-exception swallowing.

Deliberately NOT added: a system check for "helper never called". The helper is imported whenever `django_waf.forms` is, so import detection is meaningless, and chain registration is import-time, so an accurate check is not buildable; an unconditional warning would fire on correctly wired deployments.

## Verification (commit 0a1e9f1, fresh venv, Python 3.12 / Django 6.0.8)

- pytest default leg: 1468 passed, 6 skipped, coverage 93.71% (floor 90%).
- postgres leg (psycopg per ci.yml): 1466 passed, 8 skipped.
- redis-integration leg: 5 passed, 1 pre-existing environment-mismatch failure (`test_getdel_raises_on_a_pre_62_redis_server`; local Redis 7.2.8 vs CI's pinned 6.0, test unchanged from main and outside this diff). CI's own leg gates the merge.
- ruff 0.15.22 check + format: clean. mypy 2.3.1 (django-stubs 6.1.0): no issues in 91 files.
- `scripts/check_br_citations.py`: citations=67 rules=120 reconcile=True, exit 0 (BR-FORM-009 cited by the new module resolves against the umbrella spec).
- Teeth check: with the counter call stubbed out, 4 of 9 new tests fail (increment and signal assertions); restored, all green.

## Cross-repo remainder

The umbrella spec's integration section (`docs/specs/django-waf/03-services.md`) documents the mixin, decorator and template tag but not this new consumer-facing call; canon issue to be filed on icvoss/icv-oss-umbrella and linked here before merge.