### PR TITLE
fix(probe): exercise source=nginx_log in the scraper 404 fixture (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 
+- `services.detector_probe`: `_build_scraper_404_fixture`'s docstring
+  wrongly claimed its rows carried "allowed, passed, or logged" verdicts;
+  `detect_scraper_404_ratio` counts only `allowed`/`logged` and deliberately
+  excludes `passed` (an AllowRule match, BR-ANOM-014), and the fixture
+  itself already built `verdict=allowed` correctly, so only the docstring
+  was wrong. Separately, the fixture never set `RequestLog.source`, so
+  every row defaulted to `source=middleware`, and the detector has no
+  `source` filter at all: nginx-sourced rows are deliberately counted
+  alongside middleware rows (#140, #135), 98.3% of real input on the
+  reporting deployment, and the probe had never exercised that path. The
+  fixture now builds two independently qualifying IPs, one
+  `source=middleware` and one `source=nginx_log`, and
+  `django_waf_probe_detectors` now requires a rule from each: it reports
+  `detect_scraper_404_ratio` SILENT if either ingest path stops producing a
+  rule, and `rules_reported` for that detector is 2 on a healthy
+  deployment, up from 1 (#145).
+
 - README: the form-protection usage section now documents that the
   consuming login view must call `waf_record_credential_failure` after
   a failed credential check, unconditionally, and the two

--- a/src/django_waf/services/detector_probe.py
+++ b/src/django_waf/services/detector_probe.py
@@ -89,8 +89,20 @@ _SUBNET_BURST_SUBNET_BASE = "198.51.100."  # .10-.15 used below
 _CHALLENGE_FARM_IP = "203.0.113.10"
 _CLOUD_SPRAY_SUBNET_BASE = "203.0.113."  # .20-.40 used below (21 IPs)
 _SCRAPER_404_IP = "192.0.2.90"
+_SCRAPER_404_NGINX_IP = "192.0.2.91"  # same detector, source=nginx_log (#145)
 
 _PROBE_UA = "django-waf-detector-probe/1.0"
+
+# Per-detector floor for "alive", overriding the default at-least-one
+# contract every other detector keeps. detect_scraper_404_ratio counts rows
+# from two independent producers (source=middleware, written by
+# middleware.py, and source=nginx_log, written by tasks.parse_access_log;
+# see the detector's own docstring), so a fixture that only ever proves one
+# source alive would leave the other's regression path (#140, #135, where
+# nginx-sourced rows were 98.3% of real input) permanently unprobed. Requiring 2 rules here
+# means losing either source's fixture row drops rules_reported to 1 and
+# the probe correctly goes red, which a bare ">= 1" contract cannot express.
+_MIN_RULES_REPORTED: dict[str, int] = {"detect_scraper_404_ratio": 2}
 
 
 def run_detector_probe(dry_run: bool = True) -> dict:
@@ -145,9 +157,15 @@ def run_detector_probe(dry_run: bool = True) -> dict:
               each mapping to a per-detector dict with ``alive`` (bool)
               and ``rules_reported`` (int, the count
               ``run_all_detectors`` attributed to that detector for this
-              run).
+              run). ``alive`` is ``rules_reported >= 1`` for every
+              detector except where ``_MIN_RULES_REPORTED`` names a
+              higher floor: ``detect_scraper_404_ratio`` requires 2,
+              one for its ``source=middleware`` fixture row and one
+              for its ``source=nginx_log`` fixture row, so losing
+              either ingest path's rule is distinguishable from losing
+              both.
             - ``all_alive`` (bool): True only when every detector reported
-              at least one rule against its own fixture.
+              ``alive`` against its own fixture.
             - ``silent_detectors`` (list[str]): names of any detector that
               reported zero, empty when ``all_alive`` is True.
             - ``dry_run`` (bool): echoes the argument, so a caller does not
@@ -202,7 +220,7 @@ def run_detector_probe(dry_run: bool = True) -> dict:
     for detector_name in sorted(DETECTOR_NAMES):
         result_key = DETECTOR_NAME_TO_RESULT_KEY[detector_name]
         rules_reported = result.get(result_key, 0)
-        alive = rules_reported > 0
+        alive = rules_reported >= _MIN_RULES_REPORTED.get(detector_name, 1)
         report[detector_name] = {"alive": alive, "rules_reported": rules_reported}
         if not alive:
             silent_detectors.append(detector_name)
@@ -447,30 +465,64 @@ def _build_cloud_spray_fixture(*, now, conf, distinct_ip_count: int | None = Non
     )
 
 
-def _build_scraper_404_fixture(*, now, conf, total_requests: int | None = None) -> None:
-    """BR-ANOM-014: a single IP with at least
+def _build_scraper_404_fixture(
+    *,
+    now,
+    conf,
+    total_requests: int | None = None,
+    include_middleware: bool = True,
+    include_nginx: bool = True,
+) -> None:
+    """BR-ANOM-014: two IPs, one per ingest path, each with at least
     DJANGO_WAF_SCRAPER_404_MIN_REQUESTS (default 20) requests within the
     window, at least DJANGO_WAF_SCRAPER_404_RATIO (default 0.85) of them
-    404, all carrying a verdict that reached the application (allowed,
-    passed, or logged, never a WAF-produced verdict). Every row is built
-    with response_code=404 so the fixture's ratio is 100%, comfortably
-    clear of the default 85% floor.
+    404, all carrying ``verdict=allowed``: the detector counts only
+    ``Verdict.ALLOWED`` and ``Verdict.LOGGED`` rows, the verdicts that show
+    a request reached the application (see detect_scraper_404_ratio's own
+    docstring, ``anomaly_detector.py``). ``Verdict.PASSED`` (an AllowRule
+    match) is deliberately excluded by the detector per BR-ANOM-014, so a
+    ``passed`` row here would build a fixture the real query is required to
+    ignore. Every row is built with response_code=404 so the fixture's
+    ratio is 100%, comfortably clear of the default 85% floor.
+
+    Builds TWO IPs, one per ``RequestLog.source`` value
+    (``RequestLogSource.MIDDLEWARE``/``NGINX_LOG``), because the detector
+    has no ``source`` filter at all: nginx-sourced rows are deliberately
+    counted alongside middleware rows (#140, #135), and on the deployment
+    measured in #135 nginx-sourced rows were 98.3% of this detector's real
+    input. A probe fixture built only on ``source=middleware`` (the
+    model's own default, so an earlier revision of this fixture got it
+    silently by never passing ``source`` at all) never exercised that path
+    and would stay green through a regression that broke nginx-sourced
+    counting specifically.
+
+    Two IPs, each independently crossing the threshold, rather than one
+    mixed-source IP: with a single IP, a regression that dropped every
+    nginx row would still leave enough middleware rows behind to clear
+    the threshold on their own, and the probe would stay green. Two
+    independently qualifying IPs, combined with ``run_detector_probe``'s
+    ``_MIN_RULES_REPORTED`` floor of 2 for this detector, means losing
+    either source's fixture drops ``rules_reported`` to 1 and the probe
+    goes red.
 
     ``total_requests`` defaults to ``conf.DJANGO_WAF_SCRAPER_404_MIN_
     REQUESTS + 1``, for the same reason as the other config-derived
     fixtures in this module: raising the threshold alone cannot falsify a
     fixture that grows to match it. A falsifiability test that needs to
     raise the threshold past a FIXED fixture size must pass an explicit
-    literal here.
+    literal here. ``include_middleware``/``include_nginx`` default to
+    ``True`` and let a test drop one source's rows entirely, to prove the
+    probe can see a missing ingest path rather than only a missing IP.
     """
-    from django_waf.enums import Verdict
+    from django_waf.enums import RequestLogSource, Verdict
     from django_waf.models import RequestLog
 
     if total_requests is None:
         total_requests = conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS + 1
 
-    RequestLog.objects.bulk_create(
-        [
+    rows: list[RequestLog] = []
+    if include_middleware:
+        rows.extend(
             RequestLog(
                 timestamp=now,
                 ip_address=_SCRAPER_404_IP,
@@ -479,7 +531,23 @@ def _build_scraper_404_fixture(*, now, conf, total_requests: int | None = None) 
                 method="GET",
                 verdict=Verdict.ALLOWED,
                 response_code=404,
+                source=RequestLogSource.MIDDLEWARE,
             )
             for i in range(total_requests)
-        ]
-    )
+        )
+    if include_nginx:
+        rows.extend(
+            RequestLog(
+                timestamp=now,
+                ip_address=_SCRAPER_404_NGINX_IP,
+                user_agent=_PROBE_UA,
+                path=f"/scraper-404-nginx-fixture-path-{i}/",
+                method="GET",
+                verdict=Verdict.ALLOWED,
+                response_code=404,
+                source=RequestLogSource.NGINX_LOG,
+            )
+            for i in range(total_requests)
+        )
+
+    RequestLog.objects.bulk_create(rows)

--- a/tests/test_detector_probe.py
+++ b/tests/test_detector_probe.py
@@ -113,6 +113,7 @@ class TestRunDetectorProbeFalsifiability:
         for detector_name in DETECTOR_NAMES:
             assert result[detector_name]["alive"] is True
             assert result[detector_name]["rules_reported"] > 0
+        assert result["detect_scraper_404_ratio"]["rules_reported"] == 2
 
     def test_probe_goes_red_when_ua_rotation_cannot_match_its_fixture(self, db, monkeypatch):
         """detect_ua_rotation: the real query legitimately finds nothing.
@@ -438,6 +439,107 @@ class TestRunDetectorProbeFalsifiability:
             assert result[detector_name]["alive"] is True
             assert result[detector_name]["rules_reported"] > 0
 
+    def test_probe_goes_red_when_the_nginx_sourced_scraper_fixture_is_missing(self, db, monkeypatch):
+        """detect_scraper_404_ratio: losing the nginx-sourced fixture row
+        must be visible on its own, not masked by the middleware row still
+        crossing the threshold.
+
+        Layer under test: the full real path. run_all_detectors is NOT
+        patched, and detect_scraper_404_ratio is NOT patched; only the
+        fixture builder is asked to skip its nginx IP
+        (``include_nginx=False``), so the middleware IP (``.90``) still
+        qualifies on its own and the real query still creates one rule for
+        it. ``_MIN_RULES_REPORTED["detect_scraper_404_ratio"] == 2`` is what
+        turns that single rule into SILENT: without the per-detector floor,
+        ``rules_reported == 1`` would report ``alive`` under the default
+        ``>= 1`` contract, exactly the blind spot #145 exists to close
+        (a fixture that only ever built ``source=middleware`` rows, so a
+        regression in nginx-sourced counting could never turn this probe
+        red).
+        """
+        from django_waf.services import detector_probe as detector_probe_mod
+
+        real_builder = detector_probe_mod._build_scraper_404_fixture
+        monkeypatch.setattr(
+            detector_probe_mod,
+            "_build_scraper_404_fixture",
+            lambda *, now, conf: real_builder(now=now, conf=conf, include_nginx=False),
+        )
+
+        result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_scraper_404_ratio"]
+        assert result["detect_scraper_404_ratio"]["alive"] is False
+        assert result["detect_scraper_404_ratio"]["rules_reported"] == 1
+        for detector_name in DETECTOR_NAMES - {"detect_scraper_404_ratio"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+    def test_probe_goes_red_when_the_middleware_sourced_scraper_fixture_is_missing(self, db, monkeypatch):
+        """Mirror of the nginx-missing case above: losing the
+        middleware-sourced fixture row must also be visible on its own,
+        with only the nginx IP (``.91``) qualifying and creating one rule.
+
+        Layer under test: the full real path, unpatched. Proves the same
+        blind spot from the opposite direction: a fixture that only ever
+        built ``source=nginx_log`` rows would also stay green through a
+        regression in middleware-sourced counting, and the per-detector
+        floor catches that direction too.
+        """
+        from django_waf.services import detector_probe as detector_probe_mod
+
+        real_builder = detector_probe_mod._build_scraper_404_fixture
+        monkeypatch.setattr(
+            detector_probe_mod,
+            "_build_scraper_404_fixture",
+            lambda *, now, conf: real_builder(now=now, conf=conf, include_middleware=False),
+        )
+
+        result = run_detector_probe(dry_run=True)
+
+        assert result["all_alive"] is False
+        assert result["silent_detectors"] == ["detect_scraper_404_ratio"]
+        assert result["detect_scraper_404_ratio"]["alive"] is False
+        assert result["detect_scraper_404_ratio"]["rules_reported"] == 1
+        for detector_name in DETECTOR_NAMES - {"detect_scraper_404_ratio"}:
+            assert result[detector_name]["alive"] is True
+            assert result[detector_name]["rules_reported"] > 0
+
+    def test_build_scraper_404_fixture_writes_both_sources_as_documented(self, db):
+        """Direct proof, independent of the probe's reporting layer, that
+        _build_scraper_404_fixture writes what its own docstring claims:
+        the middleware IP's rows all carry source=middleware and the nginx
+        IP's rows all carry source=nginx_log, both allowed/404, both sized
+        to conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS + 1.
+        """
+        from django_waf import conf
+        from django_waf.enums import RequestLogSource, Verdict
+        from django_waf.models import RequestLog
+        from django_waf.services.detector_probe import (
+            _SCRAPER_404_IP,
+            _SCRAPER_404_NGINX_IP,
+            _build_scraper_404_fixture,
+        )
+
+        expected_count = conf.DJANGO_WAF_SCRAPER_404_MIN_REQUESTS + 1
+
+        _build_scraper_404_fixture(now=timezone.now(), conf=conf)
+
+        middleware_rows = RequestLog.objects.filter(ip_address=_SCRAPER_404_IP)
+        nginx_rows = RequestLog.objects.filter(ip_address=_SCRAPER_404_NGINX_IP)
+
+        assert middleware_rows.count() == expected_count
+        assert nginx_rows.count() == expected_count
+        for row in middleware_rows:
+            assert row.source == RequestLogSource.MIDDLEWARE
+            assert row.verdict == Verdict.ALLOWED
+            assert row.response_code == 404
+        for row in nginx_rows:
+            assert row.source == RequestLogSource.NGINX_LOG
+            assert row.verdict == Verdict.ALLOWED
+            assert row.response_code == 404
+
 
 # ---------------------------------------------------------------------------
 # run_detector_probe: BlockRule history must not silence a healthy detector
@@ -481,13 +583,13 @@ class TestRunDetectorProbeSurvivesBlockRuleHistory:
     the probe's fixture window regardless of which detector's fixture
     wrote it (see detector_probe.py's own module comment), so the combined
     volume from three OTHER detectors' fixture IPs sharing 192.0.2.0/24
-    (_UA_ROTATION_IP, _UNSOLVED_CHALLENGE_IP, _SCRAPER_404_IP) already
-    clears its burst floor on its own, independently of
-    _SUBNET_BURST_SUBNET_BASE (198.51.100.0/24). A control that seeded
-    only the 198.51.100.0/24 collision left the 192.0.2.0/24 rule free to
-    create normally, so detect_subnet_burst kept reporting alive even with
-    the fix reverted, a genuinely vacuous control caught by running it
-    against the real code before trusting it.
+    (_UA_ROTATION_IP, _UNSOLVED_CHALLENGE_IP, _SCRAPER_404_IP,
+    _SCRAPER_404_NGINX_IP) already clears its burst floor on its own,
+    independently of _SUBNET_BURST_SUBNET_BASE (198.51.100.0/24). A
+    control that seeded only the 198.51.100.0/24 collision left the
+    192.0.2.0/24 rule free to create normally, so detect_subnet_burst kept
+    reporting alive even with the fix reverted, a genuinely vacuous
+    control caught by running it against the real code before trusting it.
     """
 
     # detector_name -> list of (rule_type, match_type, pattern, action)
@@ -516,6 +618,7 @@ class TestRunDetectorProbeSurvivesBlockRuleHistory:
         ],
         "detect_scraper_404_ratio": [
             (RuleType.IP, MatchType.EXACT, "192.0.2.90", RuleAction.CHALLENGE),
+            (RuleType.IP, MatchType.EXACT, "192.0.2.91", RuleAction.CHALLENGE),
         ],
     }
 
@@ -560,6 +663,11 @@ class TestRunDetectorProbeSurvivesBlockRuleHistory:
             f"{detector_name} reported SILENT with a stale BlockRule collision present: {result[detector_name]}"
         )
         assert result[detector_name]["rules_reported"] > 0
+        if detector_name == "detect_scraper_404_ratio":
+            # Both fixture patterns (.90 and .91) are seeded as stale
+            # collisions above; count_refresh_as_created=True must keep
+            # BOTH counted, not just clear the floor by one.
+            assert result[detector_name]["rules_reported"] == 2
 
     @pytest.mark.parametrize("detector_name", sorted(_COLLIDING_FIXTURE_ROWS))
     def test_seeding_a_collision_without_the_fix_reproduces_the_defect(self, db, detector_name):
@@ -618,8 +726,11 @@ class TestRunDetectorProbeReportingLogic:
             "challenge_farm_rules": 1,
             "unsolved_challenge_rules": 1,
             "cloud_spray_rules": 1,
-            "scraper_404_rules": 1,
-            "total_rules_created": 5,
+            # 2, not 1: detect_scraper_404_ratio has its own _MIN_RULES_REPORTED
+            # floor of 2 (one per source). This class pins the reporting layer,
+            # not that floor, so every other key stays at a plain alive value.
+            "scraper_404_rules": 2,
+            "total_rules_created": 6,
         }
 
         with patch(
@@ -643,8 +754,10 @@ class TestRunDetectorProbeReportingLogic:
             "challenge_farm_rules": 1,
             "unsolved_challenge_rules": 1,
             "cloud_spray_rules": 1,
-            "scraper_404_rules": 1,
-            "total_rules_created": 4,
+            # 2, not 1: detect_scraper_404_ratio has its own _MIN_RULES_REPORTED
+            # floor of 2 (one per source), and this test is not exercising that.
+            "scraper_404_rules": 2,
+            "total_rules_created": 5,
         }
 
         with patch(


### PR DESCRIPTION
Closes icvoss/django-waf#145.

## What

`services/detector_probe.py`:

- `_build_scraper_404_fixture`'s docstring no longer names `passed` as a countable verdict. The detector counts `Verdict.ALLOWED` and `Verdict.LOGGED` only and excludes `Verdict.PASSED` (an AllowRule match, BR-ANOM-014). The code was already right; only the prose was wrong.
- The fixture now builds two IPs instead of one: `192.0.2.90` with `source=middleware` (explicit, previously the silent model default) and `192.0.2.91` with `source=nginx_log`, each with `DJANGO_WAF_SCRAPER_404_MIN_REQUESTS + 1` `verdict=allowed` rows at 100% 404. Two keyword-only flags, `include_middleware` and `include_nginx`, let a test drop one source.
- `run_detector_probe` gains a per-detector floor, `_MIN_RULES_REPORTED = {"detect_scraper_404_ratio": 2}`; every other detector keeps the at-least-one contract.

Why two IPs and a floor rather than one mixed set: the detector has no `source` filter, so with a single IP a regression that dropped every nginx row would still leave enough middleware rows to cross the threshold and the probe would stay green. Two independently qualifying IPs plus the floor of 2 means losing either ingest path drops `rules_reported` to 1 and the probe goes red.

## Behaviour change for operators

`django_waf_probe_detectors` now reports `detect_scraper_404_ratio` SILENT if either ingest path stops producing a rule. On a healthy deployment its `rules_reported` is 2, up from 1. No detector, threshold, or enforcement behaviour changes.

## Tests

- Baseline green test now asserts `rules_reported == 2` for the scraper detector.
- Two control tests prove the probe can see a missing source: builder patched to `include_nginx=False` and to `include_middleware=False`, each yielding `silent_detectors == ["detect_scraper_404_ratio"]` with `rules_reported == 1`.
- A direct fixture test queries `RequestLog` and asserts each IP's rows carry the documented `source`, `verdict=allowed`, `response_code=404`, and the config-derived count.
- The BlockRule-collision parametrisation seeds a stale rule on both fixture patterns, and the survival test asserts the scraper count stays exactly 2 under `count_refresh_as_created=True`.
- Two pre-existing hand-written reporting-layer tests that assumed `scraper_404_rules: 1` were updated to 2 with a comment.

## Verification

- Tester ran the gates CI runs, from the worktree with `PYTHONPATH=src` and the module path printed first: full `tests/` 1471 passed, 6 skipped (the self-guarded real-Redis file), exit 0; `ruff check` and `ruff format --check` clean; mypy clean on the changed file (three pre-existing `geoip.py` stub errors are unrelated, no diff there); `scripts/check_br_citations.py` citations=67 rules=120 reconcile=True exit 0.
- Teeth check: with the alive line reverted to `rules_reported > 0`, both control tests fail on `all_alive`, then the line was restored.
- Reviewer pass against `anomaly_detector.py`, `enums.py`, `models.py`, and umbrella BR-ANOM-012 and BR-ANOM-014: one blocker (the two reporting-layer tests, fixed), one attribution correction (the 98.3% figure is #135's measurement, not the detector docstring's), one assertion tightened.
- CI's full matrix is the authority on mypy 2.3.1 with django-stubs 6.1.0 and on the Redis 6.0 leg.

## Spec

Umbrella spec lines that now need amending (BR-ANOM-012 "at least one rule", the 03-services fixture table row and its `rules_reported > 0` sentence, and two new ACs) are filed on the umbrella tracker; the issue number is added in a comment below once this PR has a number to cite.
