### PR TITLE
fix(blocklist): dedupe rendered entries and constrain the auto-rule key (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,53 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.10.0] - 2026-09-06
+### Fixed
+
+- Duplicate auto-generated `BlockRule` rows no longer render duplicate
+  entries in the generated nginx blocklist. `_render_ip_geo` and
+  `_render_ua_map` now deduplicate on the rendered key, so a `geo` or
+  `map` block carries each address or user-agent at most once per output
+  variable whatever the rule table holds. A consumer whose `nginx -t`
+  printed `[warn] duplicate network "..."` on every config test stops
+  seeing it. The block and throttle variables are unaffected: the same IP
+  under both a block and a throttle rule still appears in each, since the
+  renderers are called once per variable with disjoint rule lists (#153).
+- The anomaly detector can no longer persist two `source=auto` rules for
+  one key. Two concurrent first-time detections of the same key could each
+  miss the other's row and both insert, because `select_for_update()` on an
+  empty result set locks nothing. A partial `UniqueConstraint` on
+  `(rule_type, pattern, action)` scoped to `source=auto` now rejects the
+  losing insert, and `_update_or_create_auto_rule` catches the
+  `IntegrityError` inside a savepoint and merges into the row that won,
+  returning `created=False`. An operator's `confirmed` or `rejected` review
+  decision survives that merge unchanged (BR-ANOM-007), and the losing
+  run's detector name still joins the merged `detectors` set (#153).
+
+### Changed
+
+- **Upgrading deletes duplicate auto-generated rules.** Migration
+  `0008_dedupe_auto_block_rules` keeps the newest row per
+  `(rule_type, pattern, action)` among `source=auto` rows and deletes the
+  rest, before adding the constraint. This is the policy the detector
+  already applied whenever it re-detected a duplicated key
+  (`_deduplicate_block_rules`, keep-newest by `created_at`), so it removes
+  nothing a later detection would not have removed anyway. Rules with
+  `source=admin` or `source=feed` are **not** covered by the constraint and
+  are **not** touched by the migration: hand-curated rules may legitimately
+  repeat a shape with different names, expiries or notes. Reversing the
+  migration drops the constraint but does not restore deleted rows (#153).
+- `_get_or_create_auto_rule` now raises `BlockRule.DoesNotExist` in one new
+  and genuinely concurrent case: this run lost the insert race and the
+  winning row was then deleted before it could be merged into. Previously
+  no constraint existed, so this state was unreachable. It is surfaced
+  rather than swallowed because every caller dereferences the returned rule
+  (#153).
+
+Verified on the backends CI runs: SQLite (the matrix legs) and PostgreSQL
+(the dedicated leg). Partial-constraint enforcement is not exercised on any
+other backend.
+
 ## [2.9.0] - 2026-09-04
 ### Changed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.9.0"
+version = "2.10.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"

--- a/src/django_waf/migrations/0008_dedupe_auto_block_rules.py
+++ b/src/django_waf/migrations/0008_dedupe_auto_block_rules.py
@@ -1,0 +1,74 @@
+"""Deduplicate auto-generated BlockRule rows, then constrain the key (#153).
+
+The anomaly detector keys an auto-generated rule on
+(rule_type, pattern, source=AUTO, action). Two concurrent runs could each
+fail to see the other's row and both insert, so existing databases can hold
+duplicates for a single key. AddConstraint would fail outright on those rows,
+so the RunPython below clears them first.
+
+The forward callable is a hand-written data migration, one of the cases where
+a hand edit to a generated migration is allowed. It uses the historical model
+via apps.get_model and imports nothing from django_waf, so it stays valid
+however the app's current code later changes. It is expressed entirely in the
+ORM (no backend-specific SQL), because the suite runs on both SQLite and
+PostgreSQL.
+
+Dedupe policy mirrors _deduplicate_block_rules in
+services/anomaly_detector.py exactly: order by -created_at and keep the newest
+row of each group, deleting the rest.
+"""
+
+from django.db import migrations, models
+
+
+def dedupe_auto_block_rules(apps, schema_editor):
+    """Keep only the newest auto rule per (rule_type, pattern, action) group.
+
+    Only source="auto" rows are touched. Admin and feed rules are curated by
+    hand and are not covered by the partial constraint, so duplicates among
+    them are legitimate and must survive.
+    """
+    BlockRule = apps.get_model("django_waf", "BlockRule")
+
+    auto_rules = BlockRule.objects.filter(source="auto")
+    duplicate_keys = (
+        auto_rules.values("rule_type", "pattern", "action")
+        .annotate(row_count=models.Count("id"))
+        .filter(row_count__gt=1)
+    )
+
+    stale_pks = []
+    for key in duplicate_keys:
+        group = auto_rules.filter(
+            rule_type=key["rule_type"],
+            pattern=key["pattern"],
+            action=key["action"],
+        ).order_by("-created_at")
+        # Keep the newest, discard the rest. Matches the runtime policy in
+        # _deduplicate_block_rules: the most recent write carries the freshest
+        # detector evidence, expiry and review status.
+        stale_pks.extend(group.values_list("id", flat=True)[1:])
+
+    if stale_pks:
+        BlockRule.objects.filter(id__in=stale_pks).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("django_waf", "0007_alter_requestlog_http_fingerprint_and_more"),
+    ]
+
+    operations = [
+        # Deleted duplicate rows cannot be reconstructed, so the reverse is a
+        # noop: reversing this migration drops the constraint and leaves the
+        # surviving rows in place rather than pretending to restore data.
+        migrations.RunPython(dedupe_auto_block_rules, migrations.RunPython.noop),
+        migrations.AddConstraint(
+            model_name="blockrule",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("source", "auto")),
+                fields=("rule_type", "pattern", "action"),
+                name="django_waf_br_auto_key_uniq",
+            ),
+        ),
+    ]

--- a/src/django_waf/models.py
+++ b/src/django_waf/models.py
@@ -307,6 +307,27 @@ class BlockRule(BaseModel):
             ),
             models.Index(fields=["source", "review_status"], name="django_waf_br_review_idx"),
         ]
+        constraints = [
+            # The anomaly detector identifies an auto-generated rule by
+            # (rule_type, pattern, source=AUTO, action): that tuple is the
+            # update_or_create lookup in services/anomaly_detector.py, and
+            # match_type is a default it writes, not part of the key. Two
+            # concurrent detector runs could each miss the other's row and
+            # both insert, leaving duplicates that _deduplicate_block_rules
+            # had to clean up after the fact. This closes that race in the
+            # database instead (#153).
+            #
+            # Scoped to source=AUTO because only auto rules have a machine
+            # key: admin and feed rules are curated by hand and may
+            # legitimately repeat a (rule_type, pattern, action) shape with
+            # different names, expiries or notes. source is not in the field
+            # list because the condition already restricts the rows to it.
+            models.UniqueConstraint(
+                fields=["rule_type", "pattern", "action"],
+                condition=Q(source=RuleSource.AUTO),
+                name="django_waf_br_auto_key_uniq",
+            ),
+        ]
 
     def __str__(self) -> str:
         return f"[{self.action}] {self.name}"

--- a/src/django_waf/services/anomaly_detector.py
+++ b/src/django_waf/services/anomaly_detector.py
@@ -12,7 +12,7 @@ import logging
 from datetime import timedelta
 from decimal import ROUND_HALF_UP, Decimal
 
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 logger = logging.getLogger("django_waf.anomaly_detector")
@@ -1670,7 +1670,19 @@ def _get_or_create_auto_rule(
 
     If duplicate rows already exist (created before this function existed, or
     via a race condition), catches MultipleObjectsReturned, deduplicates by
-    keeping the newest row and deleting the rest, then retries.
+    keeping the newest row and deleting the rest, then retries. That branch is
+    still load-bearing after #153: it covers a consumer whose migration 0008
+    has not run yet, and duplicate rows the partial constraint does not cover
+    (it is scoped to source=AUTO, so hand-curated admin and feed duplicates
+    reach here unconstrained).
+
+    Losing an insert race (#153) no longer produces a duplicate row and no
+    longer escapes as an exception: the partial UniqueConstraint added in
+    migration 0008 rejects the losing INSERT, and
+    ``_update_or_create_auto_rule`` catches the IntegrityError inside a
+    savepoint and merges into the row that won instead. The losing run
+    therefore returns ``created=False``, because it refreshed an existing row
+    rather than inserting one.
 
     When ``dry_run`` is True (#38), performs a read-only existence check
     instead of update_or_create: no BlockRule is written, activated, or
@@ -1768,6 +1780,13 @@ def _get_or_create_auto_rule(
         Its ``pk`` is not unset: ``BlockRule.id`` is a UUIDField with
         ``default=uuid.uuid4``, so Django generates the UUID at
         instantiation regardless of whether the instance is ever saved.
+
+    Raises:
+        BlockRule.DoesNotExist: when this run lost the insert race and the
+            winning row was then deleted before it could be merged into, so
+            there is no rule to return. Rare and genuinely concurrent;
+            surfaced rather than swallowed because every caller dereferences
+            the returned rule.
     """
     from django_waf import conf
     from django_waf.enums import ReviewStatus, RuleSource
@@ -1862,8 +1881,83 @@ def _update_or_create_auto_rule(lookup: dict, defaults: dict, detector_name: str
     CONFIRMED/REJECTED rule's detector set still accumulates on
     re-detection exactly as an unreviewed rule's does.
 
+    Lost-race recovery (#153): since migration 0008 the auto key is backed by
+    a partial UniqueConstraint (source=AUTO), so when a concurrent run inserts
+    the same key between the read above and this write, the losing side now
+    gets an IntegrityError from the database rather than silently inserting a
+    second row. Handling it means catching that error and re-running the read,
+    guard and merge against the row that won. The retry MUST be wrapped in its
+    own savepoint: an IntegrityError inside the caller's transaction.atomic()
+    poisons the whole block, and every later query in it (including the
+    re-read) would raise TransactionManagementError instead of executing. The
+    nested atomic() opens a savepoint that rolls back just the failed INSERT,
+    leaving the outer transaction usable.
+
     Must run inside the same transaction.atomic() block as its caller so the
     read and the write are consistent.
+    """
+    from django_waf.models import BlockRule
+
+    _existing, write_defaults = _auto_rule_write_defaults(lookup, defaults, detector_name)
+
+    try:
+        with transaction.atomic():
+            return BlockRule.objects.update_or_create(**lookup, defaults=write_defaults)
+    except IntegrityError:
+        logger.warning(
+            "django-waf: concurrent insert won the auto-rule race for %s/%s, merging into the existing row",
+            lookup.get("rule_type"),
+            lookup.get("pattern"),
+        )
+
+    # The savepoint above rolled back, so the outer transaction is usable and
+    # the winning row is now visible. Re-derive the write defaults from it, so
+    # the losing run applies the SAME BR-ANOM-007 review-status guard and the
+    # SAME additive detectors merge it would have applied had it read the row
+    # first: an operator's CONFIRMED/REJECTED decision survives, and this
+    # run's detector name still joins the merged set.
+    winner, retry_defaults = _auto_rule_write_defaults(lookup, defaults, detector_name)
+    if winner is None:
+        # The winner was deleted between the IntegrityError and this re-read
+        # (an expiry sweep, an operator delete, a concurrent dedupe). Falling
+        # through to update_or_create here would silently re-insert and report
+        # created=True, contradicting the IntegrityError that just proved the
+        # key was taken, and a bare return would hand None to callers that
+        # dereference the rule. Raise instead: the caller's contract is a real
+        # BlockRule, and this state is a genuine race worth surfacing.
+        raise BlockRule.DoesNotExist(f"django-waf: auto BlockRule for {lookup} vanished after a lost insert race")
+    # The row exists, so update_or_create takes its UPDATE branch: it applies
+    # the same auto_now/save() path as the ordinary write (a queryset .update()
+    # would skip updated_at) and returns created=False, which is exactly the
+    # docstring's contract for a row that already existed and was refreshed.
+    return BlockRule.objects.update_or_create(**lookup, defaults=retry_defaults)
+
+
+def _auto_rule_write_defaults(lookup: dict, defaults: dict, detector_name: str) -> tuple:
+    """Read the stored auto rule and build the write defaults derived from it.
+
+    Returns ``(existing, write_defaults)``. ``existing`` is the stored row or
+    None; it is returned rather than discarded because the lost-race path
+    needs to know whether the winning row is still there, and re-querying for
+    that would be a second read that can disagree with this locked one.
+
+    Reads the existing (rule_type, pattern, source=AUTO, action) row under
+    ``select_for_update()`` and derives the values to write from it:
+
+    - BR-ANOM-007: when the stored row is CONFIRMED or REJECTED, ``is_active``
+      and ``review_status`` are dropped entirely, so a re-detection refreshes
+      only expires_at and the evidence fields and can never undo an operator's
+      decision.
+    - #97: ``detectors`` is merged additively against the stored value, so this
+      run contributes its name without removing any prior detector's.
+
+    Factored out because ``_update_or_create_auto_rule`` needs exactly this
+    derivation twice, once before the write and once again after losing an
+    insert race, against a row it could not see the first time. Copying the
+    two guards would let the race path drift from the ordinary path, which is
+    precisely the divergence BR-ANOM-007 forbids.
+
+    Must run inside the caller's transaction.atomic() block.
     """
     from django_waf.enums import ReviewStatus
     from django_waf.models import BlockRule
@@ -1878,8 +1972,7 @@ def _update_or_create_auto_rule(lookup: dict, defaults: dict, detector_name: str
         existing.detectors if existing is not None else "",
         detector_name,
     )
-
-    return BlockRule.objects.update_or_create(**lookup, defaults=write_defaults)
+    return existing, write_defaults
 
 
 def _deduplicate_block_rules(**lookup) -> int:

--- a/src/django_waf/services/blocklist_generator.py
+++ b/src/django_waf/services/blocklist_generator.py
@@ -134,23 +134,49 @@ def generate_nginx_blocklist(output_path: str | None = None) -> int:
 
 
 def _render_ua_map(variable: str, rules: list[BlockRule]) -> list[str]:
-    """Render an nginx ``map $http_user_agent`` block for one action's UA rules."""
+    """Render an nginx ``map $http_user_agent`` block for one action's UA rules.
+
+    Deduplicates on the rendered key rather than the rule row (#153): two
+    distinct BlockRule rows whose patterns escape to the same nginx key
+    would otherwise emit a duplicate entry, which nginx accepts but reports
+    as a warning on every ``nginx -t`` (observed on a consumer box as
+    ``nginx: [warn] duplicate network ...``). First occurrence wins, which
+    given the incoming ordering (for_nginx() builds on active(), whose
+    ``.order_by("priority")`` replaces Meta.ordering) is the lowest
+    ``priority`` value, i.e. the most significant rule for the key. Rules
+    tied on priority are in unspecified database order, but they render the
+    same key, so which one wins does not change the output.
+    """
     lines = [f"map $http_user_agent {variable} {{\n", "    default 0;\n"]
+    seen: set[str] = set()
     for rule in rules:
         escaped = _nginx_escape_ua(rule.pattern, rule.match_type)
-        if escaped:
+        if escaped and escaped not in seen:
+            seen.add(escaped)
             lines.append(f"    {escaped} 1;\n")
     lines.append("}\n\n")
     return lines
 
 
 def _render_ip_geo(variable: str, rules: list[BlockRule]) -> list[str]:
-    """Render an nginx ``geo`` block for one action's IP/CIDR rules."""
+    """Render an nginx ``geo`` block for one action's IP/CIDR rules.
+
+    Deduplicates on the rendered address rather than the rule row, for the
+    same reason as _render_ua_map (#153); a repeated address in a ``geo``
+    block is what produced the reported warning. First occurrence wins.
+
+    The ``seen`` set is local to one call, and the caller invokes this once
+    per variable with a disjoint rule list, so the block/throttle split
+    (BR-BL-001) is untouched: the same IP under both a block and a throttle
+    rule still lands in $waf_block_ip and $waf_throttle_ip alike.
+    """
     lines = [f"geo {variable} {{\n", "    default 0;\n"]
+    seen: set[str] = set()
     for rule in rules:
         # For IP rules the pattern is already a valid IP or CIDR
         safe = rule.pattern.strip()
-        if safe:
+        if safe and safe not in seen:
+            seen.add(safe)
             lines.append(f"    {safe} 1;\n")
     lines.append("}\n\n")
     return lines

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 """Shared pytest fixtures for django-waf tests."""
 
 import pytest
+from django.db import connections
+
+AUTO_KEY_CONSTRAINT = "django_waf_br_auto_key_uniq"
 
 
 @pytest.fixture(autouse=True)
@@ -13,6 +16,50 @@ def _clear_rule_cache():
     yield
     re_mod._process_cache = None
     re_mod._process_cache_version = -1
+
+
+@pytest.fixture
+def _auto_key_constraint_dropped(transactional_db):
+    """Drop the auto-key partial unique constraint for the duration of a test.
+
+    The suite builds its schema from the models (MIGRATION_MODULES disables
+    migrations), so BlockRule's partial unique constraint exists from the
+    moment the table does. A test that needs to seed the duplicate rows
+    migration 0008 was written to clean up therefore has to remove it first,
+    or the seeding itself raises IntegrityError.
+
+    ``transactional_db`` rather than ``db`` is required, not a preference.
+    Django's SQLite schema editor refuses to run inside an open atomic block
+    ("SQLite schema editor cannot be used while foreign key constraint checks
+    are enabled"), which is exactly what the ``db`` fixture holds open for the
+    whole test, so this fixture raised NotSupportedError at setup on SQLite
+    while working fine on PostgreSQL.
+
+    Because a transactional test truncates tables rather than rolling back,
+    schema changes are NOT undone automatically: the constraint is explicitly
+    restored on teardown, or every later test in the same process would run
+    against a table that has silently lost it.
+    """
+    from django_waf.models import BlockRule
+
+    constraint = next(c for c in BlockRule._meta.constraints if c.name == AUTO_KEY_CONSTRAINT)
+    connection = connections["default"]
+    with connection.schema_editor() as schema_editor:
+        schema_editor.remove_constraint(BlockRule, constraint)
+    try:
+        yield constraint
+    finally:
+        with connection.cursor() as cursor:
+            still_present = AUTO_KEY_CONSTRAINT in connection.introspection.get_constraints(
+                cursor, BlockRule._meta.db_table
+            )
+        if not still_present:
+            # A test may legitimately have re-added it itself (that is the
+            # assertion in test_constraint_applies_cleanly_after_dedupe), so
+            # only restore when it is actually missing.
+            BlockRule.objects.filter(source="auto").delete()
+            with connection.schema_editor() as schema_editor:
+                schema_editor.add_constraint(BlockRule, constraint)
 
 
 def pytest_configure(config):

--- a/tests/test_auto_rule_race.py
+++ b/tests/test_auto_rule_race.py
@@ -1,0 +1,367 @@
+"""Lost-insert-race handling for auto-generated BlockRules (#153, step 4).
+
+Migration 0008 adds a partial UniqueConstraint on
+(rule_type, pattern, action) WHERE source=auto. Before it, two concurrent
+detector runs that each read no existing row both inserted, leaving
+duplicates. With it, the losing INSERT is rejected by the database, so
+``_update_or_create_auto_rule`` must catch the IntegrityError inside a
+savepoint and merge into the row that won instead of letting the exception
+reach the consumer.
+
+House discipline, mirroring ``tests/test_detector_outcomes.py``: every
+assertion must be provably falsifiable. The race is simulated
+deterministically rather than with real threads, by ``_RaceInjector``, which
+commits the winning row outside the savepoint and forces the losing run down
+``update_or_create``'s INSERT branch so the constraint really rejects it.
+See that class's docstring for why both halves are needed and which simpler
+framings do not reproduce the race at all.
+
+Each race test pairs its assertion with a control: the no-race counterpart
+is asserted in the same file, so "created is False" is evidence of a
+refresh rather than of the return value being False under every path.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.db import IntegrityError
+from django.utils import timezone
+
+import django_waf.conf as conf_mod
+import django_waf.services.anomaly_detector as detector_mod
+from django_waf.enums import MatchType, ReviewStatus, RuleAction, RuleSource, RuleType
+from django_waf.models import BlockRule
+
+pytestmark = pytest.mark.django_db(transaction=True)
+
+
+PATTERN = "198.51.100.77"
+
+
+def _call_kwargs(**overrides) -> dict:
+    """Arguments for a single _get_or_create_auto_rule call.
+
+    Deliberately fixes the whole auto key (rule_type, pattern, action) so
+    two calls with different detector names still collide on the constraint,
+    which is the situation under test.
+    """
+    kwargs = {
+        "name": "auto-block-198.51.100.77",
+        "rule_type": RuleType.IP,
+        "match_type": MatchType.EXACT,
+        "pattern": PATTERN,
+        "action": RuleAction.BLOCK,
+        "expiry": timezone.now() + timedelta(hours=24),
+        "detector_name": "detect_ua_rotation",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+def _insert_winner(**overrides) -> BlockRule:
+    """Insert the row that "wins" the race, directly, as a rival run would.
+
+    Built with the same auto key the losing call uses, so the partial
+    UniqueConstraint sees the two as the same row.
+    """
+    fields = {
+        "name": "winner-rule",
+        "rule_type": RuleType.IP,
+        "match_type": MatchType.EXACT,
+        "pattern": PATTERN,
+        "action": RuleAction.BLOCK,
+        "source": RuleSource.AUTO,
+        "is_active": True,
+        "review_status": ReviewStatus.NOT_APPLICABLE,
+        "detectors": "detect_cloud_spray",
+        "expires_at": timezone.now() + timedelta(hours=1),
+    }
+    fields.update(overrides)
+    return BlockRule.objects.create(**fields)
+
+
+class _RaceInjector:
+    """Simulate losing the insert race, at the two points that matter.
+
+    Getting this window right needs care, and two earlier framings were
+    wrong in ways worth recording so they are not reintroduced:
+
+    1. Inserting the winner only before ``update_or_create`` is too early.
+       ``update_or_create`` performs its OWN ``get()`` and INSERTs only when
+       that raises DoesNotExist, so it would simply find the winner, take its
+       UPDATE branch, raise no IntegrityError, and never reach the recovery
+       path under test.
+    2. Inserting the winner INSIDE the savepoint that the failing INSERT
+       rolls back is also wrong. The rollback removes the winner along with
+       the failed INSERT, so the retry's existence check finds nothing and
+       the code raises DoesNotExist. In production the rival run commits in a
+       separate transaction, which a savepoint rollback cannot undo.
+
+    So the winner is inserted from the ``_auto_rule_write_defaults`` wrapper,
+    which runs BEFORE ``transaction.atomic()`` opens the savepoint, and the
+    ``update_or_create`` wrapper separately forces the INSERT branch so the
+    database actually rejects the duplicate. The winner therefore survives
+    the savepoint rollback, exactly as a committed rival row would.
+
+    ``defaults_calls`` counts the write-defaults derivations, so a test can
+    assert the retry really re-derived them rather than reusing the stale set.
+    """
+
+    def __init__(self, winner_kwargs: dict | None = None, delete_instead: bool = False):
+        self.winner_kwargs = winner_kwargs or {}
+        self.delete_instead = delete_instead
+        self.defaults_calls = 0
+        self.uoc_calls = 0
+        self.winner: BlockRule | None = None
+
+    def write_defaults(self, lookup, defaults, detector_name):
+        """Wrapper for _auto_rule_write_defaults: runs outside the savepoint."""
+        self.defaults_calls += 1
+        if self.defaults_calls == 2 and self.delete_instead:
+            # Requirement 5: the winner vanishes between the IntegrityError
+            # and the retry's re-read. Deleted BEFORE the wrapped call, so
+            # the re-read genuinely returns None: _auto_rule_write_defaults
+            # returns the row it read, and it is that returned value the
+            # production code tests, so deleting afterwards would leave a
+            # stale non-None row and the vanished-winner branch would never
+            # be reached.
+            BlockRule.objects.filter(pk=self.winner.pk).delete()
+
+        result = self.original_defaults(lookup, defaults, detector_name)
+
+        if self.defaults_calls == 1:
+            # The rival run commits its row here, in the window between this
+            # run's read (just done, saw nothing) and its INSERT below.
+            self.winner = _insert_winner(**self.winner_kwargs)
+        return result
+
+    def update_or_create(self, **kwargs):
+        """Wrapper for update_or_create: forces the INSERT branch once.
+
+        Without this the call would see the winner inserted above and take
+        its UPDATE branch, so the constraint would never fire.
+        """
+        self.uoc_calls += 1
+        if self.uoc_calls == 1:
+            lookup = {k: v for k, v in kwargs.items() if k != "defaults"}
+            fields = {**lookup, **kwargs.get("defaults", {})}
+            return BlockRule.objects.create(**fields), True
+        return self.original_uoc(**kwargs)
+
+
+@contextlib.contextmanager
+def _patched_injector(injector: _RaceInjector):
+    injector.original_defaults = detector_mod._auto_rule_write_defaults
+    injector.original_uoc = BlockRule.objects.update_or_create
+    with (
+        patch.object(detector_mod, "_auto_rule_write_defaults", injector.write_defaults),
+        patch.object(BlockRule.objects, "update_or_create", injector.update_or_create),
+    ):
+        yield injector
+
+
+# ---------------------------------------------------------------------------
+# Control: no race
+# ---------------------------------------------------------------------------
+
+
+class TestNoRaceControl:
+    def test_first_ever_detection_inserts_and_reports_created_true(self):
+        """The positive control for every created=False assertion below.
+
+        Without this, "created is False" on the race path proves nothing:
+        it could mean the function never reports True at all.
+        """
+        rule, created = detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        assert created is True
+        assert BlockRule.objects.filter(pattern=PATTERN, source=RuleSource.AUTO).count() == 1
+        assert rule.detectors == "detect_ua_rotation"
+
+    def test_second_detection_of_the_same_key_refreshes_and_reports_created_false(self):
+        """Ordinary (non-race) refresh: one row, created=False, merged set."""
+        detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        rule, created = detector_mod._get_or_create_auto_rule(**_call_kwargs(detector_name="detect_cloud_spray"))
+
+        assert created is False
+        assert BlockRule.objects.filter(pattern=PATTERN, source=RuleSource.AUTO).count() == 1
+        assert rule.detectors == "detect_cloud_spray,detect_ua_rotation"
+
+    def test_the_constraint_itself_rejects_a_second_auto_row_for_the_same_key(self):
+        """Falsifiability check for the whole file: prove the database really
+        does reject the duplicate, so the recovery path below is exercising a
+        real IntegrityError and not a no-op."""
+        _insert_winner()
+
+        with pytest.raises(IntegrityError):
+            _insert_winner(name="second-row", detectors="")
+
+
+# ---------------------------------------------------------------------------
+# The race path
+# ---------------------------------------------------------------------------
+
+
+class TestLostInsertRace:
+    def test_losing_run_merges_into_the_winner_without_raising(self):
+        """The core guarantee: no IntegrityError escapes, exactly one row
+        survives, and the losing run reports created=False because it
+        refreshed a row that already existed."""
+        injector = _RaceInjector()
+
+        with _patched_injector(injector):
+            rule, created = detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        assert injector.defaults_calls == 2, "the retry path must re-derive the write defaults"
+        assert created is False
+        assert BlockRule.objects.filter(pattern=PATTERN, source=RuleSource.AUTO).count() == 1
+        assert rule.pk == injector.winner.pk
+
+    def test_losing_run_contributes_its_detector_name_to_the_merged_set(self):
+        """#97 additivity must survive the race path: the winner's own
+        detector name is kept AND the loser's is added, rather than either
+        side clobbering the other."""
+        injector = _RaceInjector(winner_kwargs={"detectors": "detect_cloud_spray"})
+
+        with _patched_injector(injector):
+            rule, _created = detector_mod._get_or_create_auto_rule(**_call_kwargs(detector_name="detect_ua_rotation"))
+
+        rule.refresh_from_db()
+        assert rule.detectors == "detect_cloud_spray,detect_ua_rotation"
+
+    def test_losing_run_does_not_overwrite_a_confirmed_winner(self):
+        """BR-ANOM-007 across the race path: an operator's CONFIRMED decision
+        on the winning row survives a concurrent detector run that lost the
+        insert. is_active and review_status must be untouched.
+
+        Paired with the unreviewed counterpart below, so this is evidence the
+        guard fired rather than that the race path never writes those fields.
+        """
+        injector = _RaceInjector(
+            winner_kwargs={
+                "is_active": True,
+                "review_status": ReviewStatus.CONFIRMED,
+                "detectors": "detect_cloud_spray",
+            }
+        )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES", True),
+            _patched_injector(injector),
+        ):
+            rule, created = detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        rule.refresh_from_db()
+        assert created is False
+        # Quarantine was on, so an unguarded write would have forced
+        # is_active=False / review_status=PENDING (proven by the next test).
+        assert rule.is_active is True
+        assert rule.review_status == ReviewStatus.CONFIRMED
+        assert "detect_ua_rotation" in rule.detectors.split(",")
+
+    def test_losing_run_does_overwrite_an_unreviewed_winner(self):
+        """The direction test for the assertion above: with the same
+        quarantine setting, an unreviewed (NOT_APPLICABLE) winner IS
+        rewritten to the quarantined state. Without this, the CONFIRMED
+        assertion cannot distinguish a working guard from a race path that
+        writes nothing at all."""
+        injector = _RaceInjector(
+            winner_kwargs={
+                "is_active": True,
+                "review_status": ReviewStatus.NOT_APPLICABLE,
+            }
+        )
+
+        with (
+            patch.object(conf_mod, "DJANGO_WAF_ANOMALY_QUARANTINE_AUTO_RULES", True),
+            _patched_injector(injector),
+        ):
+            rule, _created = detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        rule.refresh_from_db()
+        assert rule.is_active is False
+        assert rule.review_status == ReviewStatus.PENDING
+
+    def test_outer_transaction_is_usable_after_the_recovered_race(self):
+        """The savepoint requirement, stated directly: an IntegrityError left
+        unrolled-back inside the caller's atomic() block makes every later
+        query raise TransactionManagementError. A query issued straight after
+        the recovered call proves the outer transaction survived."""
+        injector = _RaceInjector()
+
+        with _patched_injector(injector):
+            detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        # Would raise TransactionManagementError without the savepoint.
+        assert BlockRule.objects.filter(source=RuleSource.AUTO).count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Requirement 5: the winner vanishes before the re-read
+# ---------------------------------------------------------------------------
+
+
+class TestWinnerDeletedAfterIntegrityError:
+    def test_vanished_winner_raises_does_not_exist_rather_than_returning_none(self):
+        """A genuine double race: this run lost the insert, then the winning
+        row was deleted (expiry sweep, operator delete, concurrent dedupe)
+        before it could be merged into. There is no rule to return, so the
+        function raises rather than handing None to callers that dereference
+        it, and rather than silently re-inserting into a key the database has
+        just proved was contended."""
+        injector = _RaceInjector(delete_instead=True)
+
+        with _patched_injector(injector), pytest.raises(BlockRule.DoesNotExist) as exc_info:
+            detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        assert "vanished after a lost insert race" in str(exc_info.value)
+
+    def test_vanished_winner_does_not_leave_a_resurrected_row_behind(self):
+        """The raise must not be accompanied by a silent re-insert: after it,
+        no auto row for the key exists. Guards against a future "just retry
+        the insert" shim reintroducing the duplicate this whole change
+        removes."""
+        injector = _RaceInjector(delete_instead=True)
+
+        with _patched_injector(injector), pytest.raises(BlockRule.DoesNotExist):
+            detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        assert not BlockRule.objects.filter(pattern=PATTERN, source=RuleSource.AUTO).exists()
+
+
+# ---------------------------------------------------------------------------
+# The MultipleObjectsReturned branch must survive (requirement 4)
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleObjectsReturnedBranchStillCovers:
+    def test_pre_existing_duplicates_are_still_deduplicated_and_retried(self):
+        """Requirement 4: the constraint does not make this branch redundant.
+        A consumer whose migration 0008 has not run can still hold duplicate
+        auto rows, so the dedupe-and-retry path must remain reachable.
+
+        Simulated by making the first update_or_create raise
+        MultipleObjectsReturned, which is what an unconstrained database
+        with duplicate rows produces, rather than by inserting duplicates the
+        test database's constraint would reject.
+        """
+        real_update_or_create = BlockRule.objects.update_or_create
+        state = {"calls": 0}
+
+        def _raise_once(*args, **kwargs):
+            state["calls"] += 1
+            if state["calls"] == 1:
+                raise BlockRule.MultipleObjectsReturned
+            return real_update_or_create(*args, **kwargs)
+
+        with patch.object(BlockRule.objects, "update_or_create", side_effect=_raise_once):
+            rule, created = detector_mod._get_or_create_auto_rule(**_call_kwargs())
+
+        assert state["calls"] == 2, "the dedupe branch must retry the write"
+        assert created is True
+        assert rule.pattern == PATTERN

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -13,9 +13,21 @@ for the rest of the suite (fast, migration-free test databases), which means
 this check must explicitly re-enable them for django_waf rather than relying
 on the ambient setting, or it would either raise ("migrations have been
 disabled") or silently compare against nothing.
+
+TestDedupeAutoBlockRules covers migration 0008's data step (#153) and works
+around the same setting differently: because the test database is built
+straight from the models, the partial unique constraint 0008 adds is already
+present, so duplicates cannot even be inserted. The shared
+``_auto_key_constraint_dropped`` fixture (tests/conftest.py) drops it, the
+test seeds the pre-migration state and runs the migration's real forward
+callable, and test_constraint_applies_cleanly_after_dedupe then re-adds the
+constraint itself, which is the assertion that the data step left the table
+clean enough to constrain.
 """
 
 from __future__ import annotations
+
+import datetime
 
 import django
 from django.db import connections
@@ -23,6 +35,7 @@ from django.db.migrations.autodetector import MigrationAutodetector
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.state import ProjectState
 from django.test import override_settings
+from django.utils import timezone
 
 
 class TestNoPendingMigrations:
@@ -54,3 +67,144 @@ class TestNoPendingMigrations:
             "Run `makemigrations django_waf` and commit the result. "
             f"Detected operations: {descriptions}"
         )
+
+
+MIGRATION_0008 = ("django_waf", "0008_dedupe_auto_block_rules")
+PREVIOUS_MIGRATION = ("django_waf", "0007_alter_requestlog_http_fingerprint_and_more")
+
+
+class TestDedupeAutoBlockRules:
+    """Migration 0008's RunPython step clears duplicate auto rules (#153)."""
+
+    @staticmethod
+    def _forward_callable():
+        """Return migration 0008's real forward RunPython callable.
+
+        Read off the migration graph rather than imported directly, so the
+        test exercises the operation as the migration actually declares it:
+        if the RunPython were dropped, reordered after AddConstraint, or
+        replaced, this lookup changes with it.
+        """
+        from django.db.migrations import RunPython
+
+        with override_settings(MIGRATION_MODULES={}):
+            loader = MigrationLoader(connections["default"], ignore_no_migrations=True)
+            migration = loader.disk_migrations[MIGRATION_0008]
+            run_pythons = [op for op in migration.operations if isinstance(op, RunPython)]
+
+        assert len(run_pythons) == 1, "0008 should declare exactly one RunPython data step"
+        return run_pythons[0].code
+
+    @staticmethod
+    def _historical_apps():
+        """Historical model registry as of the migration before 0008."""
+        with override_settings(MIGRATION_MODULES={}):
+            loader = MigrationLoader(connections["default"], ignore_no_migrations=True)
+            return loader.project_state(PREVIOUS_MIGRATION).apps
+
+    def test_keeps_newest_auto_rule_and_leaves_admin_duplicates(self, _auto_key_constraint_dropped):
+        """Duplicate auto rules collapse to the newest; admin duplicates survive.
+
+        The constraint is partial (condition source=auto), so manually
+        curated admin rules are deliberately not covered by it and the data
+        step must not touch them. Asserting on ``name`` rather than a bare
+        count is what distinguishes "kept the newest" from "kept whichever
+        row the database happened to return first".
+        """
+        from django_waf.models import BlockRule
+
+        now = timezone.now()
+
+        # Two auto rows sharing one (rule_type, pattern, action) key. created_at
+        # is auto_now_add, so it has to be forced with an UPDATE after creation.
+        older_auto = BlockRule.objects.create(
+            name="auto older",
+            rule_type="ip",
+            match_type="exact",
+            pattern="203.0.113.7",
+            action="block",
+            source="auto",
+        )
+        newer_auto = BlockRule.objects.create(
+            name="auto newer",
+            rule_type="ip",
+            # Differs only in match_type, which is in the detector's defaults
+            # rather than its lookup, so these two really are one key.
+            match_type="regex",
+            pattern="203.0.113.7",
+            action="block",
+            source="auto",
+        )
+        BlockRule.objects.filter(pk=older_auto.pk).update(created_at=now - datetime.timedelta(days=5))
+        BlockRule.objects.filter(pk=newer_auto.pk).update(created_at=now)
+
+        # Two admin rows sharing a different key. Not covered by the partial
+        # constraint, so both must survive the data step untouched.
+        first_admin = BlockRule.objects.create(
+            name="admin first",
+            rule_type="ip",
+            match_type="exact",
+            pattern="198.51.100.4",
+            action="block",
+            source="admin",
+        )
+        second_admin = BlockRule.objects.create(
+            name="admin second",
+            rule_type="ip",
+            match_type="exact",
+            pattern="198.51.100.4",
+            action="block",
+            source="admin",
+        )
+        BlockRule.objects.filter(pk=first_admin.pk).update(created_at=now - datetime.timedelta(days=5))
+        BlockRule.objects.filter(pk=second_admin.pk).update(created_at=now)
+
+        forwards = self._forward_callable()
+        forwards(self._historical_apps(), connections["default"].schema_editor())
+
+        surviving_auto = BlockRule.objects.filter(source="auto")
+        assert surviving_auto.count() == 1
+        # The survivor is the newer row specifically, not merely "one of them".
+        assert surviving_auto.get().name == "auto newer"
+        assert not BlockRule.objects.filter(pk=older_auto.pk).exists()
+
+        surviving_admin = BlockRule.objects.filter(source="admin").order_by("created_at")
+        assert [rule.name for rule in surviving_admin] == ["admin first", "admin second"]
+
+    def test_constraint_applies_cleanly_after_dedupe(self, _auto_key_constraint_dropped):
+        """After the data step, the table can actually take the constraint.
+
+        This is the reason 0008 orders RunPython before AddConstraint: on a
+        database carrying pre-existing duplicates, AddConstraint alone fails
+        outright. Re-adding the constraint here is a live proof that the data
+        step left no duplicate auto key behind.
+        """
+        from django_waf.models import BlockRule
+
+        constraint = _auto_key_constraint_dropped
+        now = timezone.now()
+
+        older = BlockRule.objects.create(
+            name="auto older",
+            rule_type="ua",
+            match_type="contains",
+            pattern="BadBot",
+            action="block",
+            source="auto",
+        )
+        BlockRule.objects.create(
+            name="auto newer",
+            rule_type="ua",
+            match_type="contains",
+            pattern="BadBot",
+            action="block",
+            source="auto",
+        )
+        BlockRule.objects.filter(pk=older.pk).update(created_at=now - datetime.timedelta(days=1))
+
+        forwards = self._forward_callable()
+        forwards(self._historical_apps(), connections["default"].schema_editor())
+
+        connection = connections["default"]
+        with connection.schema_editor() as schema_editor:
+            schema_editor.add_constraint(BlockRule, constraint)

--- a/tests/test_nginx_export.py
+++ b/tests/test_nginx_export.py
@@ -125,6 +125,211 @@ class TestBlockThrottleSeparation:
         assert "map $http_user_agent $waf_throttle_ua" in content
 
 
+class TestRenderedEntryDeduplication:
+    """Duplicate BlockRule rows must never render a duplicate nginx entry (#153).
+
+    nginx accepts a repeated key in a ``map`` or ``geo`` block but warns on
+    every ``nginx -t`` (observed on a consumer box as ``nginx: [warn]
+    duplicate network ...``), and the duplicate row pair survives until the
+    key is next re-detected. Dedup is on the RENDERED key, not the rule row,
+    since two distinct rows can escape to the same key.
+    """
+
+    def test_duplicate_ip_pattern_renders_one_geo_entry(self, db, tmp_path, settings):
+        """Two active rules for the same IP render exactly one line in the geo block.
+
+        The rows are left at the factory's default ``source=admin`` rather
+        than ``auto``: the partial UniqueConstraint added in migration 0008
+        covers ``source=auto`` only, so a duplicate auto pair can no longer be
+        inserted at all on a migrated database. Admin duplicates remain
+        legitimate and reachable, and they exercise the renderer identically,
+        because _render_ip_geo dedupes on the rendered address without
+        consulting ``source``.
+        """
+        from django_waf.services.blocklist_generator import generate_nginx_blocklist
+
+        _disable_nginx_validation(settings)
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ip",
+            match_type="exact",
+            pattern="192.0.2.44",
+            action="block",
+            priority=50,
+        )
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ip",
+            match_type="exact",
+            pattern="192.0.2.44",
+            action="block",
+            priority=90,
+        )
+        output_file = str(tmp_path / "blocklist.conf")
+
+        generate_nginx_blocklist(output_path=output_file)
+
+        content = Path(output_file).read_text()
+        block_section = content.split("geo $waf_block_ip")[1].split("}")[0]
+
+        assert block_section.count("    192.0.2.44 1;\n") == 1
+        # Positive control: the entry is genuinely present, so the count
+        # above is not vacuously satisfied by an absent pattern.
+        assert "192.0.2.44" in block_section
+
+    def test_duplicate_ua_pattern_renders_one_map_entry(self, db, tmp_path, settings):
+        """Two active rules for the same UA render exactly one line in the map block."""
+        from django_waf.services.blocklist_generator import generate_nginx_blocklist
+
+        _disable_nginx_validation(settings)
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ua",
+            match_type="exact",
+            pattern="DupeBot/2.0",
+            action="block",
+            priority=50,
+        )
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ua",
+            match_type="exact",
+            pattern="DupeBot/2.0",
+            action="block",
+            priority=90,
+        )
+        output_file = str(tmp_path / "blocklist.conf")
+
+        generate_nginx_blocklist(output_path=output_file)
+
+        content = Path(output_file).read_text()
+        block_ua_section = content.split("map $http_user_agent $waf_block_ua")[1].split("}")[0]
+
+        assert block_ua_section.count('    "DupeBot/2.0" 1;\n') == 1
+        assert '"DupeBot/2.0"' in block_ua_section
+
+    def test_same_ip_under_block_and_throttle_still_lands_in_both_variables(self, db, tmp_path, settings):
+        """Dedup is per variable: the block/throttle split (BR-BL-001) is unchanged."""
+        from django_waf.services.blocklist_generator import generate_nginx_blocklist
+
+        _disable_nginx_validation(settings)
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ip",
+            match_type="exact",
+            pattern="192.0.2.77",
+            action="block",
+        )
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ip",
+            match_type="exact",
+            pattern="192.0.2.77",
+            action="throttle",
+        )
+        output_file = str(tmp_path / "blocklist.conf")
+
+        generate_nginx_blocklist(output_path=output_file)
+
+        content = Path(output_file).read_text()
+        block_section = content.split("geo $waf_block_ip")[1].split("}")[0]
+        throttle_section = content.split("geo $waf_throttle_ip")[1].split("}")[0]
+
+        assert block_section.count("    192.0.2.77 1;\n") == 1
+        assert throttle_section.count("    192.0.2.77 1;\n") == 1
+
+    def test_duplicate_free_rule_set_renders_byte_identical_output(self, db, tmp_path, settings):
+        """With no duplicates, the generated file is byte-for-byte the pre-#153 output.
+
+        The whole file is pinned, header comments, blank-line separators,
+        block order and entry order included, so any change to the rendered
+        bytes for a duplicate-free rule set fails here. This is the
+        additive-change proof: dedup must be a no-op when there is nothing
+        to dedupe.
+        """
+        from django_waf.services.blocklist_generator import generate_nginx_blocklist
+
+        _disable_nginx_validation(settings)
+        # Priorities are distinct and ascending so entry order is fully
+        # determined: for_nginx() builds on active(), whose
+        # .order_by("priority") replaces Meta.ordering, leaving no
+        # secondary key to depend on.
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ua",
+            match_type="exact",
+            pattern="UniqueBlockBot/1.0",
+            action="block",
+            priority=10,
+        )
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ua",
+            match_type="exact",
+            pattern="UniqueThrottleBot/1.0",
+            action="throttle",
+            priority=20,
+        )
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ip",
+            match_type="exact",
+            pattern="192.0.2.10",
+            action="block",
+            priority=30,
+        )
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="cidr",
+            match_type="exact",
+            pattern="198.51.100.0/24",
+            action="block",
+            priority=40,
+        )
+        BlockRuleFactory(
+            is_active=True,
+            rule_type="ip",
+            match_type="exact",
+            pattern="203.0.113.10",
+            action="throttle",
+            priority=50,
+        )
+        output_file = str(tmp_path / "blocklist.conf")
+
+        generate_nginx_blocklist(output_path=output_file)
+
+        expected = (
+            "# Generated by django-waf, do not edit manually\n"
+            "# This file is regenerated every 5 minutes by the generate_blocklist task.\n"
+            "# Declares variables only; see django_waf/conf/nginx/ for the reference\n"
+            "# enforcement snippet (block => 403, throttle => limit_req).\n"
+            "\n"
+            "map $http_user_agent $waf_block_ua {\n"
+            "    default 0;\n"
+            '    "UniqueBlockBot/1.0" 1;\n'
+            "}\n"
+            "\n"
+            "map $http_user_agent $waf_throttle_ua {\n"
+            "    default 0;\n"
+            '    "UniqueThrottleBot/1.0" 1;\n'
+            "}\n"
+            "\n"
+            "geo $waf_block_ip {\n"
+            "    default 0;\n"
+            "    192.0.2.10 1;\n"
+            "    198.51.100.0/24 1;\n"
+            "}\n"
+            "\n"
+            "geo $waf_throttle_ip {\n"
+            "    default 0;\n"
+            "    203.0.113.10 1;\n"
+            "}\n"
+            "\n"
+        )
+
+        assert Path(output_file).read_text() == expected
+
+
 class TestReferenceFilesShipped:
     def test_http_include_reference_file_exists(self):
         from django_waf.services import blocklist_generator

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -2038,9 +2038,16 @@ class TestGetOrCreateAutoRuleDedup:
     deduplicates by keeping the newest row, and retries.
     """
 
-    @pytest.mark.django_db
-    def test_deduplicates_and_retries_on_multiple_objects_returned(self):
-        """Pre-existing duplicates are cleaned up, then the rule is created normally."""
+    def test_deduplicates_and_retries_on_multiple_objects_returned(self, _auto_key_constraint_dropped):
+        """Pre-existing duplicates are cleaned up, then the rule is created normally.
+
+        Since #153 the auto key carries a partial UniqueConstraint, so this
+        scenario can no longer be seeded on a migrated database and the
+        fixture drops the constraint first. The branch under test is still
+        load-bearing rather than dead code: it covers a consumer whose
+        migration 0008 has not run yet, which is exactly the unconstrained
+        state the fixture reproduces.
+        """
         from django_waf.enums import RuleAction, RuleSource, RuleType
         from django_waf.models import BlockRule
         from django_waf.services.anomaly_detector import _get_or_create_auto_rule
@@ -5565,12 +5572,16 @@ class TestRuleEngineHelpers:
             _create_escalation_rule("203.0.113.79")
 
     @pytest.mark.django_db
-    def test_create_escalation_rule_deduplicates_existing_rows(self):
+    def test_create_escalation_rule_deduplicates_existing_rows(self, _auto_key_constraint_dropped):
         """Pre-existing duplicate BlockRule rows are deduplicated, then the rule is created.
 
         Regression: update_or_create raises MultipleObjectsReturned if
         duplicate rows exist for the same (rule_type, pattern, source, action)
         key. The fix catches this, deduplicates, and retries.
+
+        Since #153 the partial UniqueConstraint prevents this state being
+        seeded, so the fixture drops it to reproduce a pre-migration-0008
+        consumer, which is the case the branch still exists to serve.
         """
         from django_waf.enums import RuleAction, RuleSource, RuleType
         from django_waf.models import BlockRule


### PR DESCRIPTION
Closes #153. Spec amendments filed upstream as icvoss/icv-oss-umbrella#658.

## The defect, in two halves

A consumer's `nginx -t` printed `[warn] duplicate network "82.197.65.19"` on
every config test, because two `source=auto` `BlockRule` rows existed for one
key, created 34 ms apart.

**Rendering.** `_render_ip_geo` and `_render_ua_map` appended one line per
rule with no deduplication, so any duplicate row became a duplicate nginx
entry.

**Creation.** `_update_or_create_auto_rule` did
`filter(**lookup).select_for_update().first()` then `update_or_create`.
`select_for_update()` on an empty result set locks no rows, so two concurrent
first-time detections of the same key could both insert. The existing
`MultipleObjectsReturned` recovery only ran on a *later* detection of the same
key, which is why a duplicate pair for an IP that stopped misbehaving survived
until both rows expired.

## The fix

**Renderers** dedupe on the rendered key (escaped UA, stripped address), first
occurrence winning. The `seen` set is local to one call and each renderer is
invoked once per output variable with a disjoint rule list, so BR-BL-001's
block/throttle split is untouched: the same IP under both a block and a
throttle rule still lands in each.

**Constraint.** A partial `UniqueConstraint` on `(rule_type, pattern, action)`
with `condition=Q(source=RuleSource.AUTO)`, named `django_waf_br_auto_key_uniq`.

The key deliberately excludes `match_type`, which the issue's suggested shape
included. The detector's lookup is built at `anomaly_detector.py:1781-1786` as
`rule_type, pattern, source, action`; `match_type` sits in `defaults`. A
constraint including it would permit two rows the detector treats as one key,
so it would not close the race it exists to close. A test seeds exactly that
pair (same key, differing `match_type`) to pin this.

**Migration 0008** dedupes keep-newest per key among `source=auto` rows, then
adds the constraint, in that order. It uses `apps.get_model` and pure ORM, no
backend-specific SQL. Reverse drops the constraint; deleted rows are not
restored, and the reverse is `RunPython.noop` with a comment saying so.

**Lost-race recovery.** With the constraint in place, the losing side would
raise instead of duplicating, turning a warning into an exception on a
detector run. `_update_or_create_auto_rule` now catches `IntegrityError`
inside a nested `transaction.atomic()` savepoint and merges into the winning
row, returning `created=False`. The savepoint is required, not stylistic: an
`IntegrityError` in the caller's atomic block would poison it and the re-read
itself would raise `TransactionManagementError`. Both call sites are already
inside `transaction.atomic()`, so the inner block always opens a savepoint
rather than a transaction.

The review-status guard (BR-ANOM-007) and the additive `detectors` merge are
factored into `_auto_rule_write_defaults`, used by both the ordinary and the
race path. That is DRY with cause: the two must stay identical or a lost race
silently undoes an operator's `confirmed` decision, on the one path nobody
exercises by hand.

A winner deleted between the `IntegrityError` and the re-read raises
`BlockRule.DoesNotExist` rather than returning `None` (callers dereference the
rule) or falling through to `update_or_create` (which would re-insert and
report `created=True`, contradicting the error that just proved the key was
taken).

The `MultipleObjectsReturned` branch is kept. It still covers a consumer whose
migration has not run and duplicate manual rows the partial constraint does
not reach.

## Consumer-visible change

Upgrading **deletes** duplicate auto-generated rules, keeping the newest per
key. This is the policy `_deduplicate_block_rules` already applied whenever the
detector re-detected a duplicated key, so it removes nothing a later detection
would not have removed. `source=admin` and `source=feed` rows are outside the
constraint and are not touched: hand-curated rules may legitimately repeat a
shape with different names, expiries or notes.

## Verification

Every merge-blocking gate, run against this exact tree:

| Gate | Result |
|---|---|
| pytest, SQLite | 1502 passed, 6 skipped |
| pytest, PostgreSQL | 1500 passed, 8 skipped |
| ruff check | pass |
| ruff format --check | 161 files already formatted |
| mypy, CI-exact venv (`mypy==2.3.1`, `django-stubs==6.1.0`, `[dev,celery,api,geoip]`) | Success, 0 errors, 92 source files |
| mypy file-count guard (ci.yml:245) | pass, 92 >= 80 |
| `makemigrations --check` | No changes detected |

The redis leg was not run locally (no local Redis); it is `-m redis_integration`
only and untouched by this change. CI covers it.

Every new test was confirmed to fail against the pre-change source. Five tests
pass both before and after by design and are declared controls: the
block/throttle no-regression guard, the byte-identical additive-change proof
(which pins the whole generated file), two `created=False` positive controls,
and the `MultipleObjectsReturned`-still-covers test.

Two defects were found and fixed during verification, both test-side, no
production code at fault:

- The migration-test fixture used the `db` fixture to drop a constraint via
  `schema_editor`. Django's SQLite schema editor refuses to run inside an open
  atomic block, so it raised `NotSupportedError` at setup on every SQLite leg
  while passing on PostgreSQL. Now uses `transactional_db` and restores the
  constraint explicitly in a `finally`, since truncation does not undo DDL.
- The race-simulation harness did not initially reproduce the race at all
  (injecting the rival row where `update_or_create`'s internal `get()` found
  it, taking the UPDATE branch and raising nothing). Fixed to commit the rival
  outside the savepoint.

Two pre-existing tests in `test_services.py` seeded duplicate auto rows, which
the constraint now forbids. They were updated to drop the constraint first,
reproducing a genuine pre-0008 consumer, which is the state the
`MultipleObjectsReturned` branch exists to serve. Their assertions are
unchanged.
