### PR TITLE
chore(release): 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.8.0] - 2026-09-04
 ### Added
 
 - `scripts/check_br_citations.py`: a guard that extracts every `BR-XXX-NNN`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.7.0"
+version = "2.8.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release PR per RELEASING.md. Closes no issue: version bump and CHANGELOG date only.

- pyproject.toml: 2.7.0 -> 2.8.0 (the only place the version lives; `src/django_waf/__init__.py` reads package metadata at runtime).
- CHANGELOG.md: `[Unreleased]` renamed to `[2.8.0] - 2026-09-04`; nothing remains under Unreleased.

Minor bump per RELEASING.md: new public API (`waf_record_credential_failure`, #141/#146) and behaviour changes (#140/#135 detector fix). Ships #133 (citation guard, repo-level script, correctly outside the wheel), #140 and #141.

Consumer-facing behaviour changes on upgrade, for the release notes:
- A deployment running both `parse_access_log` and `detect_scraper_404_ratio` stops seeing verified crawlers auto-challenged (#140).
- `detect_scraper_404_ratio` now requires a working Redis client to enforce at all: it fails closed and flags nothing when Redis is unavailable, logging a WARNING (#140).
- `credential_attack_observed` can now actually fire, but only for consumers who add the documented `waf_record_credential_failure` call to their login flow (#141).

Publish-gate simulation and artefact verification run separately before tagging; results to be recorded on this PR before merge.