### PR TITLE
feat(conf): cache through ICV_CACHES_ALIAS and chain DJANGO_WAF_REDIS_ALIAS onto it (#149)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+
+- Caching now routes through the fleet-global `ICV_CACHES_ALIAS` setting
+  (ADR-037) rather than always using the `"default"` Django cache: the
+  threat-feed install id, the nginx access-log ingest task's offset, and
+  the Redis-unavailable rule-version fallback all resolve their cache alias
+  from `ICV_CACHES_ALIAS` (falling back to `"default"` when it is unset).
+  A consumer with neither setting configured sees no change (#149).
+- `DJANGO_WAF_REDIS_ALIAS` now defaults to the resolved `ICV_CACHES_ALIAS`
+  instead of the literal `"default"`; an explicit `DJANGO_WAF_REDIS_ALIAS`
+  still wins (ADR-037 second amendment, case 2). One consequence a
+  consumer can hit without changing their own code: if `ICV_CACHES_ALIAS`
+  points at a cache that is not backed by `django_redis.cache.RedisCache`
+  and `DJANGO_WAF_REDIS_ALIAS` is unset, `manage.py check` now raises
+  `django_waf.E004` against that alias, where it previously checked
+  `"default"`. Set `DJANGO_WAF_REDIS_ALIAS` explicitly to a Redis-backed
+  alias to keep the WAF's Redis-only stores on their own cache (#149).
+
 ### Fixed
 
 - `services.detector_probe`: `_build_scraper_404_fixture`'s docstring

--- a/README.md
+++ b/README.md
@@ -156,7 +156,8 @@ All settings are namespaced under `DJANGO_WAF_*` and have sensible defaults.
 | `DJANGO_WAF_TRUST_X_FORWARDED_FOR` | `False` | Trust `X-Forwarded-For` header for client IP extraction |
 | `DJANGO_WAF_TRUSTED_PROXIES` | `[]` | CIDR ranges for direct TCP reverse proxies. When `REMOTE_ADDR` is in a configured range, resolve `X-Forwarded-For` from right to left, skipping trusted proxy hops |
 | `DJANGO_WAF_TRUSTED_UNIX_SOCKET` | `False` | Explicitly trust an empty `REMOTE_ADDR` from a unix-socket WSGI peer and use the same right-to-left `X-Forwarded-For` walk. Enable only when the socket is accessible exclusively to your reverse proxy |
-| `DJANGO_WAF_REDIS_ALIAS` | `"default"` | Django cache alias for Redis connections |
+| `ICV_CACHES_ALIAS` | `"default"` | Fleet-global Django cache alias (ADR-037) the package caches through by default: the threat-feed install id, the nginx log ingest task's offset, and the Redis-unavailable rule-version fallback. Shared across the whole icv fleet, not django-waf-specific |
+| `DJANGO_WAF_REDIS_ALIAS` | The resolved `ICV_CACHES_ALIAS` (itself `"default"` unless set) | Django cache alias the WAF requires to be backed by Redis, for rate-limit counters and rule-version keys. Follows the resolved `ICV_CACHES_ALIAS` unless set explicitly. If `ICV_CACHES_ALIAS` points at a non-Redis cache, set this explicitly or `django_waf.E004` fires at check time |
 | `DJANGO_WAF_ALLOWED_METHODS` | `None` | Allowed HTTP methods; requests with other methods receive 405 before rule evaluation. `None` allows all methods. |
 | `DJANGO_WAF_ALLOW_VERIFIED_CRAWLERS` | `True` | Seed rDNS-verified `AllowRule` rows for major search crawlers (Googlebot, Bingbot) so a verified crawler is never served the `noindex` challenge. See [Search engine crawlers](#search-engine-crawlers). Set `False` to opt out |
 

--- a/src/django_waf/conf.py
+++ b/src/django_waf/conf.py
@@ -338,9 +338,24 @@ def _DJANGO_WAF_TRUST_X_FORWARDED_FOR() -> bool:
     return _get_setting("DJANGO_WAF_TRUST_X_FORWARDED_FOR", False)
 
 
-# Django cache alias used for Redis rate-limit counters and rule-version keys.
+# Fleet-global cache alias (ADR-037, "Amendment 2026-09-04"): which
+# configured django.core.cache.caches entry every icv package caches
+# through by default. Not a django_waf-specific setting; every package in
+# the fleet resolves the same name the same way.
+def _ICV_CACHES_ALIAS() -> str:
+    return _get_setting("ICV_CACHES_ALIAS", "default")
+
+
+# Django cache alias used for Redis rate-limit counters and rule-version
+# keys. A package-scoped alias is still warranted here (ADR-037, second
+# 2026-09-04 amendment, case 2): this package requires the resolved alias to
+# be backed by Redis specifically (rule 5), which ICV_CACHES_ALIAS alone
+# does not guarantee. Defaults onto the resolved fleet-global alias rather
+# than the literal "default", so a consumer that has already pointed the
+# fleet at a shared cache does not also have to repeat that choice here;
+# an explicit DJANGO_WAF_REDIS_ALIAS still wins (most specific wins, #149).
 def _DJANGO_WAF_REDIS_ALIAS() -> str:
-    return _get_setting("DJANGO_WAF_REDIS_ALIAS", "default")
+    return _get_setting("DJANGO_WAF_REDIS_ALIAS", _ICV_CACHES_ALIAS())
 
 
 # Enable syncing rules from the collective threat feed.
@@ -1285,8 +1300,9 @@ def _DJANGO_WAF_SCRAPER_404_ACTION_BLOCK() -> bool:
 # ---------------------------------------------------------------------------
 # PEP 562 module-level __getattr__ / __dir__: call-time resolution (#75)
 # ---------------------------------------------------------------------------
-# Every DJANGO_WAF_* name above is a private ``_NAME()`` resolver function,
-# never a module-level constant, specifically so that ``conf.DJANGO_WAF_X``
+# Every DJANGO_WAF_* name above, and every fleet-global ICV_* name (ADR-037,
+# e.g. ICV_CACHES_ALIAS), is a private ``_NAME()`` resolver function, never
+# a module-level constant, specifically so that ``conf.DJANGO_WAF_X``
 # re-consults django.conf.settings on every access rather than freezing a
 # value read once at import time. __getattr__ is only called by Python when
 # normal attribute lookup fails (i.e. the name is not in this module's
@@ -1306,8 +1322,9 @@ def _DJANGO_WAF_SCRAPER_404_ACTION_BLOCK() -> bool:
 # use monkeypatch.setattr(conf, "NAME", ...) in a consumer's own tests for
 # this reason; use unittest.mock.patch.object (as this package's own test
 # suite does throughout) or override_settings instead.
+_RESOLVER_PREFIXES = ("_DJANGO_WAF_", "_ICV_")
 _RESOLVERS: dict[str, Any] = {
-    name[1:]: func for name, func in list(globals().items()) if name.startswith("_DJANGO_WAF_") and callable(func)
+    name[1:]: func for name, func in list(globals().items()) if name.startswith(_RESOLVER_PREFIXES) and callable(func)
 }
 
 

--- a/src/django_waf/services/redis_client.py
+++ b/src/django_waf/services/redis_client.py
@@ -127,7 +127,19 @@ def is_redis_backend(alias: str | None = None) -> bool:
     """
     from django.conf import settings
 
-    resolved_alias = alias or getattr(settings, "DJANGO_WAF_REDIS_ALIAS", "default")
+    # Deliberately bypasses django_waf.conf here rather than reading
+    # conf.DJANGO_WAF_REDIS_ALIAS: this helper backs django_waf.E004, a
+    # boot-time system check, and conf's call-time resolvers already
+    # tolerate settings being unconfigured, but a plain getattr chain keeps
+    # this module's contract (see the module docstring: no partial Redis
+    # adapter, no hidden fallback machinery) independent of conf's own
+    # behaviour. Chains onto the fleet-global ICV_CACHES_ALIAS (ADR-037)
+    # the same way conf.DJANGO_WAF_REDIS_ALIAS does, so a consumer that
+    # only sets the fleet alias still gets its Redis check pointed at the
+    # right cache; an explicit DJANGO_WAF_REDIS_ALIAS still wins.
+    resolved_alias = alias or getattr(
+        settings, "DJANGO_WAF_REDIS_ALIAS", getattr(settings, "ICV_CACHES_ALIAS", "default")
+    )
 
     caches_setting = getattr(settings, "CACHES", {})
     backend = caches_setting.get(resolved_alias, {}).get("BACKEND", "")

--- a/src/django_waf/services/threat_feed.py
+++ b/src/django_waf/services/threat_feed.py
@@ -526,7 +526,11 @@ def get_or_create_install_id() -> str:
     """
     import os
 
-    from django.core.cache import cache
+    from django.core.cache import caches
+
+    from django_waf import conf
+
+    cache = caches[conf.ICV_CACHES_ALIAS]
 
     cached = cache.get(_INSTALL_ID_SETTING)
     if cached:

--- a/src/django_waf/tasks.py
+++ b/src/django_waf/tasks.py
@@ -121,13 +121,15 @@ def parse_access_log(log_path: str | None = None) -> dict:
     """
     import os
 
-    from django.core.cache import cache
+    from django.core.cache import caches
     from django.core.exceptions import ValidationError as DjangoValidationError
     from django.core.validators import validate_ipv46_address
 
     from django_waf import conf
     from django_waf.enums import RequestLogSource
     from django_waf.models import RequestLog
+
+    cache = caches[conf.ICV_CACHES_ALIAS]
 
     path = log_path or conf.DJANGO_WAF_ACCESS_LOG_PATH
 
@@ -1020,7 +1022,9 @@ def _invalidate_rule_cache_redis() -> None:
             "django-waf: Redis unavailable for rule cache invalidation, falling back to the local Django "
             "cache (other worker processes will not see this invalidation until Redis recovers)"
         )
-        from django.core.cache import cache
+        from django.core.cache import caches
+
+        cache = caches[conf.ICV_CACHES_ALIAS]
 
         version = (cache.get("waf:rules:version") or 0) + 1
         cache.set("waf:rules:version", version)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -915,6 +915,62 @@ class TestRedisBackendCheck:
             assert _run_redis_backend_check() == []
 
 
+class TestRedisBackendCheckIcvCachesAliasConsequence:
+    """#149 / ADR-037 case 2: DJANGO_WAF_REDIS_ALIAS now defaults onto the
+    resolved ICV_CACHES_ALIAS rather than the literal "default" (conf.py's
+    ``_DJANGO_WAF_REDIS_ALIAS``). This is the one boot-time consequence a
+    consumer can hit without changing their own code: a project that already
+    points ICV_CACHES_ALIAS at a non-Redis cache alias, and never had reason
+    to set DJANGO_WAF_REDIS_ALIAS because it previously and silently checked
+    "default", now gets django_waf.E004 at check time. Exercised against
+    real settings.CACHES with is_redis_backend unmocked, unlike the other
+    E004 tests, because the chain being pinned lives in conf.py's resolver
+    itself, not in check_redis_backend's own logic."""
+
+    def test_fires_when_icv_caches_alias_points_at_a_non_redis_cache_and_redis_alias_is_unset(self):
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            override_settings(
+                CACHES={
+                    "default": {
+                        "BACKEND": "django_redis.cache.RedisCache",
+                        "LOCATION": "redis://localhost:6379/0",
+                    },
+                    "fleet": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+                },
+                ICV_CACHES_ALIAS="fleet",
+            ),
+        ):
+            messages = _run_redis_backend_check()
+
+        assert any(m.id == "django_waf.E004" for m in messages)
+        assert any("fleet" in m.msg for m in messages)
+
+    def test_silent_when_django_waf_redis_alias_is_set_explicitly(self):
+        """Most specific wins (#149): setting DJANGO_WAF_REDIS_ALIAS
+        explicitly to a Redis alias restores a clean check even though
+        ICV_CACHES_ALIAS still points at the non-Redis alias."""
+        import django_waf.conf as conf_mod
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ENABLED", True),
+            override_settings(
+                CACHES={
+                    "default": {
+                        "BACKEND": "django_redis.cache.RedisCache",
+                        "LOCATION": "redis://localhost:6379/0",
+                    },
+                    "fleet": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+                },
+                ICV_CACHES_ALIAS="fleet",
+                DJANGO_WAF_REDIS_ALIAS="default",
+            ),
+        ):
+            assert _run_redis_backend_check() == []
+
+
 class TestRedisVersionCheck:
     """E005 errors when the connected Redis server reports a version below
     MIN_REDIS_VERSION (currently 6.0, see #78: getdel silently failed on a

--- a/tests/test_conf.py
+++ b/tests/test_conf.py
@@ -182,6 +182,84 @@ class TestCallTimeResolution:
             _ = conf_mod.DJANGO_WAF_FORM_REPLAY_STORE
 
 
+class TestIcvCachesAliasChaining:
+    """ICV_CACHES_ALIAS (ADR-037) and its DJANGO_WAF_REDIS_ALIAS chain (#149).
+
+    ADR-037's second 2026-09-04 amendment, case 2: DJANGO_WAF_REDIS_ALIAS is
+    a package-scoped rule-5 concern (this package requires the alias to be
+    Redis specifically) that defaults onto the resolved fleet-global
+    ICV_CACHES_ALIAS rather than the literal "default", most specific wins.
+    """
+
+    def test_icv_caches_alias_defaults_to_default(self):
+        assert conf_mod.ICV_CACHES_ALIAS == "default"
+
+    def test_icv_caches_alias_follows_the_setting(self, settings):
+        settings.ICV_CACHES_ALIAS = "fleet"
+        assert conf_mod.ICV_CACHES_ALIAS == "fleet"
+
+    def test_redis_alias_defaults_to_default_when_neither_is_set(self):
+        assert conf_mod.DJANGO_WAF_REDIS_ALIAS == "default"
+
+    def test_redis_alias_follows_icv_caches_alias_when_only_that_is_set(self, settings):
+        settings.ICV_CACHES_ALIAS = "fleet"
+        assert conf_mod.DJANGO_WAF_REDIS_ALIAS == "fleet"
+
+    def test_redis_alias_follows_its_own_explicit_value_when_both_are_set(self, settings):
+        """Most specific wins: an explicit DJANGO_WAF_REDIS_ALIAS is never
+        overridden by ICV_CACHES_ALIAS, even when both are set."""
+        settings.ICV_CACHES_ALIAS = "fleet"
+        settings.DJANGO_WAF_REDIS_ALIAS = "waf-specific"
+        assert conf_mod.DJANGO_WAF_REDIS_ALIAS == "waf-specific"
+
+    def test_dir_includes_icv_caches_alias(self):
+        assert "ICV_CACHES_ALIAS" in dir(conf_mod)
+
+
+class TestIsRedisBackendIcvCachesAliasChaining:
+    """is_redis_backend() (services/redis_client.py) resolves its default
+    alias independently of django_waf.conf (a deliberate boot-time-check
+    seam, see that function's docstring), so it chains onto ICV_CACHES_ALIAS
+    via its own getattr fallback rather than through conf.DJANGO_WAF_REDIS_ALIAS.
+    Proven here as its own three-way case so the two independent resolution
+    paths cannot silently diverge (#149).
+    """
+
+    def test_defaults_to_default_when_neither_is_set(self):
+        from django_waf.services.redis_client import is_redis_backend
+
+        with override_settings(
+            CACHES={"default": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": "redis://localhost:6379/0"}}
+        ):
+            assert is_redis_backend() is True
+
+    def test_follows_icv_caches_alias_when_only_that_is_set(self):
+        from django_waf.services.redis_client import is_redis_backend
+
+        with override_settings(
+            CACHES={
+                "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+                "fleet": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": "redis://localhost:6379/1"},
+            },
+            ICV_CACHES_ALIAS="fleet",
+        ):
+            assert is_redis_backend() is True
+
+    def test_follows_its_own_explicit_value_when_both_are_set(self):
+        from django_waf.services.redis_client import is_redis_backend
+
+        with override_settings(
+            CACHES={
+                "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+                "fleet": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+                "waf-specific": {"BACKEND": "django_redis.cache.RedisCache", "LOCATION": "redis://localhost:6379/2"},
+            },
+            ICV_CACHES_ALIAS="fleet",
+            DJANGO_WAF_REDIS_ALIAS="waf-specific",
+        ):
+            assert is_redis_backend() is True
+
+
 class TestSitePasswordEnabledDerivation:
     """DJANGO_WAF_SITE_PASSWORD_ENABLED recurses through the resolver for
     DJANGO_WAF_SITE_PASSWORD (HAZARD 2), the one intra-conf cross-reference

--- a/tests/test_log_ingestion.py
+++ b/tests/test_log_ingestion.py
@@ -120,6 +120,48 @@ class TestReingestionDedup:
         assert RequestLog.objects.count() == 2
 
 
+class TestIcvCachesAliasRouting:
+    @pytest.mark.django_db
+    def test_offset_key_is_written_to_the_configured_alias_and_not_default(self):
+        """parse_access_log's offset cache routes through ICV_CACHES_ALIAS
+        (#149, ADR-037), proven against two real, distinct LocMemCache
+        aliases so a regression that keeps writing to "default" cannot pass
+        unnoticed.
+        """
+        from django.core.cache import caches
+        from django.test import override_settings
+
+        from django_waf.tasks import parse_access_log
+
+        log_content = '1.2.3.4 - - [07/Apr/2026:10:00:00 +0000] "GET /page/1/ HTTP/1.1" 200 1234 "-" "ua"\n'
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as fh:
+            fh.write(log_content)
+            log_path = fh.name
+
+        offset_key = f"django_waf:access_log_offset:{log_path}"
+
+        with override_settings(
+            CACHES={
+                "default": {
+                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                    "LOCATION": "icv-caches-alias-default",
+                },
+                "icv": {
+                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                    "LOCATION": "icv-caches-alias-icv",
+                },
+            },
+            ICV_CACHES_ALIAS="icv",
+        ):
+            caches["default"].delete(offset_key)
+            caches["icv"].delete(offset_key)
+
+            parse_access_log(log_path=log_path)
+
+            assert caches["icv"].get(offset_key) is not None
+            assert caches["default"].get(offset_key) is None
+
+
 # ---------------------------------------------------------------------------
 # real log-line timestamps
 # ---------------------------------------------------------------------------

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -3103,13 +3103,26 @@ class TestSubmitTelemetry:
 
 
 class TestGetOrCreateInstallId:
+    """get_or_create_install_id caches through django.core.cache.caches[alias]
+    (#149, ADR-037), not the bare ``cache`` proxy, so these tests patch
+    ``django.core.cache.caches`` with a mapping whose ``__getitem__`` returns
+    the mock, rather than patching ``django.core.cache.cache`` directly
+    (which the function under test no longer touches).
+    """
+
+    def _patched_caches(self, mock_cache):
+        mapping = MagicMock()
+        mapping.__getitem__.return_value = mock_cache
+        return patch("django.core.cache.caches", mapping)
+
     def test_returns_cached_value_without_file_io(self):
         """Returns the install_id from Django cache without touching the filesystem."""
         from django_waf.services.threat_feed import get_or_create_install_id
 
-        with patch("django.core.cache.cache") as mock_cache:
-            mock_cache.get.return_value = "cached-install-id"
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = "cached-install-id"
 
+        with self._patched_caches(mock_cache):
             result = get_or_create_install_id()
 
         assert result == "cached-install-id"
@@ -3120,13 +3133,14 @@ class TestGetOrCreateInstallId:
 
         from django_waf.services.threat_feed import get_or_create_install_id
 
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
         with (
-            patch("django.core.cache.cache") as mock_cache,
+            self._patched_caches(mock_cache),
             patch("os.path.isfile", return_value=True),
             patch("builtins.open", mock_open(read_data="file-install-id")),
         ):
-            mock_cache.get.return_value = None
-
             result = get_or_create_install_id()
 
         assert result == "file-install-id"
@@ -3137,14 +3151,15 @@ class TestGetOrCreateInstallId:
 
         from django_waf.services.threat_feed import get_or_create_install_id
 
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
         with (
-            patch("django.core.cache.cache") as mock_cache,
+            self._patched_caches(mock_cache),
             patch("os.path.isfile", return_value=False),
             patch("uuid.uuid4", return_value=uuid_mod.UUID("12345678-1234-5678-1234-567812345678")),
             patch("builtins.open", side_effect=OSError("no write")),
         ):
-            mock_cache.get.return_value = None
-
             result = get_or_create_install_id()
 
         assert result == "12345678-1234-5678-1234-567812345678"
@@ -3154,16 +3169,57 @@ class TestGetOrCreateInstallId:
         """A freshly generated install_id is stored in the Django cache."""
         from django_waf.services.threat_feed import get_or_create_install_id
 
+        mock_cache = MagicMock()
+        mock_cache.get.return_value = None
+
         with (
-            patch("django.core.cache.cache") as mock_cache,
+            self._patched_caches(mock_cache),
             patch("os.path.isfile", return_value=False),
             patch("builtins.open", side_effect=OSError("no write")),
         ):
-            mock_cache.get.return_value = None
-
             get_or_create_install_id()
 
         assert mock_cache.set.called
+
+
+class TestGetOrCreateInstallIdIcvCachesAliasRouting:
+    """get_or_create_install_id routes through ICV_CACHES_ALIAS (#149,
+    ADR-037), proven against two real, distinct LocMemCache aliases rather
+    than a mock: writing to the wrong alias and reading it back from the
+    right one would pass a mocked test that only asserts "some cache was
+    called", so this uses ``django.core.cache.caches`` for real.
+    """
+
+    def test_writes_to_the_configured_alias_and_not_default(self):
+        from django.core.cache import caches
+        from django.test import override_settings
+
+        from django_waf.services.threat_feed import _INSTALL_ID_SETTING, get_or_create_install_id
+
+        with override_settings(
+            CACHES={
+                "default": {
+                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                    "LOCATION": "icv-caches-alias-default",
+                },
+                "icv": {
+                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                    "LOCATION": "icv-caches-alias-icv",
+                },
+            },
+            ICV_CACHES_ALIAS="icv",
+        ):
+            caches["default"].clear()
+            caches["icv"].clear()
+
+            with (
+                patch("os.path.isfile", return_value=False),
+                patch("builtins.open", side_effect=OSError("no write")),
+            ):
+                install_id = get_or_create_install_id()
+
+            assert caches["icv"].get(_INSTALL_ID_SETTING) == install_id
+            assert caches["default"].get(_INSTALL_ID_SETTING) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_silent_failure_sites.py
+++ b/tests/test_silent_failure_sites.py
@@ -162,6 +162,38 @@ class TestInvalidateRuleCacheRedisFailure:
             "Django cache; before #78 this except branch was silent"
         )
 
+    def test_fallback_routes_through_icv_caches_alias(self):
+        """The Django cache fallback routes through ICV_CACHES_ALIAS (#149,
+        ADR-037), proven against two real, distinct LocMemCache aliases so a
+        regression that keeps writing to "default" cannot pass unnoticed.
+        """
+        from django.core.cache import caches
+        from django.test import override_settings
+
+        from django_waf.tasks import _invalidate_rule_cache_redis
+
+        with override_settings(
+            CACHES={
+                "default": {
+                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                    "LOCATION": "icv-caches-alias-default",
+                },
+                "icv": {
+                    "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+                    "LOCATION": "icv-caches-alias-icv",
+                },
+            },
+            ICV_CACHES_ALIAS="icv",
+        ):
+            caches["default"].delete("waf:rules:version")
+            caches["icv"].delete("waf:rules:version")
+
+            with mock_redis_connection_raises(RuntimeError("redis down")):
+                _invalidate_rule_cache_redis()
+
+            assert caches["icv"].get("waf:rules:version") == 1
+            assert caches["default"].get("waf:rules:version") is None
+
 
 # ---------------------------------------------------------------------------
 # expire_rules: the caller, proving the fail-open contract end to end


### PR DESCRIPTION
Closes icvoss/django-waf#149. ADR-037 ride-along (both 2026-09-04 amendments; fleet sweep icvoss/icv-oss-umbrella#609, case 2 ruled in #613/#616), taken now because the package was touched twice today.

## What

- `conf.py`: `ICV_CACHES_ALIAS` is resolved at call time like every other name (the PEP 562 resolver prefix set now includes `_ICV_`), default `"default"`. `DJANGO_WAF_REDIS_ALIAS` defaults to the resolved `ICV_CACHES_ALIAS` instead of the literal `"default"`; an explicit value still wins. No rename, no deprecation alias, per the owner's ruling on the issue.
- Three default-alias cache sites now use `caches[conf.ICV_CACHES_ALIAS]`: the threat-feed install id, the nginx access-log ingest task's offset key, and the Redis-unavailable rule-version fallback. These were the only `from django.core.cache import cache` sites under `src/`.
- `services/redis_client.py` `is_redis_backend`'s no-argument fallback chains the same way, keeping its documented reason for bypassing `conf`.
- README: new `ICV_CACHES_ALIAS` row, updated `DJANGO_WAF_REDIS_ALIAS` row. CHANGELOG: two `### Changed` bullets.

## Behaviour change for consumers

- Neither setting configured: no change.
- `ICV_CACHES_ALIAS` set: the three sites above cache through that alias, and the WAF's Redis-only stores follow it too unless `DJANGO_WAF_REDIS_ALIAS` is set.
- `ICV_CACHES_ALIAS` pointing at a non-Redis cache with `DJANGO_WAF_REDIS_ALIAS` unset: `manage.py check` now raises `django_waf.E004` against that alias where it previously checked `"default"`. This is the intended consequence under the ADR (most specific wins) and is named in the CHANGELOG and README. Set `DJANGO_WAF_REDIS_ALIAS` explicitly to a Redis-backed alias.

## Tests

- Routing tests with two real distinct LocMemCache aliases prove each site writes to `caches["icv"]` and not `caches["default"]` (install id in test_services.py, ingest offset in test_log_ingestion.py, rule-version fallback in test_silent_failure_sites.py).
- Three-way precedence tests in test_conf.py for `conf.DJANGO_WAF_REDIS_ALIAS` and for `is_redis_backend`'s fallback: neither set, fleet alias only, both set.
- E004 consequence pinned in test_checks.py: fires and names the fleet alias when it is non-Redis and the package alias is unset; silent when the package alias is set explicitly.
- The four existing install-id tests moved their patch target from the `cache` proxy to `caches`, with the same assertions.

## Verification

- Tester ran the gates CI runs from the worktree with `PYTHONPATH=src` and the resolved module path printed first: full `tests/` 1483 passed, 6 skipped (the self-guarded real-Redis file), exit 0, before the E004 test was added; test_checks.py 90 passed and test_conf.py 31 passed after; `ruff check` and `ruff format --check` clean; mypy clean apart from the three pre-existing `geoip.py` optional-dependency errors, none on changed lines; `scripts/check_br_citations.py` citations=67 rules=120 reconcile=True exit 0.
- Teeth: reverting the install-id site to the default alias fails its routing test; reverting the chained default fails the conf chaining test and the new E004 test. Each was restored exactly and re-run green.
- Reviewer pass against ADR-037, `conf.py`'s resolver contract, `checks.py` E004/E005, and the umbrella spec: two blockers (the undocumented E004 consequence, and no test for it), both addressed above.
- CI's full matrix is the authority on mypy 2.3.1 with django-stubs 6.1.0 and on the Redis 6.0 and PostgreSQL legs.

## Spec

Umbrella spec lines that now diverge (`04-interfaces.md:309` and `:545`, `06-threat-feed-api.md:413`, plus one new AC) are filed on the umbrella tracker; the issue number is added in a comment below.
