### PR TITLE
chore(release): 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.9.0] - 2026-09-04
 ### Changed
 
 - Caching now routes through the fleet-global `ICV_CACHES_ALIAS` setting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.8.0"
+version = "2.9.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release 2.9.0. Minor per RELEASING.md: the set includes a behaviour change (a changed default), so not a patch.

## Ships

From `CHANGELOG.md` `[2.9.0] - 2026-09-04`:

- Changed: caching routes through the fleet-global `ICV_CACHES_ALIAS` (threat-feed install id, nginx ingest offset, Redis-unavailable rule-version fallback); `DJANGO_WAF_REDIS_ALIAS` defaults to the resolved `ICV_CACHES_ALIAS` instead of `"default"`, explicit value still wins (#149, PR #151).
- Fixed: the detector liveness probe's scraper-404 fixture now exercises `source=nginx_log` as well as `source=middleware`, and the probe requires a rule for each (#145, PR #150).
- Fixed: README documents that the login flow must call `waf_record_credential_failure` (PR #148).

## Behaviour change for existing consumers on upgrade

- Neither `ICV_CACHES_ALIAS` nor `DJANGO_WAF_REDIS_ALIAS` set: no change.
- `ICV_CACHES_ALIAS` set: the three cache sites above and the WAF's Redis-only stores follow it unless `DJANGO_WAF_REDIS_ALIAS` is set.
- `ICV_CACHES_ALIAS` pointing at a non-Redis cache with `DJANGO_WAF_REDIS_ALIAS` unset: `manage.py check` now raises `django_waf.E004` against that alias. Set `DJANGO_WAF_REDIS_ALIAS` to a Redis-backed alias.
- `django_waf_probe_detectors` reports `detect_scraper_404_ratio` with `rules_reported` 2 on a healthy deployment, up from 1, and SILENT if either ingest path stops producing a rule.

## Bump

`pyproject.toml` 2.8.0 to 2.9.0 (the only place the version lives; `__init__` reads package metadata). `[Unreleased]` renamed to `[2.9.0] - 2026-09-04`; nothing remains under Unreleased.

## Gates

The six release preconditions from the umbrella CLAUDE.md are recorded on this PR and in the release notes before the tag is pushed.
