### PR TITLE
docs(readme): tell the login flow to call waf_record_credential_failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+
+- README: the form-protection usage section now documents that the
+  consuming login view must call `waf_record_credential_failure` after
+  a failed credential check, unconditionally, and the two
+  credential-throttle settings rows point at that note. A README-only
+  reader could previously enable `credential_throttle` and connect
+  `credential_attack_observed` without anything ever incrementing the
+  counters, which is the belief behind #141. Documentation only, no
+  behaviour change.
+
 ## [2.8.0] - 2026-09-04
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -351,8 +351,8 @@ until a form opts in via the mixin, decorator, or template tag.
 | `DJANGO_WAF_FORM_TIME_TRAP_MIN_SECONDS` | `1.5` | Below this → flag; below 0.5 → block (hard floor) |
 | `DJANGO_WAF_FORM_TIME_TRAP_MAX_SECONDS` | `3600` | Above this → flag (stale form) |
 | `DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_WINDOW` | `900` | Sliding window for credential-failure counters (seconds) |
-| `DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT` | `5` | Per-account threshold. Observation-only (drives `credential_attack_observed` signal); never user-visible |
-| `DJANGO_WAF_FORM_CREDENTIAL_IP_LIMIT` | `20` | Per-IP threshold. **Drives the user-visible challenge**: same behaviour regardless of which accounts were tried (enumeration-safe) |
+| `DJANGO_WAF_FORM_CREDENTIAL_THROTTLE_LIMIT` | `5` | Per-account threshold. Observation-only (drives `credential_attack_observed` signal); never user-visible. The counter increments only when your login view calls `waf_record_credential_failure`, see *Hooking the login flow* below |
+| `DJANGO_WAF_FORM_CREDENTIAL_IP_LIMIT` | `20` | Per-IP threshold. **Drives the user-visible challenge**: same behaviour regardless of which accounts were tried (enumeration-safe). Fed by the same `waf_record_credential_failure` call, see *Hooking the login flow* below |
 | `DJANGO_WAF_FORM_SIGNUP_VELOCITY_WINDOW` | `86400` | Window for completed-signup counter (24h) |
 | `DJANGO_WAF_FORM_SIGNUP_VELOCITY_LIMIT` | `5` | Successful signups per IP before next attempt is flagged |
 | `DJANGO_WAF_FORM_POW_DIFFICULTY` | `12` | Per-submission PoW difficulty (bits). 12 ≈ 4k SHA-256 hashes ≈ 50ms desktop / ~200ms mobile |
@@ -419,6 +419,30 @@ def contact_view(request):
   <button type="submit">Send</button>
 </form>
 ```
+
+**Hooking the login flow** (required for the `credential_throttle`
+defence): the defence only *reads* the failure counters at submit time.
+Neither the mixin nor the decorator increments them, because both run
+before your authentication check and cannot tell a wrong password from
+any other validation failure. Your login view must call
+`waf_record_credential_failure` after its own credential check fails,
+unconditionally, whether or not the account exists: an attacker must
+not be able to tell "wrong password" from "no such account" by
+observing side effects.
+
+```python
+from django_waf.forms import waf_record_credential_failure
+
+# In the login view, after the credential check fails (authenticate()
+# returns None, or form.is_valid() is False for an AuthenticationForm):
+waf_record_credential_failure(request, form.cleaned_data["username"])
+```
+
+Without that call the per-account counter never increments, so
+`credential_attack_observed` never fires, and the per-IP counter never
+increments, so the challenge never triggers. The helper returns
+`(account_count, ip_count)` and fails open, returning `(0, 0)` on a
+Redis outage, so it is safe to call from the hot path of a login view.
 
 **HTMX compatibility**: the form-protection render token persists
 across HTMX re-renders of the same form (a user fixing a validation


### PR DESCRIPTION
## What

Docs only. README's form-protection usage section gains a **Hooking the login flow** note: the `credential_throttle` defence only reads the failure counters, neither the mixin nor the decorator increments them, and the consumer's login view must call `waf_record_credential_failure(request, identifier)` after a failed credential check, unconditionally, whether or not the account exists (PRD 3.6 and 3.6.1). Both credential-throttle settings rows now point at that note. CHANGELOG gets its `[Unreleased]` heading back with a Fixed entry.

## Why

A README-only reader reproduces the #141 belief exactly: enable `credential_throttle`, connect `credential_attack_observed`, and nothing ever fires, because nothing increments the counters. The only code path that increments either counter is the public helper (`src/django_waf/forms/credentials.py`; no other caller of `counters.record_credential_failure` exists under `src/`), so without the call the per-IP challenge never triggers either.

Closes nothing: the gap was found during the #141 fix and this PR is the fix. Follow-up in the umbrella spec is already filed as icvoss/icv-oss-umbrella#607.

## Verification

- Every claim in the note checked against `credentials.py`, `services/counters.py`, `defences/credential_throttle.py` and `forms/__init__.py`, and against PRD 3.6 and 3.6.1, by a reviewer pass. One wording concern (the example comment implied a bare `authenticate()` call, which `AuthenticationForm` users never see) was taken.
- Confirmed against installed Django 6.0.8 that `form.cleaned_data["username"]` survives a failed `AuthenticationForm.clean()` (`BaseForm._clean_form` catches the error and keeps `cleaned_data`), so the example line is valid in both integration shapes.
- `python -m build` and `twine check` pass on this branch, and the built wheel's METADATA carries the new note, so the PyPI long description still renders. The PyPI page itself stays stale until the next release, which is expected; no release for this.
- No em or en dashes in the diff.
- CI's full matrix runs on the PR (ci.yml has no path filters).
