### PR TITLE
chore: ignore suffixed virtualenv directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,15 @@ htmlcov/
 uv.lock
 
 # Virtual environments
-venv/
+# Suffixed forms (.venv312, venv-3.12, .venv-test) are matched too: a
+# version-suffixed venv is the usual shape when testing several Python or
+# Django versions side by side, and an unmatched one is thousands of files
+# one `git add -A` away from a pushed branch. See icvoss/icv-oss-umbrella#675
+# and icvoss/icv-cms#118.
 .venv/
+.venv*/
+venv/
+venv*/
 env/
-.env
-
 # Agent working areas
 .claude/


### PR DESCRIPTION
Propagates `templates/repo/gitignore` after icvoss/icv-oss-umbrella#675 (`.venv*/`, `venv*/`).

Refs: icvoss/icv-cms#118.