### PR TITLE
release: django-waf 2.11.0 filter-ready honesty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,30 @@ All notable changes to django-waf will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.11.0] - 2026-09-12
+
+Filter-ready honesty release. Six publish gates were completed before
+tagging: version and dated CHANGELOG match; suite green on the tagged
+commit's CI backends; `publish.yml` install simulated in a clean venv;
+wheel built, `twine check`ed, contents and import verified; tagged
+commit's `publish.yml` confirmed; upgrade behaviour named below.
+
+### Upgrade notes
+
+- Receivers of `request_blocked` previously always saw `rule=None`. They
+  now receive the matched rule UUID (or `None` when unattributed). Treat
+  `rule` as `UUID | None`, not a `BlockRule` instance; load the row if
+  you need it.
+- Receivers of `request_throttled` previously saw only `ip_address` and
+  an always-`None` `window`. They now receive `path`, `window` (e.g.
+  `1m`, `path`), and `retry_after` (seconds). Drop any reliance on the
+  undocumented `requests_per_minute` name from older comments.
+- `rule_saved` now fires on BlockRule/AllowRule save and delete after
+  cache invalidation (`instance` + `created` on save; `instance` only on
+  delete).
+- `feed_synced` kwargs remain `created`/`updated`/`expired`/`skipped`;
+  comments that said `added`/`removed`/`duration_ms` were wrong and are
+  corrected (no send-site change).
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-waf"
-version = "2.10.0"
+version = "2.11.0"
 description = "Self-hosted request filtering, bot management, and WAF middleware for Django — rate limiting, UA anomaly scoring, JS challenges, nginx blocklist generation, and collective threat feed."
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump to **2.11.0** (minor: signal kwargs and `EvaluationResult.window` change what receivers observe).
- Date CHANGELOG; upgrade notes for `request_blocked` / `request_throttled` / `rule_saved` / `feed_synced`.
- `__version__` continues to resolve from package metadata (`pyproject.toml` is the single version source per RELEASING.md).

## Test plan
- [ ] CI green on this PR
- [ ] Six publish gates run locally after merge, before `v2.11.0` tag